### PR TITLE
Test suite: Add regression test for cupsSNMP/IPPSupplies

### DIFF
--- a/test/5.1-lpadmin.sh
+++ b/test/5.1-lpadmin.sh
@@ -61,3 +61,67 @@ else
 	echo "    PASSED"
 fi
 echo ""
+
+echo "Add a printer for cupSNMP/IPPSupplies test"
+echo ""
+echo "    lpadmin -p Test4 -E -v file:/dev/null -m drv:///sample.drv/zebra.ppd"
+$runcups $VALGRIND ../systemv/lpadmin -p Test4 -E -v file:/dev/null -m drv:///sample.drv/zebra.ppd 2>&1
+if test $? != 0; then
+	echo "    FAILED"
+	exit 1
+else
+	echo "    PASSED"
+fi
+echo ""
+
+echo "Turn on cupsSNMP/IPPSupplies option"
+echo ""
+echo "    lpadmin -p Test4 -o cupsSNMPSupplies=true -o cupsIPPSupplies=true"
+$runcups $VALGRIND ../systemv/lpadmin -p Test4 -o cupsSNMPSupplies=true -o cupsIPPSupplies=true 2>&1
+grep '*cupsSNMPSupplies: True' $BASE/ppd/Test4.ppd
+if test $? != 0; then
+	echo "    FAILED"
+	exit 1
+else
+	echo "    PASSED"
+fi
+grep '*cupsIPPSupplies: True' $BASE/ppd/Test4.ppd
+if test $? != 0; then
+	echo "    FAILED"
+	exit 1
+else
+	echo "    PASSED"
+fi
+echo ""
+
+echo "Turn on cupsSNMP/IPPSupplies option"
+echo ""
+echo "    lpadmin -p Test4 -o cupsSNMPSupplies=false -o cupsIPPSupplies=false"
+$runcups $VALGRIND ../systemv/lpadmin -p Test4 -o cupsSNMPSupplies=false -o cupsIPPSupplies=false 2>&1
+grep '*cupsSNMPSupplies: False' $BASE/ppd/Test4.ppd
+if test $? != 0; then
+	echo "    FAILED"
+	exit 1
+else
+	echo "    PASSED"
+fi
+grep '*cupsIPPSupplies: False' $BASE/ppd/Test4.ppd
+if test $? != 0; then
+	echo "    FAILED"
+	exit 1
+else
+	echo "    PASSED"
+fi
+echo ""
+
+echo "Delete the printer with cupsSNMP/IPPSupplies"
+echo ""
+echo "    lpadmin -x Test4"
+$runcups $VALGRIND ../systemv/lpadmin -x Test4 2>&1
+if test $? != 0; then
+	echo "    FAILED"
+	exit 1
+else
+	echo "    PASSED"
+fi
+echo ""

--- a/test/run-stp-tests.sh
+++ b/test/run-stp-tests.sh
@@ -1034,9 +1034,15 @@ else
 	echo "    <p>PASS: Printer 'Test3' correctly produced $count page(s).</p>" >>$strfile
 fi
 
+# Number of requests from 5.1-lpadmin.sh: cupsSNMP/IPPSupplies tests - total 5 in 'expected':
+# - 2 requests for creating a queue - CUPS-Get-PPD and CUPS-Add-Modify-Printer
+# - 1 request for setting cupsSNMP/IPPSupplies to True - CUPS-Add-Modify-Printer
+# - 1 request for setting cupsSNMP/IPPSupplies to False - CUPS-Add-Modify-Printer
+# - 1 request for deleting the queue - CUPS-Delete-Printer
+
 # Requests logged
 count=`wc -l $BASE/log/access_log | awk '{print $1}'`
-expected=`expr 35 + 18 + 30 + $pjobs \* 8 + $pprinters \* $pjobs \* 4 + 2 + 2`
+expected=`expr 35 + 18 + 30 + $pjobs \* 8 + $pprinters \* $pjobs \* 4 + 2 + 2 + 5`
 if test $count != $expected; then
 	echo "FAIL: $count requests logged, expected $expected."
 	echo "    <p>FAIL: $count requests logged, expected $expected.</p>" >>$strfile


### PR DESCRIPTION
lpadmin can set cupsSNMPSupplies and cupsIPPSupplies keywords in the PPD
file which was broken in the past (Apple Issue #5610).

Until we get rid of PPD files completely or if we use the options in the
no-PPD future, it would be great if we had a regression test in the test
suite.