### PR TITLE
man-ipptool.html, man-ipptoolfile.html: Fix links

### DIFF
--- a/doc/help/man-ipptool.html
+++ b/doc/help/man-ipptool.html
@@ -221,9 +221,9 @@ Get a list of completed jobs for "myprinter":
 </pre>
 <h2 class="title"><a name="SEE_ALSO">See Also</a></h2>
 <b>ipptoolfile</b>(5),
-IANA IPP Registry (<a href="https://www.iana.org/assignments/ipp\-registrations)">https://www.iana.org/assignments/ipp\-registrations)</a>,
+IANA IPP Registry (<a href="https://www.iana.org/assignments/ipp-registrations">https://www.iana.org/assignments/ipp-registrations</a>),
 PWG Internet Printing Protocol Workgroup (<a href="https://www.pwg.org/ipp">https://www.pwg.org/ipp</a>)
-RFC 8011 (<a href="https://datatracker.ietf.org/doc/html/rfc8011)">https://datatracker.ietf.org/doc/html/rfc8011)</a>,
+RFC 8011 (<a href="https://datatracker.ietf.org/doc/html/rfc8011">https://datatracker.ietf.org/doc/html/rfc8011</a>),
 <h2 class="title"><a name="COPYRIGHT">Copyright</a></h2>
 Copyright &copy; 2021 by OpenPrinting.
 

--- a/doc/help/man-ipptoolfile.html
+++ b/doc/help/man-ipptoolfile.html
@@ -549,8 +549,8 @@ if any.
 </dl>
 <h2 class="title"><a name="SEE_ALSO">See Also</a></h2>
 <b>ipptool</b>(1),
-IANA IPP Registry (<a href="https://www.iana.org/assignments/ipp-registrations)">https://www.iana.org/assignments/ipp-registrations)</a>,
-PWG Internet Printing Protocol Workgroup (<a href="https://www.pwg.org/ipp)">https://www.pwg.org/ipp)</a>,
+IANA IPP Registry (<a href="https://www.iana.org/assignments/ipp-registrations">https://www.iana.org/assignments/ipp-registrations</a>),
+PWG Internet Printing Protocol Workgroup (<a href="https://www.pwg.org/ipp">https://www.pwg.org/ipp</a>),
 RFC 8011 (<a href="https://datatracker.ietf.org/doc/html/rfc8011">https://datatracker.ietf.org/doc/html/rfc8011</a>)
 <h2 class="title"><a name="COPYRIGHT">Copyright</a></h2>
 Copyright &copy; 2021 by OpenPrinting.


### PR DESCRIPTION
The links contained closing brackets and a backslash, which broke them.
The patch fixes it.