### PR TITLE
fix _cupsGet1284Values

### DIFF
--- a/cups/options.c
+++ b/cups/options.c
@@ -604,16 +604,16 @@ _cupsGet1284Values(
       if (ptr < (value + sizeof(value) - 1))
         *ptr++ = *device_id;
 
-    if (!*device_id && strlen(value) == 0)
-      break;
-
     while (ptr > value && _cups_isspace(ptr[-1]))
       ptr --;
 
     *ptr = '\0';
+    if (ptr > value)
+    	num_values = cupsAddOption(key, value, num_values, values);
+	  
+    if (!*device_id)
+      break;
     device_id ++;
-
-    num_values = cupsAddOption(key, value, num_values, values);
   }
 
   return (num_values);

--- a/cups/options.c
+++ b/cups/options.c
@@ -598,12 +598,13 @@ _cupsGet1284Values(
 
     if (!*device_id)
       break;
-
+    
+    memset(value, 0, sizeof(value));
     for (ptr = value; *device_id && *device_id != ';'; device_id ++)
       if (ptr < (value + sizeof(value) - 1))
         *ptr++ = *device_id;
 
-    if (!*device_id)
+    if (!*device_id && strlen(value) == 0)
       break;
 
     while (ptr > value && _cups_isspace(ptr[-1]))

--- a/cups/options.c
+++ b/cups/options.c
@@ -598,8 +598,7 @@ _cupsGet1284Values(
 
     if (!*device_id)
       break;
-    
-    memset(value, 0, sizeof(value));
+
     for (ptr = value; *device_id && *device_id != ';'; device_id ++)
       if (ptr < (value + sizeof(value) - 1))
         *ptr++ = *device_id;

--- a/cups/options.c
+++ b/cups/options.c
@@ -607,8 +607,7 @@ _cupsGet1284Values(
       ptr --;
 
     *ptr = '\0';
-    if (ptr > value)
-    	num_values = cupsAddOption(key, value, num_values, values);
+    num_values = cupsAddOption(key, value, num_values, values);
 	  
     if (!*device_id)
       break;


### PR DESCRIPTION
when 1284id dosen't end with semicolon，_cupsGet1284Values() cannot get last key and value.
eg.
uos@uos-PC:/usr/lib/cups/backend/snmp 10.10.120.220
network socket://10.10.120.220 "Unknown" "FUJI XEROX ApeosPort-V 4070 v  3. 43.  0 Multifunction System" "MANUFACTURER:FUJI XEROX;MODEL:ApeosPort-V 4070" ""