### PR TITLE
scheduler/cups.service.in: Use nss-user-lookup.target in "After="

### DIFF
--- a/scheduler/cups.service.in
+++ b/scheduler/cups.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=CUPS Scheduler
 Documentation=man:cupsd(8)
-After=network.target sssd.service ypbind.service nslcd.service
+After=network.target nss-user-lookup.target
 Requires=cups.socket
 
 [Service]

--- a/scheduler/cups.service.in
+++ b/scheduler/cups.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=CUPS Scheduler
 Documentation=man:cupsd(8)
-After=network.target nss-user-lookup.target
+After=network.target nss-user-lookup.target nslcd.service
 Requires=cups.socket
 
 [Service]


### PR DESCRIPTION
Start cupsd after nss-user-lookup.target has been reached, instead of listing every service that could provide username resolution (sssd, ypbind, nslcd, etc.) to the "After=" line in the systemd unit file.

https://www.freedesktop.org/software/systemd/man/systemd.special.html says that nss-user-lookup.target
should be used as synchronization point for all regular UNIX user/group name service lookups. ... All services for which the availability of the full user/group database is essential should be ordered after this target, but not pull it in. All services which provide parts of the user/group database should be ordered before this target, and pull it in. 