### PR TITLE
http-support.c: Add avahi-common/malloc.h header for avahi_free() def…

### DIFF
--- a/cups/http-support.c
+++ b/cups/http-support.c
@@ -27,6 +27,7 @@
 #elif defined(HAVE_AVAHI)
 #  include <avahi-client/client.h>
 #  include <avahi-client/lookup.h>
+#  include <avahi-common/malloc.h>
 #  include <avahi-common/simple-watch.h>
 #endif /* HAVE_DNSSD */
 


### PR DESCRIPTION
…inition

It fixes warning during compilation.