### PR TITLE
Set SyncOnClose to @CUPS_SYNC_ON_CLOSE@, not only in comment

### DIFF
--- a/conf/cups-files.conf.in
+++ b/conf/cups-files.conf.in
@@ -7,7 +7,7 @@
 #FatalErrors @CUPS_FATAL_ERRORS@
 
 # Do we call fsync() after writing configuration or status files?
-#SyncOnClose @CUPS_SYNC_ON_CLOSE@
+SyncOnClose @CUPS_SYNC_ON_CLOSE@
 
 # Default user and group for filters/backends/helper programs; this cannot be
 # any user or group that resolves to ID 0 for security reasons...


### PR DESCRIPTION
It seems [the patch to set SyncOnClose](https://github.com/OpenPrinting/cups/commit/9c1dcee087eee3c57937a223df76757a61dfd046#diff-0f0c74dfbd27453fcc8265cf53bf787e27a2cff768486e36b620723eae3dd54dR10) was incomplete. The default will be set, but commented.