### PR TITLE
Debian: Allow configuration of MaxLogSize at configure-time

### DIFF
--- a/conf/cupsd.conf.in
+++ b/conf/cupsd.conf.in
@@ -8,6 +8,9 @@
 LogLevel @CUPS_LOG_LEVEL@
 @CUPS_PAGE_LOG_FORMAT@
 
+# Specifies the maximum size of the log files before they are rotated.  The value "0" disables log rotation.
+MaxLogSize @CUPS_MAX_LOG_SIZE@
+
 # Only listen for connections from the local machine.
 Listen localhost:@DEFAULT_IPP_PORT@
 @CUPS_LISTEN_DOMAINSOCKET@

--- a/config-scripts/cups-defaults.m4
+++ b/config-scripts/cups-defaults.m4
@@ -93,6 +93,13 @@ AC_ARG_WITH(log_file_perm, [  --with-log-file-perm    set default LogFilePerm va
 AC_SUBST(CUPS_LOG_FILE_PERM)
 AC_DEFINE_UNQUOTED(CUPS_DEFAULT_LOG_FILE_PERM, 0$CUPS_LOG_FILE_PERM)
 
+dnl Default MaxLogSize
+AC_ARG_WITH(max_log_size, [  --with-max-log-size     set default MaxLogSize value, default=1m],
+	CUPS_MAX_LOG_SIZE="$withval",
+	CUPS_MAX_LOG_SIZE="1m")
+AC_SUBST(CUPS_MAX_LOG_SIZE)
+AC_DEFINE_UNQUOTED(CUPS_DEFAULT_MAX_LOG_SIZE, "$CUPS_MAX_LOG_SIZE")
+
 dnl Default FatalErrors
 AC_ARG_WITH(fatal_errors, [  --with-fatal-errors     set default FatalErrors value, default=config],
 	CUPS_FATAL_ERRORS="$withval",


### PR DESCRIPTION
Linuxes ship with logrotate.