### PR TITLE
CUPS_EXE_FILE_PERM: also match host_os_name on *-gnu, to also catch kfreebsd-gnu

### DIFF
--- a/config-scripts/cups-defaults.m4
+++ b/config-scripts/cups-defaults.m4
@@ -53,7 +53,7 @@ dnl Default executable file permissions
 AC_ARG_WITH(exe_file_perm, [  --with-exe-file-perm    set default executable permissions value, default=0555],
 	CUPS_EXE_FILE_PERM="$withval",
 	[case "$host_os_name" in
-		linux* | gnu*)
+		linux* | gnu* | *-gnu)
 			CUPS_EXE_FILE_PERM="755"
 			;;
 		*)


### PR DESCRIPTION
Debian's kfreebsd-gnu architectures (kfreebsd-amd64 and kfreebsd-i386) work as Debian/GNU systems, hence with a 755 CUP_EXE_FILE_PERM, not 555.

Similar as #60 