### PR TITLE
Debian: Fix tests for a multitude of architectures

### DIFF
--- a/cups/testi18n.c
+++ b/cups/testi18n.c
@@ -410,7 +410,7 @@ main(int  argc,				/* I - Argument Count */
       puts("PASS");
   }
 
-#ifndef __linux
+#if !defined(__linux__) && !defined(__GLIBC__)
   fputs("cupsCharsetToUTF8(CUPS_EUC_JP): ", stdout);
 
   strlcpy(legsrc, legdest, sizeof(legsrc));

--- a/cups/testppd.c
+++ b/cups/testppd.c
@@ -658,6 +658,14 @@ main(int  argc,				/* I - Number of command-line arguments */
     * Test localization...
     */
 
+   /*
+    * Enforce void localization
+    */
+    putenv("LANG=C");
+    putenv("LC_ALL=C");
+    putenv("LC_CTYPE=C");
+    putenv("LC_MESSAGES=C");
+
     fputs("ppdLocalizeIPPReason(text): ", stdout);
     if (ppdLocalizeIPPReason(ppd, "foo", NULL, buffer, sizeof(buffer)) &&
         !strcmp(buffer, "Foo Reason"))

--- a/test/5.1-lpadmin.sh
+++ b/test/5.1-lpadmin.sh
@@ -52,8 +52,8 @@ echo ""
 
 echo "Add Shared Printer Test"
 echo ""
-echo "    lpadmin -p Test3 -E -v ipp://localhost:$IPP_PORT/printers/Test2 -m everywhere"
-$runcups $VALGRIND ../systemv/lpadmin -p Test3 -E -v ipp://localhost:$IPP_PORT/printers/Test2 -m everywhere 2>&1
+echo "    lpadmin -p Test3 -E -v ipp://127.0.0.1:$IPP_PORT/printers/Test2 -m everywhere"
+$runcups $VALGRIND ../systemv/lpadmin -p Test3 -E -v ipp://127.0.0.1:$IPP_PORT/printers/Test2 -m everywhere 2>&1
 if test $? != 0; then
 	echo "    FAILED"
 	exit 1

--- a/test/run-stp-tests.sh
+++ b/test/run-stp-tests.sh
@@ -1025,7 +1025,9 @@ else
 fi
 
 # Error log messages
-count=`$GREP '^E ' $BASE/log/error_log | $GREP -v 'Unknown default SystemGroup' | wc -l | awk '{print $1}'`
+count=`$GREP '^E ' $BASE/log/error_log | $GREP -v 'Unknown default SystemGroup' | \
+       $GREP -v -E 'Unable to open listen socket for address .* Address family not supported by protocol.' | \
+       wc -l | awk '{print $1}'`
 if test $count != 33; then
 	echo "FAIL: $count error messages, expected 33."
 	$GREP '^E ' $BASE/log/error_log

--- a/test/run-stp-tests.sh
+++ b/test/run-stp-tests.sh
@@ -1040,7 +1040,11 @@ else
 fi
 
 # Warning log messages
-count=`$GREP '^W ' $BASE/log/error_log | $GREP -v CreateProfile | wc -l | awk '{print $1}'`
+count=`$GREP '^W ' $BASE/log/error_log | $GREP -v CreateProfile | \
+       $GREP -v 'Unable to initialize USB access via libusb, libusb error' | \
+       $GREP -v 'org.freedesktop.ColorManager' | \
+       $GREP -v -E 'Avahi client failed: -(1|26)' | \
+       wc -l | awk '{print $1}'`
 if test $count != 8; then
 	echo "FAIL: $count warning messages, expected 8."
 	$GREP '^W ' $BASE/log/error_log

--- a/test/run-stp-tests.sh
+++ b/test/run-stp-tests.sh
@@ -268,7 +268,7 @@ case "$usedebugprintfs" in
 		echo "Enabling debug printfs (level $usedebugprintfs); log files can be found in $BASE/log..."
 		CUPS_DEBUG_LOG="$BASE/log/debug_printfs.%d"; export CUPS_DEBUG_LOG
 		CUPS_DEBUG_LEVEL="$usedebugprintfs"; export CUPS_DEBUG_LEVEL
-		CUPS_DEBUG_FILTER='^(http|_http|ipp|_ipp|cups.*Request|cupsGetResponse|cupsSend|mime).*$'; export CUPS_DEBUG_FILTER
+		CUPS_DEBUG_FILTER='^(http|_http|ipp|_ipp|cups.*Request|cupsGetResponse|cupsSend).*$'; export CUPS_DEBUG_FILTER
 		;;
 
 	*)
@@ -443,14 +443,12 @@ EOF
 }
 
 ln -s $root/test/test.convs $BASE/share/mime
-ln -s $root/test/test.types $BASE/share/mime
 
 if test `uname` = Darwin; then
 	instfilter cgimagetopdf imagetopdf pdf
 	instfilter cgpdftopdf pdftopdf passthru
 	instfilter cgpdftops pdftops ps
 	instfilter cgpdftoraster pdftoraster raster
-	instfilter cgpdftoraster pdftourf raster
 	instfilter cgtexttopdf texttopdf pdf
 	instfilter pstocupsraster pstoraster raster
 else

