### PR TITLE
cups/http-support.c: Apply DigestOptions to RFC 2069 support

### DIFF
--- a/cups/http-support.c
+++ b/cups/http-support.c
@@ -1430,6 +1430,12 @@ _httpSetDigestAuthString(
     * Use old RFC 2069 Digest method...
     */
 
+    if (cg->digestoptions == _CUPS_DIGESTOPTIONS_DENYMD5)
+    {
+      DEBUG_puts("3_httpSetDigestAuthString: MD5 Digest is disabled.");
+      return (0);
+    }
+
     /* H(A1) = H(username:realm:password) */
     snprintf(temp, sizeof(temp), "%s:%s:%s", username, http->realm, password);
     hashsize = (size_t)cupsHashData("md5", (unsigned char *)temp, strlen(temp), hash, sizeof(hash));


### PR DESCRIPTION
Earlier we applied DigestOptions only for devices which implement RFC
2617 or RFC 7616, this commit applies it even for RFC 2069 support.

This issue came up during CentOS Stream/RHEL 9 development, where MD5
digest is marked as insecure for authentication/authorization, so it
should be turned off in default configurations to prevent security
issues.

This PR is a preview how the fix should look if accepted - more I'm
looking for discussion whether we should tackle MD5 usage for devices
supporting only RFC 2069.