### PR TITLE
Fix handling of the output-bin and print-quality IPP attributes

### DIFF
--- a/cups/ppd-cache.c
+++ b/cups/ppd-cache.c
@@ -3929,7 +3929,7 @@ _ppdCreateFromIPP(char   *buffer,	/* I - Filename buffer */
   else
     strlcpy(ppdname, "Unknown", sizeof(ppdname));
 
-  if ((attr = ippFindAttribute(response, "output-bin-supported", IPP_TAG_ZERO)) != NULL && (count = ippGetCount(attr)) > 1)
+  if ((attr = ippFindAttribute(response, "output-bin-supported", IPP_TAG_ZERO)) != NULL && (count = ippGetCount(attr)) > 0)
   {
     ipp_attribute_t	*trays = ippFindAttribute(response, "printer-output-tray", IPP_TAG_STRING);
 					/* printer-output-tray attribute, if any */

--- a/scheduler/printers.c
+++ b/scheduler/printers.c
@@ -4019,7 +4019,8 @@ load_ppd(cupsd_printer_t *p)		/* I - Printer */
 
     num_qualities = 0;
 
-    if ((output_mode = ppdFindOption(ppd, "OutputMode")) != NULL)
+    if ((output_mode = ppdFindOption(ppd, "OutputMode")) ||
+        (output_mode = ppdFindOption(ppd, "cupsPrintQuality")))
     {
       if (ppdFindChoice(output_mode, "draft") ||
           ppdFindChoice(output_mode, "fast"))


### PR DESCRIPTION
The PPD generation code now works for printers that support a single
output bin. Also the PPD parsing code now parses the cupsPrintQuality
field which is generated by the PPD generation code.