### PR TITLE
Debian: Set default job error policy to "retry-job"

### DIFF
--- a/doc/help/man-cupsd.conf.html
+++ b/doc/help/man-cupsd.conf.html
@@ -95,9 +95,9 @@ The default is typically the server's ".local" hostname.
 <dt><b>ErrorPolicy retry-current-job</b>
 <dd style="margin-left: 5.0em">Specifies that a failed print job should be retried immediately unless otherwise specified for the printer.
 <dt><b>ErrorPolicy retry-job</b>
-<dd style="margin-left: 5.0em">Specifies that a failed print job should be retried at a later time unless otherwise specified for the printer.
+<dd style="margin-left: 5.0em">Specifies that a failed print job should be retried at a later time unless otherwise specified for the printer. The 'retry-job' error policy is the default.
 <dt><b>ErrorPolicy stop-printer</b>
-<dd style="margin-left: 5.0em">Specifies that a failed print job should stop the printer unless otherwise specified for the printer. The 'stop-printer' error policy is the default.
+<dd style="margin-left: 5.0em">Specifies that a failed print job should stop the printer unless otherwise specified for the printer.
 <dt><a name="FilterLimit"></a><b>FilterLimit </b><i>limit</i>
 <dd style="margin-left: 5.0em">Specifies the maximum cost of filters that are run concurrently, which can be used to minimize disk, memory, and CPU resource problems.
 A limit of 0 disables filter limiting.

--- a/man/cupsd.conf.5
+++ b/man/cupsd.conf.5
@@ -140,10 +140,10 @@ Specifies that a failed print job should be aborted (discarded) unless otherwise
 Specifies that a failed print job should be retried immediately unless otherwise specified for the printer.
 .TP 5
 \fBErrorPolicy retry-job\fR
-Specifies that a failed print job should be retried at a later time unless otherwise specified for the printer.
+Specifies that a failed print job should be retried at a later time unless otherwise specified for the printer. The 'retry-job' error policy is the default.
 .TP 5
 \fBErrorPolicy stop-printer\fR
-Specifies that a failed print job should stop the printer unless otherwise specified for the printer. The 'stop-printer' error policy is the default.
+Specifies that a failed print job should stop the printer unless otherwise specified for the printer.
 .\"#FilterLimit
 .TP 5
 \fBFilterLimit \fIlimit\fR

--- a/scheduler/conf.c
+++ b/scheduler/conf.c
@@ -752,7 +752,7 @@ cupsdReadConfiguration(void)
   cupsdSetString(&LPDConfigFile, CUPS_DEFAULT_LPD_CONFIG_FILE);
   cupsdSetString(&SMBConfigFile, CUPS_DEFAULT_SMB_CONFIG_FILE);
 
-  cupsdSetString(&ErrorPolicy, "stop-printer");
+  cupsdSetString(&ErrorPolicy, "retry-job");
 
   JobHistory          = DEFAULT_HISTORY;
   JobFiles            = DEFAULT_FILES;
@@ -1231,8 +1231,8 @@ cupsdReadConfiguration(void)
       strcmp(ErrorPolicy, "retry-job") &&
       strcmp(ErrorPolicy, "stop-printer"))
   {
-    cupsdLogMessage(CUPSD_LOG_ALERT, "Invalid ErrorPolicy \"%s\", resetting to \"stop-printer\".", ErrorPolicy);
-    cupsdSetString(&ErrorPolicy, "stop-printer");
+    cupsdLogMessage(CUPSD_LOG_ALERT, "Invalid ErrorPolicy \"%s\", resetting to \"retry-job\".", ErrorPolicy);
+    cupsdSetString(&ErrorPolicy, "retry-job");
   }
 
  /*


### PR DESCRIPTION
It it is less confusing and a better default on most machines.
Amend documentation accordingly.