### PR TITLE
`lpinfo -m` timeout parallelization of PPD Generators.

### DIFF
--- a/cups/dest.c
+++ b/cups/dest.c
@@ -3502,6 +3502,12 @@ cups_enum_dests(
 
     num_dests = _cupsGetDests(http, IPP_OP_CUPS_GET_PRINTERS, NULL, &dests, type, mask);
 
+    /*
+    * Pass the number of destinations to fetch required dest...
+    */
+
+    num_dests = cups_get_dests(filename,NULL, NULL, 1, user_default != NULL, num_dests, &dests);
+
     if (data.def_name[0])
     {
      /*
@@ -3687,6 +3693,8 @@ cups_enum_dests(
     remaining = INT_MAX;
   else
     remaining = msec;
+
+  data.num_dests = cups_get_dests(filename ,NULL, NULL, 1, user_default != NULL, data.num_dests, &data.dests);
 
   while (remaining > 0 && (!cancel || !*cancel))
   {
@@ -4183,14 +4191,14 @@ cups_get_dests(
       if ((dest = cupsGetDest(name, instance, num_dests, *dests)) == NULL)
       {
        /*
-	* Out of memory!
-	*/
+	      * Out of memory!
+	      */
 
         DEBUG_puts("9cups_get_dests: Out of memory!");
         break;
       }
     }
-
+  
    /*
     * Add options until we hit the end of the line...
     */


### PR DESCRIPTION
This PR is with respect to issue Issue https://github.com/OpenPrinting/cups/issues/65 .

`driverless` was taking too much time, so created a separate thread to call the PPD generators while waiting for timeout in the main thread. If the PPD is not returned within the timeout then terminated that call and looped over.
I have created separate functions regarding this. Requires some testing.

Commit 1204a8b
@michaelrsweet @tillkamppeter Please review this.