### PR TITLE
Fix installation of xinetd configuration file for cups-lpd

### DIFF
--- a/scheduler/Makefile
+++ b/scheduler/Makefile
@@ -199,7 +199,8 @@ install-data:
 		$(INSTALL_DATA) org.cups.cupsd.socket $(BUILDROOT)$(SYSTEMD_DIR); \
 		$(INSTALL_DATA) org.cups.cups-lpdAT.service $(BUILDROOT)$(SYSTEMD_DIR)/org.cups.cups-lpd@.service; \
 		$(INSTALL_DATA) org.cups.cups-lpd.socket $(BUILDROOT)$(SYSTEMD_DIR); \
-	elif test "x$(XINETD)" != x; then \
+	fi
+	if test "x$(XINETD)" != x; then \
 		echo Installing xinetd configuration file for cups-lpd...; \
 		$(INSTALL_DIR) -m 755 $(BUILDROOT)$(XINETD); \
 		$(INSTALL_DATA) cups-lpd.xinetd $(BUILDROOT)$(XINETD)/cups-lpd; \


### PR DESCRIPTION
Fix --with-xinetd=/etc/xinetd.d not installing the cups-ldp xinetd configuration file.

This change is already shipping downstream for a long time now in source-based distributions like e.g. Gentoo Linux and Exherbo Linux.