### PR TITLE
http-support.c: Fix memory leak from Avahi

### DIFF
--- a/cups/http-support.c
+++ b/cups/http-support.c
@@ -2629,6 +2629,8 @@ http_resolve_cb(
       memcpy(resource + 1, value, valueLen);
       resource[valueLen + 1] = '\0';
     }
+
+    free(value);
   }
   else
   {


### PR DESCRIPTION
Avahi library allocates memory for 'value' within 'avahi_string_list_get_pair()' function - this allocated memory is returned as a pointer via parameter to 'http_resolve_cb()' function scope, so it needs to be freed.

It can be reproduced via cups-browsed if the printer/CUPS server is within local network and it is discoverable by Avahi - then if cups-browsed is run within valgrind, it will report the following issue:

```
==4931== 21 bytes in 1 blocks are definitely lost in loss record 356 of 1,326
==4931==    at 0x4839809: malloc (vg_replace_malloc.c:307)
==4931==    by 0x48539B4: UnknownInlinedFun (malloc.c:68)
==4931==    by 0x48539B4: avahi_malloc (malloc.c:107)
==4931==    by 0x4853EC9: avahi_memdup (malloc.c:252)
==4931==    by 0x485522A: avahi_string_list_get_pair (strlst.c:513)
==4931==    by 0x4CA24D7: http_resolve_cb (http-support.c:2602)
==4931==    by 0x486A44A: avahi_service_resolver_event (resolver.c:146)
==4931==    by 0x486B3BC: filter_func (client.c:256)
==4931==    by 0x4F19384: dbus_connection_dispatch (in /usr/lib64/libdbus-1.so.3.19.13)
==4931==    by 0x4863BDF: dispatch_timeout_callback (dbus-watch-glue.c:105)
==4931==    by 0x4856577: avahi_simple_poll_dispatch (simple-watch.c:570)
==4931==    by 0x4CA8C37: _httpResolveURI (http-support.c:2045)
==4931==    by 0x4C02C59: resolve_uri (ipp.c:88)
```

The report is gone if the fix is applied.

Would you mind merging it into the project?

Thank you in advance!