### PR TITLE
Add check for whether 'option' variable exists or not for closeUI and…

### DIFF
--- a/cups/ppd.c
+++ b/cups/ppd.c
@@ -1496,7 +1496,7 @@ _ppdOpen(
 	goto error;
       }
 
-      if (!_cups_strcasecmp(option->defchoice, "custom") || !_cups_strncasecmp(option->defchoice, "custom.", 7))
+      if (option && (!_cups_strcasecmp(option->defchoice, "custom") || !_cups_strncasecmp(option->defchoice, "custom.", 7)))
       {
        /*
 	* "*DefaultOption: Custom..." may set the default to a custom value
@@ -1531,7 +1531,7 @@ _ppdOpen(
 	goto error;
       }
 
-      if (!_cups_strcasecmp(option->defchoice, "custom") || !_cups_strncasecmp(option->defchoice, "custom.", 7))
+      if (option && (!_cups_strcasecmp(option->defchoice, "custom") || !_cups_strncasecmp(option->defchoice, "custom.", 7)))
       {
        /*
 	* "*DefaultOption: Custom..." may set the default to a custom value


### PR DESCRIPTION
… JCLCloseUI lines in ppd.c

Fixes Issue #64 
The issue was caused when two closeUI statements are encountered simultaneously. When the first one is encountered, option is set to NULL. After that, if another closeUI is found before openUI, then when option is accessed, it gives the segmentation fault. 
Adding this check in the if statement should fix the issue. 