### PR TITLE
scheduler/ipp.c: Change job state to IPP_JOB_HELD when job is restarted with appropriate job-held-until attribute.

### DIFF
--- a/scheduler/ipp.c
+++ b/scheduler/ipp.c
@@ -9374,6 +9374,9 @@ restart_job(cupsd_client_t  *con,	/* I - Client connection */
 		"Restarted by \"%s\" with job-hold-until=%s.",
                 username, attr->values[0].string.text);
     cupsdSetJobHoldUntil(job, attr->values[0].string.text, 0);
+    cupsdSetJobState(job, IPP_JOB_HELD, CUPSD_JOB_DEFAULT,
+		     "Job restarted by user with job-hold-until=%s",
+		     attr->values[0].string.text);
 
     cupsdAddEvent(CUPSD_EVENT_JOB_CONFIG_CHANGED | CUPSD_EVENT_JOB_STATE,
                   NULL, job, "Job restarted by user with job-hold-until=%s",

--- a/scheduler/ipp.c
+++ b/scheduler/ipp.c
@@ -9373,14 +9373,10 @@ restart_job(cupsd_client_t  *con,	/* I - Client connection */
     cupsdLogJob(job, CUPSD_LOG_DEBUG,
 		"Restarted by \"%s\" with job-hold-until=%s.",
                 username, attr->values[0].string.text);
-    cupsdSetJobHoldUntil(job, attr->values[0].string.text, 0);
+    cupsdSetJobHoldUntil(job, attr->values[0].string.text, 1);
     cupsdSetJobState(job, IPP_JOB_HELD, CUPSD_JOB_DEFAULT,
 		     "Job restarted by user with job-hold-until=%s",
 		     attr->values[0].string.text);
-
-    cupsdAddEvent(CUPSD_EVENT_JOB_CONFIG_CHANGED | CUPSD_EVENT_JOB_STATE,
-                  NULL, job, "Job restarted by user with job-hold-until=%s",
-		  attr->values[0].string.text);
   }
   else
   {


### PR DESCRIPTION
If a job is restarted with a `job-held-until` attribute that isn't `no-hold`, the job should be restarted and held, but it isn't.  To demonstrate this, I wrote a small program that will restart a print job:

```
$ cat restart-and-hold-job.c
#include <stdio.h>
#include <stdlib.h>
#include <cups/cups.h>

int main(int argc, char *argv[]) {

  ipp_t*         request = NULL;
  char           uri[HTTP_MAX_URI] = "";
  int            job_id = 0;

  job_id = atoi(argv[1]);

  /*
   * Restart but hold the job
   */

  // Create request
  request = ippNewRequest(IPP_RESTART_JOB);
  sprintf(uri, "ipp://localhost/jobs/%d", job_id);
  ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_URI, "job-uri", NULL, uri);
  ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_NAME, "requesting-user-name", NULL, cupsUser());

  // Hold job
  ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_KEYWORD, "job-hold-until", NULL, "indefinite");

  // Do request
  ippDelete(cupsDoRequest(CUPS_HTTP_DEFAULT, request, "/jobs"));

  // Check result
  if ( cupsLastError() > IPP_OK_CONFLICT ) {
    fprintf(stderr, "Restart-Job: %s\n", cupsLastErrorString());
    exit(1);
  }
  
  exit(0);
}
```
And an `ipptool` test that will get some job attributes:
```
$ cat get-job-attributes.test
{
  # The name of the test...
  NAME "Get job attributes"

  # The operation to use
  OPERATION Get-Job-Attributes

  # Attributes, starting in the operation group...
  GROUP operation-attributes-tag
  ATTR charset attributes-charset utf-8
  ATTR language attributes-natural-language en
  ATTR name requesting-user-name $user
  ATTR integer job-id $job_id
  ATTR uri printer-uri $uri
  ATTR keyword requested-attributes
       job-hold-until,job-state

  # What statuses are OK?
  STATUS successful-ok

  # What attributes to display

   DISPLAY job-hold-until
   DISPLAY job-state
}
```
If I submit a job that is aborted due to some backend failure (and the `ErrorPolicy` is `abort-job`), like this:
```
$ lp -d pstest /etc/services
request id is pstest-30 (1 file(s))
```
The job state is aborted, as expected:
```
$ ipptool -t -d job_id=30 ipp://localhost/printers/pstest get-job-attributes.test
"get-job-attributes.test":
    Get job attributes                                                   [PASS]
        job-hold-until (keyword) = no-hold
        job-state (enum) = aborted
```
When I run the program to restart and hold the job:
```
./restart-and-hold-job 30
```
the job isn't held; it's still aborted:
```
$ ipptool -t -d job_id=30 ipp://localhost/printers/pstest get-job-attributes.test
"get-job-attributes.test":
    Get job attributes                                                   [PASS]
        job-hold-until (keyword) = no-hold
        job-state (enum) = aborted
```
After applying the patch in this PR, the job is now held, which is what I expected:
```
$ ./restart-and-hold-job 30
$ ipptool -t -d job_id=30 ipp://localhost/printers/pstest get-job-attributes.test
"get-job-attributes.test":
    Get job attributes                                                   [PASS]
        job-hold-until (keyword) = no-hold
        job-state (enum) = pending-held
```
I suspect that `job-hold-until` should also be `indefinite` instead of `no-hold`.  I think that's because:
```
    cupsdSetJobHoldUntil(job, attr->values[0].string.text, 0);
```
should really be:
```
    cupsdSetJobHoldUntil(job, attr->values[0].string.text, 1);
```
but I didn't include that in the PR. I'm happy to add that if you want me to.