### PR TITLE
Fix build on ancient platforms lacking SHA224

### DIFF
--- a/cups/hash.c
+++ b/cups/hash.c
@@ -85,6 +85,7 @@ cupsHashData(const char    *algorithm,	/* I - Algorithm name */
 
     return (CC_SHA1_DIGEST_LENGTH);
   }
+#ifdef CC_SHA224_DIGEST_LENGTH
   else if (!strcmp(algorithm, "sha2-224"))
   {
     CC_SHA256_CTX	ctx;		/* SHA-224 context */
@@ -98,6 +99,7 @@ cupsHashData(const char    *algorithm,	/* I - Algorithm name */
 
     return (CC_SHA224_DIGEST_LENGTH);
   }
+#endif /* CC_SHA224_DIGEST_LENGTH */
   else if (!strcmp(algorithm, "sha2-256"))
   {
     CC_SHA256_CTX	ctx;		/* SHA-256 context */
@@ -137,6 +139,7 @@ cupsHashData(const char    *algorithm,	/* I - Algorithm name */
 
     return (CC_SHA512_DIGEST_LENGTH);
   }
+#ifdef CC_SHA224_DIGEST_LENGTH
   else if (!strcmp(algorithm, "sha2-512_224"))
   {
     CC_SHA512_CTX	ctx;		/* SHA-512 context */
@@ -158,6 +161,7 @@ cupsHashData(const char    *algorithm,	/* I - Algorithm name */
 
     return (CC_SHA224_DIGEST_LENGTH);
   }
+#endif /* CC_SHA224_DIGEST_LENGTH */
   else if (!strcmp(algorithm, "sha2-512_256"))
   {
     CC_SHA512_CTX	ctx;		/* SHA-512 context */


### PR DESCRIPTION
This is one of the less offensive patches needed to compile modern CUPS on Mac OS X 10.4.