### PR TITLE
Fix path to libcupsimage.so.2 in EPM packaging

### DIFF
--- a/packaging/cups.list.in
+++ b/packaging/cups.list.in
@@ -508,7 +508,7 @@ f 0444 root sys $INCLUDEDIR/cups/versioning.h cups/versioning.h
 
 %if INSTALLSTATIC
 f 0444 root sys $LIBDIR/libcups.a cups/libcups.a
-f 0444 root sys $LIBDIR/libcupsimage.a filter/libcupsimage.a
+f 0444 root sys $LIBDIR/libcupsimage.a cups/libcupsimage.a
 %endif
 
 d 0755 root sys $DOCDIR/help -

--- a/packaging/cups.list.in
+++ b/packaging/cups.list.in
@@ -348,12 +348,12 @@ l 0755 root sys /usr/bsd/lprm $BINDIR/lprm
 %system darwin
 f 0555 root sys $LIBDIR/libcups.2.dylib cups/libcups.2.dylib nostrip()
 l 0755 root sys $LIBDIR/libcups.dylib libcups.2.dylib
-f 0555 root sys $LIBDIR/libcupsimage.2.dylib filter/libcupsimage.2.dylib nostrip()
+f 0555 root sys $LIBDIR/libcupsimage.2.dylib cups/libcupsimage.2.dylib nostrip()
 l 0755 root sys $LIBDIR/libcupsimage.dylib libcupsimage.2.dylib
 %system !darwin
 f 0555 root sys $LIBDIR/libcups.so.2 cups/libcups.so.2 nostrip()
 l 0755 root sys $LIBDIR/libcups.so libcups.so.2
-f 0555 root sys $LIBDIR/libcupsimage.so.2 filter/libcupsimage.so.2 nostrip()
+f 0555 root sys $LIBDIR/libcupsimage.so.2 cups/libcupsimage.so.2 nostrip()
 l 0755 root sys $LIBDIR/libcupsimage.so libcupsimage.so.2
 %system all
 %subpackage


### PR DESCRIPTION
Back in commit 123979a9db0cec406d710e3b89f351f2e98cb686, `libcupsimage.so.2` was moved from the `filter/` directory to the `cups/` directory.

But the EPM packaging file didn't get updated at the time, so a `make deb` etc. is failing.

This fixes the path in the packaging so that the packages create successfully.