### PR TITLE
Use getpwnam_r instead of getpwnam in multi-threaded code

### DIFF
--- a/cups/auth.c
+++ b/cups/auth.c
@@ -1087,12 +1087,14 @@ cups_local_auth(http_t *http)		/* I - HTTP connection to server */
     * Verify that the current cupsUser() matches the current UID...
     */
 
-    struct passwd	*pwd;		/* Password information */
+    struct passwd	pwd;		/* Password information */
+    struct passwd	*result;	/* Auxiliary pointer */
     const char		*username;	/* Current username */
 
     username = cupsUser();
 
-    if ((pwd = getpwnam(username)) != NULL && pwd->pw_uid == getuid())
+    getpwnam_r(username, &pwd, cg->pw_buf, PW_BUF_SIZE, &result);
+    if (result && pwd.pw_uid == getuid())
     {
       httpSetAuthString(http, "PeerCred", username);
 

--- a/cups/cups-private.h
+++ b/cups/cups-private.h
@@ -85,6 +85,11 @@ typedef struct _cups_globals_s		/**** CUPS global state data ****/
 			*cups_statedir,	/* CUPS_STATEDIR environment var */
 			*home,		/* HOME environment var */
 			*localedir;	/* LOCALDIR environment var */
+#ifndef _WIN32
+#define PW_BUF_SIZE 16384		/* As per glibc manual page */
+  char			pw_buf[PW_BUF_SIZE];
+					/* Big buffer for struct passwd buffers */
+#endif
 
   /* adminutil.c */
   time_t		cupsd_update;	/* Last time we got or set cupsd.conf */

--- a/cups/globals.c
+++ b/cups/globals.c
@@ -325,10 +325,12 @@ cups_globals_alloc(void)
 
   if (!cg->home)
   {
-    struct passwd	*pw;		/* User info */
+    struct passwd	pw;		/* User info */
+    struct passwd	*result;	/* Auxiliary pointer */
 
-    if ((pw = getpwuid(getuid())) != NULL)
-      cg->home = _cupsStrAlloc(pw->pw_dir);
+    getpwuid_r(getuid(), &pw, cg->pw_buf, PW_BUF_SIZE, &result);
+    if (result)
+      cg->home = _cupsStrAlloc(pw.pw_dir);
   }
 #endif /* _WIN32 */
 


### PR DESCRIPTION
This pull request is an attempt to provide an upstream fix to multiple crashes seen in Alpine with cups. The crashes have in common that they happen on calls to `getpwnam`. Reading the documentation, I found that `getpwnam` and `getpwuid` are thread-unsafe functions. If I understand it correctly, the code under the `cups` folder is (potentially?) multi-threaded and could explain the crashes in `getpwnam`. Substituting all calls by `getpwnam_r` and `getpwuid_r` fix the crashes, at least in my limited testing.

Two things to note:
 * `getpwnam` and `getpwuid` are marked thread-unsafe by musl/POSIX, but also by glibc. Therefore, although I have not seen reports of crashes happening with glibc, they could potentially happen in the future if this fix is not applied in multi-threaded code.
 * There are also many calls to `getpwnam` and `getpwuid` under different files in the `scheduler` folder. However, if I understand it correctly by the [documentation](https://openprinting.github.io/cups/doc/spec-design.html), the scheduler is single-threaded and using `getpwnam` and `getpwuid` should be safe. Otherwise, should I also change the calls there?
 

