### PR TITLE
scheduler/log.c: Use `[Job N]` even for syslog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@ CUPS v2.4rc1 (Pending)
   and `cups-files.conf`.
 - Add `SYSTEMD_WANTED_BY` variable for adding different targets into 'WantedBy'
   directive in CUPS service file during configuration (Issue #144)
+- Log `Job N` even for syslog
 
 
 CUPS v2.3.3op2 (February 1, 2021)

--- a/scheduler/log.c
+++ b/scheduler/log.c
@@ -569,11 +569,7 @@ cupsdLogJob(cupsd_job_t *job,		/* I - Job */
   * Format and write the log message...
   */
 
-#ifdef HAVE_SYSTEMD_SD_JOURNAL_H
-  if (job && strcmp(ErrorLog, "syslog"))
-#else
   if (job)
-#endif /* HAVE_SYSTEMD_SD_JOURNAL_H */
     snprintf(jobmsg, sizeof(jobmsg), "[Job %d] %s", job->id, message);
   else
     strlcpy(jobmsg, message, sizeof(jobmsg));


### PR DESCRIPTION
Currently there is a difference in job log format based on where logs
are sent - the message contains `[Job N]` if sent to a file and it
doesn't contain the string if sent to syslog.
Though it can be seen as a duplicate of information, since the main
syslog system used (journald) is capable of filtering messages based on
JID, but having `[Job N]` string in logs in syslog is useful when you
need to debug complex issues and you need to see what happens in the
scheduler and in a specific job at the same time - f.e. at print
servers.

How to reproduce:
0) set error logs to syslog in /etc/cups/cups-files.conf
1) $ cupsctl --debug-logging
2) $ lp -d <queue> <file>
3) $ journalctl -u cups

Actual results:
Cannot distinguish logs from scheduler and from the job

Results after the patch:
Job logs have `[Job N]` at the start of message, where N is a job id.