### PR TITLE
cups/dest.c: Remove an underscore from queue name if it is the last c…

### DIFF
--- a/CHANGES-OPENPRINTING.md
+++ b/CHANGES-OPENPRINTING.md
@@ -1,6 +1,12 @@
 OpenPrinting CUPS Changes
 =========================
 
+Changes in CUPS v2.3.3op2
+-------------------------
+
+- Clarified the documentation for the "Listen" directive (Issue #53)
+
+
 Changes in CUPS v2.3.3op1
 -------------------------
 

--- a/cups/dest.c
+++ b/cups/dest.c
@@ -4369,5 +4369,12 @@ cups_queue_name(
       *nameptr++ = '_';
   }
 
+ /*
+  * Remove an underscore if it is the last character
+  * and isn't the only character in the string
+  */
+  if (nameptr[-1] == '_' && nameptr > (name + 1))
+    nameptr--;
+
   *nameptr = '\0';
 }

--- a/doc/help/man-cups-files.conf.html
+++ b/doc/help/man-cups-files.conf.html
@@ -213,6 +213,7 @@ command is used instead.
 CUPS Online Help (<a href="http://localhost:631/help">http://localhost:631/help</a>)
 <h2 class="title"><a name="COPYRIGHT">Copyright</a></h2>
 Copyright &copy; 2020 by Michael R Sweet
+<br>
 Copyright &copy; 2007-2019 by Apple Inc.
 
 </body>

--- a/doc/help/man-cupsd.conf.html
+++ b/doc/help/man-cupsd.conf.html
@@ -163,6 +163,7 @@ The default is "0" which disables the limit check.
 <dd style="margin-left: 5.0em">Listens to the specified address and port or domain socket path for connections.
 Multiple Listen directives can be provided to listen on multiple addresses.
 The Listen directive is similar to the Port directive but allows you to restrict access to specific interfaces or networks.
+Note: "Listen *:<i>port</i>" and "Port <i>port</i>" effectively listen on all IP addresses, so you cannot combine them with Listen directives for explicit IPv4 or IPv6 addresses on the same port.
 <dt><a name="ListenBackLog"></a><b>ListenBackLog </b><i>number</i>
 <dd style="margin-left: 5.0em">Specifies the number of pending connections that will be allowed.
 This normally only affects very busy servers that have reached the MaxClients limit, but can also be triggered by large numbers of simultaneous connections.
@@ -624,6 +625,8 @@ Require authentication for accesses from outside the 10. network:
 <b>subscriptions.conf</b>(5),
 CUPS Online Help (<a href="http://localhost:631/help">http://localhost:631/help</a>)
 <h2 class="title"><a name="COPYRIGHT">Copyright</a></h2>
+Copyright &copy; 2020 by Michael R Sweet
+<br>
 Copyright &copy; 2007-2019 by Apple Inc.
 
 </body>

--- a/man/cups-files.conf.5
+++ b/man/cups-files.conf.5
@@ -295,4 +295,5 @@ command is used instead.
 CUPS Online Help (http://localhost:631/help)
 .SH COPYRIGHT
 Copyright \[co] 2020 by Michael R Sweet
+.br
 Copyright \[co] 2007-2019 by Apple Inc.

--- a/man/cupsd.conf.5
+++ b/man/cupsd.conf.5
@@ -1,13 +1,14 @@
 .\"
 .\" cupsd.conf man page for CUPS.
 .\"
+.\" Copyright © 2020 by Michael R Sweet
 .\" Copyright © 2007-2019 by Apple Inc.
 .\" Copyright © 1997-2006 by Easy Software Products.
 .\"
 .\" Licensed under Apache License v2.0.  See the file "LICENSE" for more
 .\" information.
 .\"
-.TH cupsd.conf 5 "CUPS" "16 July 2019" "Apple Inc."
+.TH cupsd.conf 5 "CUPS" "28 November 2020" "Apple Inc."
 .SH NAME
 cupsd.conf \- server configuration file for cups
 .SH DESCRIPTION
@@ -245,6 +246,7 @@ The default is "0" which disables the limit check.
 Listens to the specified address and port or domain socket path for connections.
 Multiple Listen directives can be provided to listen on multiple addresses.
 The Listen directive is similar to the Port directive but allows you to restrict access to specific interfaces or networks.
+Note: "Listen *:\fIport\fR" and "Port \fIport\fR" effectively listen on all IP addresses, so you cannot combine them with Listen directives for explicit IPv4 or IPv6 addresses on the same port.
 .\"#ListenBackLog
 .TP 5
 \fBListenBackLog \fInumber\fR
@@ -902,4 +904,6 @@ Require authentication for accesses from outside the 10. network:
 .BR subscriptions.conf (5),
 CUPS Online Help (http://localhost:631/help)
 .SH COPYRIGHT
+Copyright \[co] 2020 by Michael R Sweet
+.br
 Copyright \[co] 2007-2019 by Apple Inc.


### PR DESCRIPTION
…haracter

It is a cosmetic issue to queue name looking better in print dialogs.