### PR TITLE
Let cups.1 point to client.conf.5, not client.conf.7

### DIFF
--- a/man/cups.1
+++ b/man/cups.1
@@ -125,7 +125,7 @@ Printers that do not support IPP can be supported using applications such as
 .BR ippeveprinter (1).
 .SH SEE ALSO
 .BR cancel (1),
-.BR client.conf (7),
+.BR client.conf (5),
 .BR cupsctl (8),
 .BR cupsd (8),
 .BR lp (1),


### PR DESCRIPTION
It seems the cups.1 manpage has been wrongly pointing to client.conf in section 7 since 2014, while it was always shipped in section 5. Fix this.

See Debian bug: https://bugs.debian.org/982303