### PR TITLE
SERVERBIN: match host_os_name on *-gnu before *bsd* to catch kfreebsd-gnu's

### DIFF
--- a/config-scripts/cups-directories.m4
+++ b/config-scripts/cups-directories.m4
@@ -262,6 +262,11 @@ AC_SUBST(CUPS_REQUESTS)
 
 # Server executables...
 case "$host_os_name" in
+	*-gnu)
+		# GNUs
+		INSTALL_SYSV="install-sysv"
+		CUPS_SERVERBIN="$exec_prefix/lib/cups"
+		;;
 	*bsd* | darwin*)
 		# *BSD and Darwin (macOS)
 		INSTALL_SYSV=""


### PR DESCRIPTION
Debian's kfreebsd-gnu architectures (`kfreebsd-amd64` and `kfreebsd-i386`) work as Debian/GNU systems, hence with a `/usr/lib/cups` SERVERBIN, not a `/usr/libexec/cups`.

* Debian kfreebsd-amd64's host system type is `x86_64-pc-kfreebsd-gnu`
* [FreeBSD's CUPS build log](http://beefy18.nyi.freebsd.org/data/head-amd64-default/p556876_s368287/logs/cups-2.3.3_1.log) shows that it is `amd64-portbld-freebsd13.0` for FreeBSD.