### PR TITLE
modifying lp commands for multiple files

### DIFF
--- a/systemv/lp.c
+++ b/systemv/lp.c
@@ -595,8 +595,13 @@ main(int  argc,				/* I - Number of command-line arguments */
     return (1);
   }
 
-  if (num_files > 0)
-    job_id = cupsPrintFiles(printer, num_files, files, title, num_options, options);
+  if (num_files > 0){
+	  const char* temp[1];
+	  for(int filenum =0;filenum<num_files;filenum++){
+		  temp[0]=files[filenum];
+    	job_id = cupsPrintFiles(printer, 1, temp, title, num_options, options);
+	  }
+  }
   else if ((job_id = cupsCreateJob(CUPS_HTTP_DEFAULT, printer,
                                    title ? title : "(stdin)",
                                    num_options, options)) > 0)


### PR DESCRIPTION
[issue 187](https://github.com/OpenPrinting/cups-filters/issues/187)
when trying to print multiple files only a single file is printed, for instance when giving command `lp a.pdf b.pdf`, only b.pdf file is printed.
so we can try to print these files seprately creating different job for each.
Modified code seems to work fine now.