### PR TITLE
backend,scheduler/ipp.c: Fix 'printer-alert' invalid free

### DIFF
--- a/backend/ipp.c
+++ b/backend/ipp.c
@@ -3075,7 +3075,7 @@ report_printer_state(ipp_t *ipp)	/* I - IPP response */
   * Report alerts and messages...
   */
 
-  if ((pa = ippFindAttribute(ipp, "printer-alert", IPP_TAG_TEXT)) != NULL)
+  if ((pa = ippFindAttribute(ipp, "printer-alert", IPP_TAG_STRING)) != NULL)
     report_attr(pa);
 
   if ((pam = ippFindAttribute(ipp, "printer-alert-message",

--- a/scheduler/ipp.c
+++ b/scheduler/ipp.c
@@ -4891,7 +4891,7 @@ copy_printer_attrs(
   }
 
   if (printer->alert && (!ra || cupsArrayFind(ra, "printer-alert")))
-    ippAddString(con->response, IPP_TAG_PRINTER, IPP_TAG_STRING, "printer-alert", NULL, printer->alert);
+    ippAddOctetString(con->response, IPP_TAG_PRINTER, "printer-alert", printer->alert, (int)strlen(printer->alert));
 
   if (printer->alert_description && (!ra || cupsArrayFind(ra, "printer-alert-description")))
     ippAddString(con->response, IPP_TAG_PRINTER, IPP_TAG_TEXT, "printer-alert-description", NULL, printer->alert_description);


### PR DESCRIPTION
The fix is created by Bernhard Übelacker from apple/cups #5826.

The problem is described in detail [here](https://github.com/apple/cups/issues/5826). I just removed:

```
--- a/backend/ipp.c
+++ b/backend/ipp.c
@@ -3026,6 +3026,7 @@ report_attr(ipp_attribute_t *attr)        /* I - Attribute */
           valptr += strlen(valptr);
           break;
 
+      case IPP_TAG_STRING :
       default :
          /*
          * Unsupported value type...
```

from the original patch - it looks okay without it (since the attribute is found as IPP_TAG_STRING and the tag doesn't have a case in switch, it will fallback into ```default:``` case automatically).

Regarding [PWG standard](http://ftp.pwg.org/pub/pwg/candidates/cs-ippstate10-20090731-5100.9.pdf) IPP_TAG_STRING is the correct one - ```printer-alert``` is defined as octet-string (meaning ```ippAddOctetString``` must be used) and IPP_TAG_TEXT tag works with ```ippAddString```, so based on this it looks like IPP_TAG_STRING is the correct one.