### PR TITLE
Expand whitelist for use of "offline-report"

### DIFF
--- a/scheduler/job.c
+++ b/scheduler/job.c
@@ -3115,8 +3115,7 @@ finalize_job(cupsd_job_t *job,		/* I - Job */
   * rarely have current information for network devices...
   */
 
-  if (strncmp(job->printer->device_uri, "usb:", 4) &&
-      strncmp(job->printer->device_uri, "ippusb:", 7))
+  if (!strstr(job->printer->device_uri, "usb:"))
     cupsdSetPrinterReasons(job->printer, "-offline-report");
 
  /*


### PR DESCRIPTION
The old behavior unconditionally cleared the "offline-report"
printer-reason unless the backend was 'usb:' or 'ippusb:' with the
assumption that these were the only two direct-connect USB backends
in use, with everything else being remote.

This is definitely not the case; putting aside proprietary 3rd-party
backends, there is Gutenprint's USB backend, which identifies itself
with 'gutenprint52+usb:' or 'gutenprint53+usb:' depending on the version.

So, generalize the rule to search for the string 'usb:' in the uri
instead, which will allow all three/four usb backends to use the
'offline-report' printer-reason.

(FWIW, I'm not happy with this approach; It seems to me that the
 CorrectSolution(tm) is to track the device-class returned by the backend
 at discovery time, and ignore 'offline-report' for anything other than
 'direct', but that's going to be a lot more involved..)