### PR TITLE
Debian: Make log files readable to group "adm", if present.

### DIFF
--- a/scheduler/log.c
+++ b/scheduler/log.c
@@ -21,6 +21,7 @@
 #  include <systemd/sd-journal.h>
 #endif /* HAVE_ASL_H */
 #include <syslog.h>
+#include <grp.h>
 
 
 /*
@@ -110,6 +111,7 @@ cupsdCheckLogFile(cups_file_t **lf,	/* IO - Log file */
 		filename[1024],		/* Formatted log filename */
 		*ptr;			/* Pointer into filename */
   const char	*logptr;		/* Pointer into log filename */
+  struct group  *loggrp;		/* Group entry of log filename */
 
 
  /*
@@ -128,6 +130,11 @@ cupsdCheckLogFile(cups_file_t **lf,	/* IO - Log file */
     *lf = LogStderr;
     return (1);
   }
+
+ /*
+  * Use adm group if possible, fall back to Group
+  */
+ loggrp = getgrnam("adm");
 
  /*
   * Format the filename as needed...
@@ -241,7 +248,7 @@ cupsdCheckLogFile(cups_file_t **lf,	/* IO - Log file */
       * Change ownership and permissions of non-device logs...
       */
 
-      fchown(cupsFileNumber(*lf), RunUser, Group);
+      fchown(cupsFileNumber(*lf), RunUser, loggrp ? loggrp->gr_gid : Group);
       fchmod(cupsFileNumber(*lf), LogFilePerm);
     }
   }
@@ -284,7 +291,7 @@ cupsdCheckLogFile(cups_file_t **lf,	/* IO - Log file */
     * Change ownership and permissions of non-device logs...
     */
 
-    fchown(cupsFileNumber(*lf), RunUser, Group);
+    fchown(cupsFileNumber(*lf), RunUser, loggrp ? loggrp->gr_gid : Group);
     fchmod(cupsFileNumber(*lf), LogFilePerm);
   }
 


### PR DESCRIPTION
Bug-Ubuntu: https://launchpad.net/bugs/345953