### PR TITLE
cgi-bin/ipp-var.c: Use "guest" user for Move Job when no REMOTE_USER given

### DIFF
--- a/cgi-bin/ipp-var.c
+++ b/cgi-bin/ipp-var.c
@@ -271,9 +271,7 @@ cgiMoveJobs(http_t     *http,		/* I - Connection to server */
   */
 
   if ((user = getenv("REMOTE_USER")) == NULL)
-  {
     user = "guest";
-  }
 
  /*
   * See if the user has already selected a new destination...


### PR DESCRIPTION
`cgi-bin/do_job_op()` sets `user` to "`guest`" if `REMOTE_USER` isn't set.  However, `cgiMoveJob()` (in `cgi-bin/ipp-var.c`) returns 401/Unauthorized if `REMOTE_USER` isn't set.  This inconsistent behavior leads to the following issue:

If an administrator wants to allow unfettered access to allow unauthenticated users to perform administration functions, they can do this by removing `Require user` entries from `cupsd.conf`.  (We can debate the wisdom of this sort of configuration, but I have a customer who wants to do this.)  This works for everything but the "Move Job" operation in the "Jobs" page.  Because `cgiMoveJob()` returns 401, it is impossible to move the job using the Web UI.  This patch fixes that.

With the patch applied and `Require user` entries removed from `cupsd.conf`, unauthenticated users can move print jobs using the Web UI.  

With the patch applied and the default `cupsd.conf`, authentication occurs later in the process of moving a print job, through the following sequence of events:
1. Go to the "Jobs" page (`http://<lhost>:631/jobs/`)
2. Press "Move Job" -- the page with the destination list is shown
3. Select a destination and press "Move Job" -- the "Upgrade Required" page is shown and the browser is redirected back to the "Jobs" page (`https://<host>:631/jobs/`.
4. Press "Move Job" again -- page with destination list is shown
5. Select a destination and press "Move Job" -- browser prompts for authentication
6. Enter credentials -- job is moved

Although this path seems a bit circuitous, it's not dissimilar to the process needed to modify a printer, where navigating to a printer page (`http://<host>/printers/<printer>`) and selecting "Modify Printer" from the "Administration" drop-down results in an "Upgrade Required" redirect to the "Administration" page (`https://<host>:631/admin/`)
