### PR TITLE
Fall back to /private/tmp on Mac OS X 10.4

### DIFF
--- a/cups/ppd-util.c
+++ b/cups/ppd-util.c
@@ -226,17 +226,21 @@ cupsGetPPD3(http_t     *http,		/* I  - HTTP connection or @code CUPS_HTTP_DEFAUL
 	* per-process TMPDIR value.
 	*/
 
+#ifdef _CS_DARWIN_USER_TEMP_DIR
         char		tmppath[1024];	/* Temporary directory */
+#endif /* _CS_DARWIN_USER_TEMP_DIR */
 
 	if ((tmpdir = getenv("TMPDIR")) != NULL && access(tmpdir, W_OK))
 	  tmpdir = NULL;
 
 	if (!tmpdir)
 	{
+#ifdef _CS_DARWIN_USER_TEMP_DIR
 	  if (confstr(_CS_DARWIN_USER_TEMP_DIR, tmppath, sizeof(tmppath)))
 	    tmpdir = tmppath;
 	  else
-	    tmpdir = "/private/tmp";		/* This should never happen */
+#endif /* _CS_DARWIN_USER_TEMP_DIR */
+	    tmpdir = "/private/tmp";		/* OS X 10.4 and earlier */
 	}
 #else
        /*

--- a/cups/tempfile.c
+++ b/cups/tempfile.c
@@ -38,9 +38,9 @@ cupsTempFd(char *filename,		/* I - Pointer to buffer */
   int		fd;			/* File descriptor for temp file */
   int		tries;			/* Number of tries */
   const char	*tmpdir;		/* TMPDIR environment var */
-#if defined(__APPLE__) || defined(_WIN32)
+#if (defined(__APPLE__) && defined(_CS_DARWIN_USER_TEMP_DIR)) || defined(_WIN32)
   char		tmppath[1024];		/* Temporary directory */
-#endif /* __APPLE__ || _WIN32 */
+#endif /* (__APPLE__ && _CS_DARWIN_USER_TEMP_DIR) || _WIN32 */
 #ifdef _WIN32
   DWORD		curtime;		/* Current time */
 #else
@@ -72,10 +72,12 @@ cupsTempFd(char *filename,		/* I - Pointer to buffer */
 
   if (!tmpdir)
   {
+#ifdef _CS_DARWIN_USER_TEMP_DIR
     if (confstr(_CS_DARWIN_USER_TEMP_DIR, tmppath, sizeof(tmppath)))
       tmpdir = tmppath;
     else
-      tmpdir = "/private/tmp";		/* This should never happen */
+#endif /* _CS_DARWIN_USER_TEMP_DIR */
+      tmpdir = "/private/tmp";		/* OS X 10.4 and earlier */
   }
 
 #else


### PR DESCRIPTION
`_CS_DARWIN_USER_TEMP_DIR` was introduced in the 10.5 SDK. Sandboxing was introduced in 10.6 so the generic /tmp location should be fine on earlier OS versions.