### PR TITLE
scheduler/job.c: use gziptoany for raw files (not just raw printers)

### DIFF
--- a/scheduler/job.c
+++ b/scheduler/job.c
@@ -501,6 +501,7 @@ cupsdContinueJob(cupsd_job_t *job)	/* I - Job */
   int			backroot;	/* Run backend as root? */
   int			pid;		/* Process ID of new filter process */
   int			banner_page;	/* 1 if banner page, 0 otherwise */
+  int			raw_file;       /* 1 if file type is vnd.cups-raw */
   int			filterfds[2][2] = { { -1, -1 }, { -1, -1 } };
 					/* Pipes used between filters */
   int			envc;		/* Number of environment variables */
@@ -746,8 +747,11 @@ cupsdContinueJob(cupsd_job_t *job)	/* I - Job */
   * Add decompression/raw filter as needed...
   */
 
+  raw_file = !strcmp(job->filetypes[job->current_file]->super, "application") &&
+    !strcmp(job->filetypes[job->current_file]->type, "vnd.cups-raw");
+  
   if ((job->compressions[job->current_file] && (!job->printer->remote || job->num_files == 1)) ||
-      (!job->printer->remote && job->printer->raw && job->num_files > 1))
+      (!job->printer->remote && (job->printer->raw || raw_file) && job->num_files > 1))
   {
    /*
     * Add gziptoany filter to the front of the list...


### PR DESCRIPTION
Printing banner pages with raw print files (but not on raw printers), causes only the banner to be printed.  The patch to fix https://github.com/apple/cups/issues/4782 caused a slight regression that re-introduced part of the issue described in STR #1933.  The gziptoany filter is invoked for multi-file jobs on raw queues, but not for raw files on a non-raw queue.