### PR TITLE
making True case-insensitive and correcting documentation for existing clients

### DIFF
--- a/cups/ppd.c
+++ b/cups/ppd.c
@@ -871,15 +871,15 @@ _ppdOpen(
       ppd_decode(ppd->jcl_ps);		/* Decode quoted string */
     }
     else if (!strcmp(keyword, "AccurateScreensSupport"))
-      ppd->accurate_screens = !strcmp(string, "True");
+      ppd->accurate_screens = !strcasecmp(string, "True");
     else if (!strcmp(keyword, "ColorDevice"))
-      ppd->color_device = !strcmp(string, "True");
+      ppd->color_device = !strcasecmp(string, "True");
     else if (!strcmp(keyword, "ContoneOnly"))
-      ppd->contone_only = !strcmp(string, "True");
+      ppd->contone_only = !strcasecmp(string, "True");
     else if (!strcmp(keyword, "cupsFlipDuplex"))
-      ppd->flip_duplex = !strcmp(string, "True");
+      ppd->flip_duplex = !strcasecmp(string, "True");
     else if (!strcmp(keyword, "cupsManualCopies"))
-      ppd->manual_copies = !strcmp(string, "True");
+      ppd->manual_copies = !strcasecmp(string, "True");
     else if (!strcmp(keyword, "cupsModelNumber"))
       ppd->model_number = atoi(string);
     else if (!strcmp(keyword, "cupsColorProfile"))

--- a/doc/help/spec-ppd.html
+++ b/doc/help/spec-ppd.html
@@ -1958,7 +1958,7 @@ hardware. The default value is <code>false</code>.</p>
 
 <pre class='command'>
 <em>*% Tell the RIP filters to generate the copies for us</em>
-*cupsManualCopies: true
+*cupsManualCopies: True
 </pre>
 
 

--- a/filter/spec-ppd.shtml
+++ b/filter/spec-ppd.shtml
@@ -1403,7 +1403,7 @@ hardware. The default value is <code>false</code>.</p>
 
 <pre class='command'>
 <em>*% Tell the RIP filters to generate the copies for us</em>
-*cupsManualCopies: true
+*cupsManualCopies: True
 </pre>
 
 


### PR DESCRIPTION
Made `True` case-insensitive in
`AccurateScreensSupport`,
`ColorDevice`,
`ContoneOnly`,
`cupsFlipDuplex` and
`cupsManualCopies`
and corrected documentation for existing clients. 
solved issue [#93](https://github.com/OpenPrinting/cups/issues/93)