### PR TITLE
cups/dests.c: cupsGetNamedDest() - set IPP_STATUS_ERROR_NOT_FOUND err…

### DIFF
--- a/berkeley/lpr.c
+++ b/berkeley/lpr.c
@@ -234,6 +234,12 @@ main(int  argc,				/* I - Number of command-line arguments */
 		_cupsLangPrintf(stderr, _("%s: Error - add '/version=1.1' to server name."), argv[0]);
 		return (1);
 	      }
+	      else if (cupsLastError() == IPP_STATUS_ERROR_NOT_FOUND)
+	      {
+		_cupsLangPrintf(stderr,
+				_("%s: Error - The printer or class does not exist."), argv[0]);
+		return (1);
+	      }
 	      break;
 
 	  case '#' : /* Number of copies */

--- a/cups/dest.c
+++ b/cups/dest.c
@@ -1839,7 +1839,10 @@ cupsGetNamedDest(http_t     *http,	/* I - Connection to server or @code CUPS_HTT
       cupsEnumDests(0, 1000, NULL, 0, 0, (cups_dest_cb_t)cups_name_cb, &data);
 
       if (!data.dest)
+      {
+        _cupsSetError(IPP_STATUS_ERROR_NOT_FOUND, _("The printer or class does not exist."), 1);
         return (NULL);
+      }
 
       dest = data.dest;
     }

--- a/systemv/lp.c
+++ b/systemv/lp.c
@@ -161,6 +161,12 @@ main(int  argc,				/* I - Number of command-line arguments */
 				  "name."), argv[0]);
 		return (1);
 	      }
+	      else if (cupsLastError() == IPP_STATUS_ERROR_NOT_FOUND)
+	      {
+		_cupsLangPrintf(stderr,
+				_("%s: Error - The printer or class does not exist."), argv[0]);
+		return (1);
+	      }
 	      break;
 
 	  case 'f' : /* Form */


### PR DESCRIPTION
…or if queue was not found

lp.c/lpr.c: check for IPP_STATUS_ERROR_NOT_FOUND and generate a proper message if hit

See https://github.com/apple/cups/pull/5809