### PR TITLE
Fix swapped arguments

### DIFF
--- a/ppdc/ppdc-source.cxx
+++ b/ppdc/ppdc-source.cxx
@@ -537,7 +537,7 @@ ppdcSource::get_color_profile(
   for (i = 0; i < 9; i ++)
     m[i] = get_float(fp);
 
-  return (new ppdcProfile(resolution, media_type, g, d, m));
+  return (new ppdcProfile(resolution, media_type, d, g, m));
 }
 
 
@@ -1880,7 +1880,7 @@ ppdcSource::get_simple_profile(ppdcFile *fp)
   }
 
   // Return the new profile...
-  return (new ppdcProfile(resolution, media_type, g, kd, m));
+  return (new ppdcProfile(resolution, media_type, kd, g, m));
 }
 
 

--- a/ppdc/ppdc.cxx
+++ b/ppdc/ppdc.cxx
@@ -229,7 +229,6 @@ main(int  argc,				// I - Number of command-line arguments
 
 	  default :			// Unknown
 	      usage();
-	      break;
 	}
     }
     else
@@ -393,7 +392,7 @@ main(int  argc,				// I - Number of command-line arguments
 	return (1);
       }
 
-      if (templocales != locales)
+      if (templocales && templocales != locales)
         templocales->release();
 
       cupsFileClose(fp);


### PR DESCRIPTION
The arguments being passed to the constructor of ppdcProfile are actually swapped. This patch fixes that issue.