### PR TITLE
Logging enhancement.

### DIFF
--- a/backend/backend-private.h
+++ b/backend/backend-private.h
@@ -324,7 +324,8 @@ extern int		backendWaitLoop(int snmp_fd, http_addr_t *addr,
  * Used to log messages in backend.
  * This was done to avoid a mismatch between the message string and the size of the string to write.
  */
-#define backendMessage(msg) {const char *s=msg; write(2, s, strlen(s));}
+#define CUPS_BACKEND_LOG_MESSAGE_SIZE 2048
+#define backendMessage(msg) {const char *s=msg; write(2, s, _cups_strnlen(s, CUPS_BACKEND_LOG_MESSAGE_SIZE));}
 
 #  ifdef __cplusplus
 }

--- a/backend/backend-private.h
+++ b/backend/backend-private.h
@@ -320,6 +320,11 @@ extern int		backendSNMPSupplies(int snmp_fd, http_addr_t *addr,
 extern int		backendWaitLoop(int snmp_fd, http_addr_t *addr,
 			                int use_bc, _cups_sccb_t side_cb);
 
+/*
+ * Used to log messages in backend.
+ * This was done to avoid a mismatch between the message string and the size of the string to write.
+ */
+#define backendMessage(msg) {const char *s=msg; write(2, s, strlen(s));}
 
 #  ifdef __cplusplus
 }

--- a/backend/ipp.c
+++ b/backend/ipp.c
@@ -3418,7 +3418,7 @@ sigterm_handler(int sig)		/* I - Signal */
 {
   (void)sig;	/* remove compiler warnings... */
 
-  write(2, "DEBUG: Got SIGTERM.\n", 20);
+  fprintf(stderr, "DEBUG: Got SIGTERM.\n");
 
 #if defined(HAVE_GSSAPI) && defined(HAVE_XPC)
   if (child_pid)
@@ -3434,7 +3434,7 @@ sigterm_handler(int sig)		/* I - Signal */
     * Flag that the job should be canceled...
     */
 
-    write(2, "DEBUG: sigterm_handler: job_canceled = 1.\n", 25);
+    fprintf(stderr, "DEBUG: sigterm_handler: job_canceled = 1.\n");
 
     job_canceled = 1;
     return;

--- a/backend/ipp.c
+++ b/backend/ipp.c
@@ -3418,7 +3418,7 @@ sigterm_handler(int sig)		/* I - Signal */
 {
   (void)sig;	/* remove compiler warnings... */
 
-  fprintf(stderr, "DEBUG: Got SIGTERM.\n");
+  backendMessage("DEBUG: Got SIGTERM.\n");
 
 #if defined(HAVE_GSSAPI) && defined(HAVE_XPC)
   if (child_pid)
@@ -3434,7 +3434,7 @@ sigterm_handler(int sig)		/* I - Signal */
     * Flag that the job should be canceled...
     */
 
-    fprintf(stderr, "DEBUG: sigterm_handler: job_canceled = 1.\n");
+    backendMessage("DEBUG: sigterm_handler: job_canceled = 1.\n");
 
     job_canceled = 1;
     return;

--- a/backend/snmp.c
+++ b/backend/snmp.c
@@ -424,7 +424,7 @@ alarm_handler(int sig)			/* I - Signal number */
 #endif /* !HAVE_SIGSET && !HAVE_SIGACTION */
 
   if (DebugLevel)
-    write(2, "DEBUG: ALARM!\n", 14);
+    fprintf(stderr, "DEBUG: ALARM!\n");
 }
 
 

--- a/backend/snmp.c
+++ b/backend/snmp.c
@@ -424,7 +424,7 @@ alarm_handler(int sig)			/* I - Signal number */
 #endif /* !HAVE_SIGSET && !HAVE_SIGACTION */
 
   if (DebugLevel)
-    fprintf(stderr, "DEBUG: ALARM!\n");
+    backendMessage("DEBUG: ALARM!\n");
 }
 
 

