### PR TITLE
Debian: Install root backends world-readable

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -13,7 +13,7 @@ include ../Makedefs
 # Object files...
 #
 
-# RBACKENDS are installed mode 0700 so cupsd will run them as root...
+# RBACKENDS are installed mode 0744 so cupsd will run them as root...
 #
 # UBACKENDS and ULBACKENDS are installed mode 0755 so cupsd will run them as
 # an unprivileged user...
@@ -118,7 +118,7 @@ install-exec:	$(INSTALLXPC)
 	echo Installing backends in $(SERVERBIN)/backend
 	$(INSTALL_DIR) -m 755 $(SERVERBIN)/backend
 	for file in $(RBACKENDS); do \
-		$(INSTALL_BIN) -m 700 $$file $(SERVERBIN)/backend; \
+		$(INSTALL_BIN) -m 744 $$file $(SERVERBIN)/backend; \
 	done
 	for file in $(UBACKENDS); do \
 		$(INSTALL_BIN) $$file $(SERVERBIN)/backend; \

--- a/scheduler/cups-deviced.c
+++ b/scheduler/cups-deviced.c
@@ -265,7 +265,7 @@ main(int  argc,				/* I - Number of command-line args */
     * all others run as the unprivileged user...
     */
 
-    start_backend(dent->filename, !(dent->fileinfo.st_mode & (S_IWGRP | S_IRWXO)));
+    start_backend(dent->filename, !(dent->fileinfo.st_mode & (S_IWGRP | S_IWOTH | S_IXOTH)));
   }
 
   cupsDirClose(dir);

--- a/scheduler/job.c
+++ b/scheduler/job.c
@@ -1247,7 +1247,7 @@ cupsdContinueJob(cupsd_job_t *job)	/* I - Job */
       else if (stat(command, &backinfo))
 	backroot = 0;
       else
-        backroot = !(backinfo.st_mode & (S_IWGRP | S_IRWXO));
+        backroot = !(backinfo.st_mode & (S_IWGRP | S_IWOTH | S_IXOTH));
 
       argv[0] = job->printer->sanitized_device_uri;
 


### PR DESCRIPTION
This is needed:
 - to comply with Debian Policy
 - because it is both nonsensical to not do so
 - it also breaks system checkers, bug reporting, etc

Bug: https://github.com/apple/cups/issues/2935
Bug-Debian: https://bugs.debian.org/410171