### PR TITLE
Debian: Do not use host names for broadcasting print queues 

### DIFF
--- a/scheduler/conf.c
+++ b/scheduler/conf.c
@@ -899,7 +899,7 @@ cupsdReadConfiguration(void)
     cupsdAddAlias(ServerAlias, temp);
     cupsdLogMessage(CUPSD_LOG_DEBUG, "Added auto ServerAlias %s", temp);
 
-    if (HostNameLookups || RemotePort)
+    if (HostNameLookups)
     {
       struct hostent	*host;		/* Host entry to get FQDN */
 


### PR DESCRIPTION
 Do not use host names for broadcasting print queues 
 managing print queues broadcasted from other servers by default. Many
 networks do not have valid host names for all machines.
Bug-Ubuntu: https://bugs.launchpad.net/bugs/449586