### PR TITLE
Fix negotiate authentication between CGIs and scheduler

### DIFF
--- a/cups/auth.c
+++ b/cups/auth.c
@@ -295,7 +295,7 @@ cupsDoAuthentication(
     }
   }
 
-  if (http->authstring)
+  if (http->authstring && http->authstring[0])
   {
     DEBUG_printf(("1cupsDoAuthentication: authstring=\"%s\".", http->authstring));
 

--- a/cups/auth.c
+++ b/cups/auth.c
@@ -1043,11 +1043,6 @@ cups_local_auth(http_t *http)		/* I - HTTP connection to server */
   }
 #  endif /* HAVE_AUTHORIZATION_H */
 
-#  ifdef HAVE_GSSAPI
-  if (cups_auth_find(www_auth, "Negotiate"))
-    return (1);
-#  endif /* HAVE_GSSAPI */
-
 #  if defined(SO_PEERCRED) && defined(AF_LOCAL)
  /*
   * See if we can authenticate using the peer credentials provided over a

--- a/cups/auth.c
+++ b/cups/auth.c
@@ -175,10 +175,10 @@ cupsDoAuthentication(
     DEBUG_printf(("2cupsDoAuthentication: Trying scheme \"%s\"...", scheme));
 
 #ifdef HAVE_GSSAPI
-    if (!_cups_strcasecmp(scheme, "Negotiate"))
+    if (!_cups_strcasecmp(scheme, "Negotiate") && !cups_is_local_connection(http))
     {
      /*
-      * Kerberos authentication...
+      * Kerberos authentication to remote server...
       */
 
       int gss_status;			/* Auth status */
@@ -202,7 +202,9 @@ cupsDoAuthentication(
     }
     else
 #endif /* HAVE_GSSAPI */
-    if (_cups_strcasecmp(scheme, "Basic") && _cups_strcasecmp(scheme, "Digest"))
+    if (_cups_strcasecmp(scheme, "Basic") &&
+	_cups_strcasecmp(scheme, "Digest") &&
+	_cups_strcasecmp(scheme, "Negotiate"))
     {
      /*
       * Other schemes not yet supported...
@@ -216,7 +218,7 @@ cupsDoAuthentication(
     * See if we should retry the current username:password...
     */
 
-    if ((http->digest_tries > 1 || !http->userpass[0]) && (!_cups_strcasecmp(scheme, "Basic") || (!_cups_strcasecmp(scheme, "Digest"))))
+    if (http->digest_tries > 1 || !http->userpass[0])
     {
      /*
       * Nope - get a new password from the user...

--- a/cups/auth.c
+++ b/cups/auth.c
@@ -90,6 +90,7 @@ static void	cups_gss_printf(OM_uint32 major_status, OM_uint32 minor_status,
 #    define	cups_gss_printf(major, minor, message)
 #  endif /* DEBUG */
 #endif /* HAVE_GSSAPI */
+static int	cups_is_local_connection(http_t *http);
 static int	cups_local_auth(http_t *http);
 
 
@@ -916,6 +917,14 @@ cups_gss_printf(OM_uint32  major_status,/* I - Major status code */
 #  endif /* DEBUG */
 #endif /* HAVE_GSSAPI */
 
+static int				/* O - 0 if not a local connection */
+					/*     1  if local connection */
+cups_is_local_connection(http_t *http)	/* I - HTTP connection to server */
+{
+  if (!httpAddrLocalhost(http->hostaddr) && _cups_strcasecmp(http->hostname, "localhost") != 0)
+    return 0;
+  return 1;
+}
 
 /*
  * 'cups_local_auth()' - Get the local authorization certificate if
@@ -958,7 +967,7 @@ cups_local_auth(http_t *http)		/* I - HTTP connection to server */
   * See if we are accessing localhost...
   */
 
-  if (!httpAddrLocalhost(http->hostaddr) && _cups_strcasecmp(http->hostname, "localhost") != 0)
+  if (!cups_is_local_connection(http))
   {
     DEBUG_puts("8cups_local_auth: Not a local connection!");
     return (1);

--- a/scheduler/client.c
+++ b/scheduler/client.c
@@ -2109,18 +2109,13 @@ cupsdSendHeader(
     }
     else if (auth_type == CUPSD_AUTH_NEGOTIATE)
     {
-#if defined(SO_PEERCRED) && defined(AF_LOCAL)
-      if (httpAddrFamily(httpGetAddress(con->http)) == AF_LOCAL)
-	strlcpy(auth_str, "PeerCred", sizeof(auth_str));
-      else
-#endif /* SO_PEERCRED && AF_LOCAL */
       strlcpy(auth_str, "Negotiate", sizeof(auth_str));
     }
 
-    if (con->best && auth_type != CUPSD_AUTH_NEGOTIATE && !con->is_browser && !_cups_strcasecmp(httpGetHostname(con->http, NULL, 0), "localhost"))
+    if (con->best && !con->is_browser && !_cups_strcasecmp(httpGetHostname(con->http, NULL, 0), "localhost"))
     {
      /*
-      * Add a "trc" (try root certification) parameter for local non-Kerberos
+      * Add a "trc" (try root certification) parameter for local
       * requests when the request requires system group membership - then the
       * client knows the root certificate can/should be used.
       *


### PR DESCRIPTION
Fixes the infinite loop when "Negotiate" authentication is used and allows "Local" certificate based authentication when connecting to localhost:

```
    Client                       CGI
    Browser <- Remote conn -> admin.cgi <--- Localhost conn --->  Scheduler
      |                           |                                    |
      + --- HTTP/POST /admin/ --> |                                    |
      |                           + --- CUPS-Get-Devices ------------> |
      |                           |                                    |
      |                           | <-- 401 Unauthorized --------------+
      |                           |     WWW-Authenticate:              |
      |                           |       Negotiate, (PeerCred,) Local |
      |                           |                                    |
      | <-- 401 Unauthorized -----+                                    |
      |     WWW-Authenticate:     |                                    |
      |       Negotiate           |                                    |
      |                           |                                    |
      | --- HTTP/POST /admin/ --> |                                    |
      |     Authorization:        + --- IPP CUPS-GetDevices ---------> |
      |       Negotiate           |     Authorization: Local <cert>    |
      |                           |                                    |
```

Fixes apple/cups issue #5596 