### PR TITLE
Fix bug that removes language instead of country code

### DIFF
--- a/scheduler/client.c
+++ b/scheduler/client.c
@@ -2934,7 +2934,7 @@ get_file(cupsd_client_t *con,		/* I  - Client connection */
 	*/
 
 	if (language[3])
-	  language[0] = '\0';		/* Strip country code */
+	  language[3] = '\0';		/* Strip country code */
 	else
 	  language[0] = '\0';		/* Strip language */
       }


### PR DESCRIPTION
Because of this bug, the two if branches were identical and the do while loop was only running once.