### PR TITLE
Add the Canon PIXMA MP240 to the USB quirk list

### DIFF
--- a/backend/org.cups.usb-quirks
+++ b/backend/org.cups.usb-quirks
@@ -77,6 +77,9 @@
 # Canon, Inc. MP210 (https://bugzilla.redhat.com/show_bug.cgi?id=847923#c53)
 0x04a9 0x1721 unidir
 
+# Canon, Inc. MP240 Printer (https://github.com/agalakhov/captdriver/issues/7#issuecomment-890380405)
+0x04a9 0x1732 unidir
+
 # Canon, Inc. MP500 Printer (https://bugs.launchpad.net/bugs/1032456)
 0x04a9 0x170c unidir
 

--- a/backend/org.cups.usb-quirks
+++ b/backend/org.cups.usb-quirks
@@ -95,14 +95,47 @@
 # Canon, Inc. MP270 Printer
 0x04a9 0x173b unidir
 
-# Canon, Inc. MP280 Printer
+# Canon, Inc. MP280 series (Apple #5221)
 0x04a9 0x1746 unidir
+
+# Canon PIXMA MP410
+0x04a9 0x1702 unidir
+
+# Canon PIXMA MP430
+0x04a9 0x1703 unidir
+
+# Canon PIXMA MP450
+0x04a9 0x170b unidir
+
+# Canon PIXMA MP460
+0x04a9 0x1716 unidir
+
+# Canon PIXMA MP470
+0x04a9 0x1723 unidir
+
+# Canon PIXMA MP480 (Issue #192)
+0x04a9 0x1731 unidir
+
+# Canon PIXMA MP490
+0x04a9 0x173c unidir
+
+# Canon PIXMA MP493
+0x04a9 0x1757 unidir
+
+# Canon PIXMA MP495
+0x04a9 0x1747 unidir
 
 # Canon, Inc. MP500 Printer (https://bugs.launchpad.net/bugs/1032456)
 0x04a9 0x170c unidir
 
 # Canon, Inc. MP510 Printer (https://bugs.launchpad.net/bugs/1050009)
 0x04a9 0x1717 unidir
+
+# Canon, Inc. MP520 Printer
+0x04a9 0x1724 unidir
+
+# Canon, Inc. MP530 Printer
+0x04a9 0x1712 unidir
 
 # Canon, Inc. MP540 Printer, https://bugzilla.redhat.com/967873
 0x04a9 0x1730 unidir
@@ -303,9 +336,6 @@
 # HP LaserJet 1160 (Apple #5121)
 0x03f0 0x1e17 delay-close
 
-# Canon, Inc. MP280 series (Apple #5221)
-0x04a9 0x1746 unidir
-
 # Star Micronics printers (Apple #5251)
 0x0519 unidir
 
@@ -338,6 +368,3 @@
 
 # HP DesignJet 130 (Apple #5838)
 0x03f0 0x0314 no-reattach
-
-# Canon PIXMA MP480 (Issue #192)
-0x04a9 0x1731 unidir

--- a/backend/org.cups.usb-quirks
+++ b/backend/org.cups.usb-quirks
@@ -77,8 +77,26 @@
 # Canon, Inc. MP210 (https://bugzilla.redhat.com/show_bug.cgi?id=847923#c53)
 0x04a9 0x1721 unidir
 
+# Canon, Inc. MP220 Printer
+0x04a9 0x1722 unidir
+
+# Canon, Inc. MP230 Printer
+0x04a9 0x175f unidir
+
 # Canon, Inc. MP240 Printer (https://github.com/agalakhov/captdriver/issues/7#issuecomment-890380405)
 0x04a9 0x1732 unidir
+
+# Canon, Inc. MP250 Printer
+0x04a9 0x173a unidir
+
+# Canon, Inc. MP260 Printer
+0x04a9 0x1733 unidir
+
+# Canon, Inc. MP270 Printer
+0x04a9 0x173b unidir
+
+# Canon, Inc. MP280 Printer
+0x04a9 0x1746 unidir
 
 # Canon, Inc. MP500 Printer (https://bugs.launchpad.net/bugs/1032456)
 0x04a9 0x170c unidir


### PR DESCRIPTION
Without it the printer gets stuck waiting for some kind of USB response from the computer 3/4 into the page. Right at the end of the job. Sometimes it moves the printing head once every few minutes, if we wait for 20-30 minutes it often finishes correctly. Which is unacceptable.

Using `no-reattach unidir` instead of only `unidir` seems to also work fine, but it seemed superfluous in my case, so try that if things are still wonky. Disconnecting the USB cable makes it stop the job instantly, spitting the rest of the page.

The same setup works on Windows just fine. Maybe adding the other MP2XX models into the list should be considered. In my case, until a few months ago printing via CUPS without any kinds of quirks seemed to work fine, so it seems like some kind of regression.

The credit goes to @mounaiban for the original solution:
https://github.com/agalakhov/captdriver/issues/7#issuecomment-602004919

More information here:
https://github.com/agalakhov/captdriver/issues/7#issuecomment-890380405