### PR TITLE
Debian: Add Requires=cups.socket to cups.service, to make sure they start in order

### DIFF
--- a/scheduler/org.cups.cupsd.service.in
+++ b/scheduler/org.cups.cupsd.service.in
@@ -2,6 +2,7 @@
 Description=CUPS Scheduler
 Documentation=man:cupsd(8)
 After=sssd.service
+Requires=cups.socket
 
 [Service]
 ExecStart=@sbindir@/cupsd -l


### PR DESCRIPTION
This depends on #30 