### PR TITLE
scheduler/main.c: Set select timeout to JobHistoryUpdate again

### DIFF
--- a/scheduler/main.c
+++ b/scheduler/main.c
@@ -1731,6 +1731,11 @@ select_timeout(int fds)			/* I - Number of descriptors returned */
  /*
   * Check for any job activity...
   */
+  if (JobHistoryUpdate && timeout > JobHistoryUpdate)
+  {
+    timeout = JobHistoryUpdate;
+    why     = "update job history";
+  }
 
   for (job = (cupsd_job_t *)cupsArrayFirst(ActiveJobs);
        job;


### PR DESCRIPTION
The commit 9bdea94b145 introduced a regression in job control and data
files cleanup. If user sets PreserveJobHistory and PreserveJobFiles,
prints a file and stops cupsd before files are cleaned up, the files
aren't removed after cupsd restarts and the timeouts for removal are
reached.

The files will be removed if user uses command 'lpstat -W completed -o'
or by another cupsd restart after time passes JobHistoryUpdate, so
workarounds exist, however the current behavior is strange :( .