--- a/test/run-stp-tests.sh
+++ b/test/run-stp-tests.sh
@@ -1027,6 +1027,7 @@ fi
 # Error log messages
 count=`$GREP '^E ' $BASE/log/error_log | $GREP -v 'Unknown default SystemGroup' | \
        $GREP -v -E 'Unable to open listen socket for address .* Address family not supported by protocol.' | \
+       $GREP -v 'Job held by' | \
        wc -l | awk '{print $1}'`
 if test $count != 33; then
 	echo "FAIL: $count error messages, expected 33."

--- a/test/run-stp-tests.sh
+++ b/test/run-stp-tests.sh
@@ -642,6 +642,7 @@ echo "DYLD_LIBRARY_PATH=\"$DYLD_LIBRARY_PATH\"; export DYLD_LIBRARY_PATH" >>$run
 echo "LD_LIBRARY_PATH=\"$LD_LIBRARY_PATH\"; export LD_LIBRARY_PATH" >>$runcups
 echo "LD_PRELOAD=\"$LD_PRELOAD\"; export LD_PRELOAD" >>$runcups
 echo "LOCALEDIR=\"$LOCALEDIR\"; export LOCALEDIR" >>$runcups
+echo "LC_ALL=\"C\"; export LC_ALL" >>$runcups
 if test "x$CUPS_DEBUG_LEVEL" != x; then
 	echo "CUPS_DEBUG_FILTER='$CUPS_DEBUG_FILTER'; export CUPS_DEBUG_FILTER" >>$runcups
 	echo "CUPS_DEBUG_LEVEL=$CUPS_DEBUG_LEVEL; export CUPS_DEBUG_LEVEL" >>$runcups

--- a/test/run-stp-tests.sh
+++ b/test/run-stp-tests.sh
@@ -776,6 +776,11 @@ echo "    $date by $user on `hostname`." >>$strfile
 echo "    <pre>" >>$strfile
 
 for file in 5*.sh; do
+	#
+	# Make sure the past jobs are done before going on.
+	#
+	./waitjobs.sh 1800
+
 	echo $ac_n "Performing $file: $ac_c"
 	echo "" >>$strfile
         echo "`date '+[%d/%b/%Y:%H:%M:%S %z]'` \"$file\":" >>$strfile

--- a/test/run-stp-tests.sh
+++ b/test/run-stp-tests.sh
@@ -490,7 +490,7 @@ fi
 cat >$BASE/cupsd.conf <<EOF
 StrictConformance Yes
 Browsing Off
-Listen localhost:$port
+Listen 127.0.0.1:$port
 Listen $BASE/sock
 MaxSubscriptions 3
 MaxLogSize 0
@@ -617,7 +617,7 @@ fi
 
 # These get exported because they don't have side-effects...
 CUPS_DISABLE_APPLE_DEFAULT=yes; export CUPS_DISABLE_APPLE_DEFAULT
-CUPS_SERVER=localhost:$port; export CUPS_SERVER
+CUPS_SERVER=127.0.0.1:$port; export CUPS_SERVER
 CUPS_SERVERROOT=$BASE; export CUPS_SERVERROOT
 CUPS_STATEDIR=$BASE; export CUPS_STATEDIR
 CUPS_DATADIR=$BASE/share; export CUPS_DATADIR
@@ -743,10 +743,10 @@ for file in 4*.test ../examples/ipp-2.1.test; do
         echo $ac_n "`date '+[%d/%b/%Y:%H:%M:%S %z]'` $ac_c" >>$strfile
 
 	if test $file = ../examples/ipp-2.1.test; then
-		uri="ipp://localhost:$port/printers/Test1"
+		uri="ipp://127.0.0.1:$port/printers/Test1"
 		options="-V 2.1 -d NOPRINT=1 -f testfile.ps"
 	else
-		uri="ipp://localhost:$port/printers"
+		uri="ipp://127.0.0.1:$port/printers"
 		options=""
 	fi
 	$runcups $VALGRIND ../tools/ipptool -tI $options $uri $file >> $strfile

--- a/test/test.convs
+++ b/test/test.convs
@@ -2,7 +2,6 @@
 application/pdf application/vnd.cups-pdf 100 pdftopdf
 application/pdf application/postscript 100 pdftops
 application/pdf application/vnd.cups-raster 100 pdftoraster
-application/pdf image/urf 100 pdftourf
 application/postscript application/vnd.cups-raster 100 pstoraster
 image/jpeg application/pdf 100 imagetopdf
 text/plain application/pdf 100 texttopdf

--- a/test/test.types
+++ b/test/test.types
@@ -1,2 +1,0 @@
-# Test file listing potential MIME media types that are not in the standard mime.types file
-image/urf


### PR DESCRIPTION
This suite of commits is special in that it got built over the years to fix test/run-stp-tests.sh (and others) accross all the Debian archs, and in various environments (specifically, Reproducible Builds'; https://tests.reproducible-builds.org/debian/rb-pkg/unstable/amd64/cups.html ).

What I can say is that this suite of patches is enough to let the tests run successfully across all archs (besides kfreebsd-*, which fail with errors in `5.5-lp.sh` (`FAIL: Printer 'Test2' produced 17 page(s), expected 23.`) see [2.3.3-3's build log](https://buildd.debian.org/status/fetch.php?pkg=cups&arch=kfreebsd-amd64&ver=2.3.3-3&stamp=1604275441&raw=0)). I wish it could be smaller, but it's quite tedious to test this across all architectures.