### PR TITLE
Systemd: Let cups.service start after nslcd.service

### DIFF
--- a/scheduler/cups.service.in
+++ b/scheduler/cups.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=CUPS Scheduler
 Documentation=man:cupsd(8)
-After=network.target sssd.service ypbind.service
+After=network.target sssd.service ypbind.service nslcd.service
 Requires=cups.socket
 
 [Service]


### PR DESCRIPTION
As reported in Debian's https://bugs.debian.org/977198 , some setups use nslcd.service for user account management. Starting CUPS after that makes sense.
