### PR TITLE
Debian: Run testlang for each CUPS locale

### DIFF
--- a/cups/Makefile
+++ b/cups/Makefile
@@ -639,9 +639,9 @@ testlang:	testlang.o $(LIBCUPSSTATIC)
 		lang=`basename $$po .po | sed -e '1,$$s/^cups_//'`; \
 		$(MKDIR) locale/$$lang; \
 		$(LN) ../../$$po locale/$$lang; \
+		echo Running language API tests for $$lang...; \
+		LOCALEDIR=locale ./testlang -l $$lang; \
 	done
-	echo Running language API tests...
-	LOCALEDIR=locale ./testlang
 
 
 #


### PR DESCRIPTION
… and only for these.

Of the build environment forces LC_ALL to a non-provided locale, the build will fail.

For instance, the Debian reproducible builds' initiative runs builds under arbitrary locales; specifically the `testlang` make target will fail when run with `LC_ALL=kz_KZ` for example.