--- a/backend/testbackend.c
+++ b/backend/testbackend.c
@@ -395,7 +395,7 @@ main(int  argc,				/* I - Number of command-line args */
 	  data = ps_data;
 
         write(1, data, strlen(data));
-	fprintf(stderr, "DEBUG: START\n");
+	backendMessage("DEBUG: START\n");
 	timeout = 60.0;
         while ((bytes = cupsBackChannelRead(buffer, sizeof(buffer),
 	                                    timeout)) > 0)
@@ -403,7 +403,7 @@ main(int  argc,				/* I - Number of command-line args */
 	  write(2, buffer, (size_t)bytes);
 	  timeout = 5.0;
 	}
-	fprintf(stderr, "\nDEBUG: END\n");
+	backendMessage("\nDEBUG: END\n");
       }
 
       exit(0);

--- a/backend/testbackend.c
+++ b/backend/testbackend.c
@@ -19,6 +19,7 @@
 #include <fcntl.h>
 #include <sys/wait.h>
 #include <signal.h>
+#include "backend-private.h"
 
 
 /*

--- a/backend/testbackend.c
+++ b/backend/testbackend.c
@@ -395,7 +395,7 @@ main(int  argc,				/* I - Number of command-line args */
 	  data = ps_data;
 
         write(1, data, strlen(data));
-	write(2, "DEBUG: START\n", 13);
+	fprintf(stderr, "DEBUG: START\n");
 	timeout = 60.0;
         while ((bytes = cupsBackChannelRead(buffer, sizeof(buffer),
 	                                    timeout)) > 0)
@@ -403,7 +403,7 @@ main(int  argc,				/* I - Number of command-line args */
 	  write(2, buffer, (size_t)bytes);
 	  timeout = 5.0;
 	}
-	write(2, "\nDEBUG: END\n", 12);
+	fprintf(stderr, "\nDEBUG: END\n");
       }
 
       exit(0);

--- a/backend/usb-darwin.c
+++ b/backend/usb-darwin.c
@@ -2231,7 +2231,7 @@ sigterm_handler(int sig)		/* I - Signal */
       _exit(0);
     else
     {
-      write(2, "DEBUG: Child crashed.\n", 22);
+      fprintf(stderr, "DEBUG: Child crashed.\n");
       _exit(CUPS_BACKEND_STOP);
     }
   }

--- a/backend/usb-darwin.c
+++ b/backend/usb-darwin.c
@@ -2231,7 +2231,7 @@ sigterm_handler(int sig)		/* I - Signal */
       _exit(0);
     else
     {
-      fprintf(stderr, "DEBUG: Child crashed.\n");
+      backendMessage("DEBUG: Child crashed.\n");
       _exit(CUPS_BACKEND_STOP);
     }
   }

--- a/cups/string-private.h
+++ b/cups/string-private.h
@@ -170,6 +170,8 @@ extern int	_cups_vsnprintf(char *, size_t, const char *, va_list) _CUPS_PRIVATE;
 #    define vsnprintf _cups_vsnprintf
 #  endif /* !HAVE_VSNPRINTF */
 
+extern size_t _cups_strnlen(const char *, size_t) _CUPS_PRIVATE;
+
 /*
  * String pool functions...
  */

--- a/cups/string.c
+++ b/cups/string.c
@@ -753,6 +753,22 @@ _cups_strlcpy(char       *dst,		/* O - Destination string */
 #endif /* !HAVE_STRLCPY */
 
 
+size_t					/* O - Length of string */
+_cups_strnlen( const char *str,		/* I - A string */
+	       size_t      maxsize)	/* I - The maximum size of string */
+{
+  if (str == NULL)
+    return 0;
+
+  size_t count = 0;
+
+  while (*str++ && maxsize--)
+    count++;
+
+  return count;
+}
+
+
 /*
  * 'compare_sp_items()' - Compare two string pool items...
  */


### PR DESCRIPTION
I found that in different places, different functions are used for logging.

Those are examples:
fprintf(stderr, "DEBUG: message\n");
fputs("DEBUG: message\n", stderr);
write(2, "DEBUG: message\n", <string-length>);

The last one:
write(2, "DEBUG: message\n", <string-length>);
Is unsafe.

The string could be updated, but <string-length> not, by mistake.

I found the one such place:
File: backends/ipp.c
Line: 3437
write(2, "DEBUG: sigterm_handler: job_canceled = 1.\n", 25);

String length is smaller than actual string.

Changed all places of using write(2, ...) to fprintf(stderr, ...), where using of it could be potentialy unsafe.