### PR TITLE
Fix misspelled variable names in configure script

### DIFF
--- a/config-scripts/cups-startup.m4
+++ b/config-scripts/cups-startup.m4
@@ -89,7 +89,7 @@ AS_IF([test $with_ondemand = systemd -o $with_ondemand = yes], [
 	    AC_MSG_RESULT([no])
 	])
 
-	AS_IF([test $have_system = yes], [
+	AS_IF([test $have_systemd = yes], [
 	    AC_DEFINE([HAVE_SYSTEMD], [1], [Have systemd support?])
 	    AC_DEFINE([HAVE_ONDEMAND], [1], [Have on-demand launch support?])
 	    AC_CHECK_HEADER([systemd/sd-journal.h], [

--- a/config-scripts/cups-threads.m4
+++ b/config-scripts/cups-threads.m4
@@ -33,7 +33,7 @@ AS_IF([test x$ac_cv_header_pthread_h = xyes], [
 	])
 	AC_MSG_RESULT([$have_pthread])
 
-	AS_IF([test $have_thread = yes], [
+	AS_IF([test $have_pthread = yes], [
 	    PTHREAD_FLAGS="-D_THREAD_SAFE -D_REENTRANT"
 
 	    # Solaris requires -D_POSIX_PTHREAD_SEMANTICS to be POSIX-

--- a/configure
+++ b/configure
@@ -9605,7 +9605,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam \
 	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $have_pthread" >&5
 printf "%s\n" "$have_pthread" >&6; }
 
-	if test $have_thread = yes
+	if test $have_pthread = yes
 then :
 
 	    PTHREAD_FLAGS="-D_THREAD_SAFE -D_REENTRANT"
@@ -11281,7 +11281,7 @@ printf "%s\n" "no" >&6; }
 
 fi
 
-	if test $have_system = yes
+	if test $have_systemd = yes
 then :
 
 


### PR DESCRIPTION
have_system should be have_systemd. have_thread should be have_pthread.