### PR TITLE
cups-common.m4: Check for dbus_thread_init_default()

### DIFF
--- a/config-scripts/cups-common.m4
+++ b/config-scripts/cups-common.m4
@@ -338,8 +338,8 @@ AS_IF([test "x$enable_dbus" != xno -a "x$PKGCONFIG" != x -a "x$host_os_name" != 
 	AC_CHECK_FUNC([dbus_message_iter_init_append], [
 	    AC_DEFINE([HAVE_DBUS_MESSAGE_ITER_INIT_APPEND], [1], [Have dbus_message_iter_init_append function?])
 	])
-	AC_CHECK_FUNC([dbus_threads_init], [
-	    AC_DEFINE([HAVE_DBUS_THREADS_INIT], [1], [Have dbus_threads_init function?])
+	AC_CHECK_FUNC([dbus_threads_init_default], [
+	    AC_DEFINE([HAVE_DBUS_THREADS_INIT], [1], [Have dbus_threads_init_default function?])
 	])
 	LIBS="$SAVELIBS"
 	AS_IF([test -d /etc/dbus-1 -a "x$DBUSDIR" = x], [


### PR DESCRIPTION
We actually use dbus_thread_init_default() in the code, so we should
check for it during configuration.