### PR TITLE
Add _CUPS_NORETURN to missing functions

### DIFF
--- a/cups/tlscheck.c
+++ b/cups/tlscheck.c
@@ -24,7 +24,7 @@ int main(void) { puts("Sorry, no TLS support compiled in."); return (1); }
  * Local functions...
  */
 
-static void	usage(void);
+static void	usage(void) _CUPS_NORETURN;
 
 
 /*

--- a/ppdc/ppdc.cxx
+++ b/ppdc/ppdc.cxx
@@ -21,7 +21,7 @@
 // Local functions...
 //
 
-static void	usage(void);
+static void	usage(void) _CUPS_NORETURN;
 
 
 //

--- a/ppdc/ppdhtml.cxx
+++ b/ppdc/ppdhtml.cxx
@@ -20,7 +20,7 @@
 // Local functions...
 //
 
-static void	usage(void);
+static void	usage(void) _CUPS_NORETURN;
 
 
 //

--- a/ppdc/ppdi.cxx
+++ b/ppdc/ppdi.cxx
@@ -21,7 +21,7 @@
 // Local functions...
 //
 
-static void	usage(void);
+static void	usage(void) _CUPS_NORETURN;
 
 
 //

--- a/ppdc/ppdmerge.cxx
+++ b/ppdc/ppdmerge.cxx
@@ -22,7 +22,7 @@
 //
 
 static const char	*ppd_locale(ppd_file_t *ppd);
-static void		usage(void);
+static void		usage(void) _CUPS_NORETURN;
 
 
 //

--- a/ppdc/ppdpo.cxx
+++ b/ppdc/ppdpo.cxx
@@ -21,7 +21,7 @@
 //
 
 static void	add_ui_strings(ppdcDriver *d, ppdcCatalog *catalog);
-static void	usage(void);
+static void	usage(void) _CUPS_NORETURN;
 
 
 //


### PR DESCRIPTION
Almost every non-returning function has this qualifier, but not all. This should properly define them all as well as shrink the final binary a little bit.