### PR TITLE
cgi-bin/help-index.c: Check node->section before using it in strcmp()

### DIFF
--- a/CHANGES-OPENPRINTING.md
+++ b/CHANGES-OPENPRINTING.md
@@ -12,6 +12,7 @@ Changes in CUPS v2.3.3op2
 - The scheduler's systemd service file now waits for the nslcd service to start
   (Issue #69)
 - Root certificates were incorrectly stored in "~/.cups/ssl".
+- Fixed segfault in help.cgi when searching in man pages
 
 
 Changes in CUPS v2.3.3op1

--- a/cgi-bin/help-index.c
+++ b/cgi-bin/help-index.c
@@ -579,7 +579,7 @@ helpSearchIndex(help_index_t *hi,	/* I - Index */
   */
 
   for (; node; node = (help_node_t *)cupsArrayNext(hi->nodes))
-    if (section && strcmp(node->section, section))
+    if (node->section && section && strcmp(node->section, section))
       continue;
     else if (filename && strcmp(node->filename, filename))
       continue;


### PR DESCRIPTION
Fixes a segfault in help.cgi, which happens if user tries to search in man pages.
Fedora bug [#1921881](https://bugzilla.redhat.com/show_bug.cgi?id=1921881)