### PR TITLE
Avoid a crash when an Avahi or mDNS printer has neither device-uri nor printer-uri-supported set.

### DIFF
--- a/cups/dest.c
+++ b/cups/dest.c
@@ -1142,7 +1142,7 @@ _cupsGetDestResource(
   DEBUG_printf(("1_cupsGetDestResource: device-uri=\"%s\", printer-uri-supported=\"%s\".", device_uri, printer_uri));
 
 #ifdef HAVE_DNSSD
-  if (((flags & CUPS_DEST_FLAGS_DEVICE) || !printer_uri) && strstr(device_uri, "._tcp"))
+  if (((flags & CUPS_DEST_FLAGS_DEVICE) || !printer_uri) && device_uri && strstr(device_uri, "._tcp"))
   {
     if ((device_uri = cups_dnssd_resolve(dest, device_uri, 5000, NULL, NULL, NULL)) != NULL)
     {


### PR DESCRIPTION
This was found in https://bugzilla.mozilla.org/1691347