### PR TITLE
Tests: sleep 5 even when not waiting on jobs (Issue #54)

### DIFF
--- a/test/waitjobs.sh
+++ b/test/waitjobs.sh
@@ -36,6 +36,7 @@ fi
 
 jobs=`$runcups ../systemv/lpstat 2>/dev/null | wc -l | tr -d ' '`
 if test $jobs = 0; then
+	sleep 5
 	exit 0
 fi
 


### PR DESCRIPTION
It seems to me the issue we're experiencing on Travis-CI (and Debian's Gitlab CI builds) is a timing issue; since 09c18efc06c374afad7f1548ffe1355801d64274 there's no `sleep 5` anymore after "Waiting for jobs to complete...".

By re-adding a `sleep 5` in the first condition, it seems the history "has time" to land in `spool/`, and that fixes both the Travis CI build and the Gitlab CI build.

Of course, this is a weird (= wrong) fix, but I think it underlines the timing issue; the test is likely not waiting on the right things.