### PR TITLE
Prevent accessing ppd_name if ppd_name is NULL

### DIFF
--- a/cgi-bin/admin.c
+++ b/cgi-bin/admin.c
@@ -1218,7 +1218,17 @@ do_am_printer(http_t *http,		/* I - HTTP connection */
 
       cgiCopyTemplateLang("printer-modified.tmpl");
     }
-    else if (strcmp(ppd_name, "everywhere") && !strstr(ppd_name, "driverless"))
+    else if (ppd_name && (strcmp(ppd_name, "everywhere") == 0 || strstr(ppd_name, "driverless")))
+    {
+      /*
+       * Set the printer options...
+       */
+
+       cgiSetVariable("OP", "set-printer-options");
+       do_set_options(http, 0);
+       return;
+    }
+    else
     {
       /*
        * If we don't have an everywhere model, show printer-added
@@ -1227,16 +1237,6 @@ do_am_printer(http_t *http,		/* I - HTTP connection */
 
       cgiStartHTML(title);
       cgiCopyTemplateLang("printer-added.tmpl");
-    }
-    else
-    {
-     /*
-      * Set the printer options...
-      */
-
-      cgiSetVariable("OP", "set-printer-options");
-      do_set_options(http, 0);
-      return;
     }
 
     cgiEndHTML();


### PR DESCRIPTION
There is not guarantee that ppd_name will be set when we reach this branch. We need to just go to the next branch if this is the case, since there is no way the printer will be set as "everywhere" if this is the case.