### PR TITLE
Debian: Rename the systemd service file from org.cups.cups.* to cups.*

### DIFF
--- a/scheduler/org.cups.cups-lpd.socket
+++ b/scheduler/org.cups.cups-lpd.socket
@@ -1,6 +1,6 @@
 [Unit]
 Description=CUPS LPD Server Socket
-PartOf=org.cups.cups-lpd.service
+PartOf=cups-lpd.service
 
 [Socket]
 ListenStream=515

--- a/scheduler/org.cups.cupsd.path.in
+++ b/scheduler/org.cups.cupsd.path.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=CUPS Scheduler
-PartOf=org.cups.cupsd.service
+PartOf=cups.service
 
 [Path]
 PathExists=@CUPS_CACHEDIR@/org.cups.cupsd

--- a/scheduler/org.cups.cupsd.service.in
+++ b/scheduler/org.cups.cupsd.service.in
@@ -9,5 +9,5 @@ Type=simple
 Restart=on-failure
 
 [Install]
-Also=org.cups.cupsd.socket org.cups.cupsd.path
+Also=cups.socket cups.path
 WantedBy=printer.target

--- a/scheduler/org.cups.cupsd.socket.in
+++ b/scheduler/org.cups.cupsd.socket.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=CUPS Scheduler
-PartOf=org.cups.cupsd.service
+PartOf=cups.service
 
 [Socket]
 ListenStream=@CUPS_DEFAULT_DOMAINSOCKET@


### PR DESCRIPTION
Debian (and all systemd Linux'es) expect `systemctl status cups.service`.

The renaming is only done _within_ the files (to fix relationships), as Debian renames them at install time. But we could rename them too, of course.