### PR TITLE
CUPS Web UI: Fix uninitialized variable during driver selection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,6 +64,7 @@ CUPS v2.4rc1 (Pending)
   `LPDConfigFile`, `KeepAliveTimeout`, `RIPCache`, and `SMBConfigFile`
   directives in `cupsd.conf` and `cups-files.conf`.
 - Stubbed out deprecated `httpMD5` functions.
+- Fixed uninitialized variable during driver selection in Web UI
 
 
 CUPS v2.3.3op2 (February 1, 2021)

--- a/templates/choose-model.tmpl
+++ b/templates/choose-model.tmpl
@@ -39,7 +39,7 @@
 <TD>
 <SELECT NAME="PPD_NAME" SIZE="10">
 {op=add-printer?:<OPTION VALUE="__no_change__" SELECTED>Current Driver - {current_make_and_model}</OPTION>:}
-{show_ipp_everywhere?<OPTION VALUE="everywhere" SELECTED>{current_make_and_model} - IPP Everywhere &trade;</OPTION>:}
+{show_ipp_everywhere?<OPTION VALUE="everywhere" SELECTED>{current_make_and_model?{current_make_and_model} -:} IPP Everywhere &trade;</OPTION>:}
 {[ppd_name]<OPTION VALUE="{ppd_name}" {op=modify-printer?:{?current_make_and_model={ppd_make_and_model}?SELECTED:}}>{ppd_make_and_model} ({ppd_natural_language})
 }</SELECT>
 </TD>


### PR DESCRIPTION
If device uri doesn't contain model name, `current_make_and_model` is
uninitialized during driver selection in CUPS Web UI.

The issue manifests itself during choosing IPP Everywhere driver, which
has the variable in its name, so it ends up into
`{current_make_and_model} - IPP Everywhere`.

Since we don't have any info about model at the time, I would propose to
just shorten the driver name for such cases. The PR works that way.