### PR TITLE
Debian: Let snmp backend also use manufacturer-specific MIBs

### DIFF
--- a/backend/snmp.c
+++ b/backend/snmp.c
@@ -154,6 +154,8 @@ static const int	UriOID[] = { CUPS_OID_ppmPortServiceNameOrURI, 1, 1, -1 };
 static const int	LexmarkProductOID[] = { 1,3,6,1,4,1,641,2,1,2,1,2,1,-1 };
 static const int	LexmarkProductOID2[] = { 1,3,6,1,4,1,674,10898,100,2,1,2,1,2,1,-1 };
 static const int	LexmarkDeviceIdOID[] = { 1,3,6,1,4,1,641,2,1,2,1,3,1,-1 };
+static const int	HPDeviceIdOID[] = { 1,3,6,1,4,1,11,2,3,9,1,1,7,0,-1 };
+static const int	RicohDeviceIdOID[] = { 1,3,6,1,4,1,367,3,2,1,1,1,11,0,-1 };
 static const int	XeroxProductOID[] = { 1,3,6,1,4,1,128,2,1,3,1,2,0,-1 };
 static cups_array_t	*DeviceURIs = NULL;
 static int		HostNameLookups = 0;
@@ -970,8 +972,14 @@ read_snmp_response(int fd)		/* I - SNMP socket file descriptor */
 	               packet.community, CUPS_ASN1_GET_REQUEST,
 		       DEVICE_ID, LexmarkDeviceIdOID);
 	_cupsSNMPWrite(fd, &(packet.address), CUPS_SNMP_VERSION_1,
+		       packet.community, CUPS_ASN1_GET_REQUEST,
+		       DEVICE_ID, RicohDeviceIdOID);
+	_cupsSNMPWrite(fd, &(packet.address), CUPS_SNMP_VERSION_1,
 	               packet.community, CUPS_ASN1_GET_REQUEST,
 		       DEVICE_PRODUCT, XeroxProductOID);
+	_cupsSNMPWrite(fd, &(packet.address), CUPS_SNMP_VERSION_1,
+		       packet.community, CUPS_ASN1_GET_REQUEST,
+		       DEVICE_ID, HPDeviceIdOID);
         break;
 
     case DEVICE_DESCRIPTION :


### PR DESCRIPTION
 … of HP and Ricoh to obtain the device IDs of network-connected
 printers. This way we get more reliable information about make and model
 and in addition the supported page description languages, which allows one to
 identify whether an optional PostScript add-on is installed or for an
 unsupported printer which generic PPD is the best choice (requested by
 Ricoh).
Bug: https://github.com/apple/cups/issues/3552