### PR TITLE
cups.service.in: Add SYSTEMD_WANTED_BY variable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,8 @@ CUPS v2.4rc1 (Pending)
 - Removed support for the (long deprecated and unused) `FontPath`,
   `LPDConfigFile`, `RIPCache`, and `SMBConfigFile` directives in `cupsd.conf`
   and `cups-files.conf`.
+- Add `SYSTEMD_WANTED_BY` variable for adding different targets into 'WantedBy'
+  directive in CUPS service file during configuration (Issue #144)
 
 
 CUPS v2.3.3op2 (February 1, 2021)

--- a/config-scripts/cups-defaults.m4
+++ b/config-scripts/cups-defaults.m4
@@ -9,6 +9,9 @@ dnl Licensed under Apache License v2.0.  See the file "LICENSE" for more
 dnl information.
 dnl
 
+dnl Set a default systemd WantedBy directive
+SYSTEMD_WANTED_BY="printers.target"
+
 dnl Default languages...
 LANGUAGES="$(ls -1 locale/cups_*.po 2>/dev/null | sed -e '1,$s/locale\/cups_//' -e '1,$s/\.po//' | tr '\n' ' ')"
 
@@ -420,3 +423,8 @@ AS_CASE(["x$enable_webif"], [xno], [
 
 AC_SUBST([CUPS_WEBIF])
 AC_DEFINE_UNQUOTED([CUPS_DEFAULT_WEBIF], [$CUPS_DEFAULT_WEBIF], [Default WebInterface value.])
+
+AS_IF([test $CUPS_WEBIF = Yes || test $CUPS_BROWSING = Yes], [
+  SYSTEMD_WANTED_BY="$SYSTEMD_WANTED_BY multi-user.target"], [
+  ])
+AC_SUBST([SYSTEMD_WANTED_BY])

--- a/scheduler/cups.service.in
+++ b/scheduler/cups.service.in
@@ -11,4 +11,4 @@ Restart=on-failure
 
 [Install]
 Also=cups.socket cups.path
-WantedBy=printer.target
+WantedBy=@SYSTEMD_WANTED_BY@


### PR DESCRIPTION
The variable contains 'multi-user.target' if CUPS is configured with
enabled browsing or enabled web interface, empty otherwise.