### PR TITLE
[WIP] usb-libusb.c: Set bigger timeout for bulk reading

### DIFF
--- a/backend/usb-libusb.c
+++ b/backend/usb-libusb.c
@@ -1704,7 +1704,7 @@ static void *read_thread(void *reference)
     readstatus = libusb_bulk_transfer(g.printer->handle,
 				      g.printer->read_endp,
 				      readbuffer, rbytes,
-				      &rbytes, 250);
+				      &rbytes, 60000);
     if (readstatus == LIBUSB_SUCCESS && rbytes > 0)
     {
       fprintf(stderr, "DEBUG: Read %d bytes of back-channel data...\n", (int)rbytes);
@@ -1721,7 +1721,8 @@ static void *read_thread(void *reference)
     * Make sure this loop executes no more than once every 250 miliseconds...
     */
 
-    if ((g.wait_eof || !g.read_thread_stop))
+    if ((readstatus != LIBUSB_SUCCESS || rbytes == 0) &&
+	 (g.wait_eof || !g.read_thread_stop))
       usleep(250000);
   }
   while (g.wait_eof || !g.read_thread_stop);


### PR DESCRIPTION
Some older USB devices (Samsung ML series) are not capable of sending
USB bulks within reading timeout (250ms) when `usb` backend is reading
data from back-channel. The transaction ends with timeout, the whole
job ends garbled and the device prints out 'INTERNAL ERROR - Incomplete
Session by time out'.

This behavior is a regression introduced by commit db53b49265ba, which
simplified the read loop, but put a 250ms timeout instead of the
original 60s in `libusb_bulk_transfer()`.

The timeout used in this PR is tested by two Fedora users
([Samsung ML-2240](https://bugzilla.redhat.com/show_bug.cgi?id=1942326),
[Samsung ML-1665](https://bugzilla.redhat.com/show_bug.cgi?id=1935318))
and works for them.