### PR TITLE
Prevent writing to NULL if buffer is NULL

### DIFF
--- a/cups/snprintf.c
+++ b/cups/snprintf.c
@@ -323,7 +323,8 @@ _cups_vsnprintf(char       *buffer,	/* O - Output buffer */
   * Nul-terminate the string and return the number of characters needed.
   */
 
-  *bufptr = '\0';
+  if (bufptr)
+  	*bufptr = '\0';
 
   return (bytes);
 }


### PR DESCRIPTION
A NULL check was forgotten to be placed despite every other operation to buffer checking for NULL first in the same function, but these checks do not account for evert possible branch path