### PR TITLE
Do not open logfiles with read access

### DIFF
--- a/cups/file.c
+++ b/cups/file.c
@@ -1056,6 +1056,7 @@ cupsFileNumber(cups_file_t *fp)		/* I - CUPS file */
  *
  * The "mode" parameter can be "r" to read, "w" to write, overwriting any
  * existing file, "a" to append to an existing file or create a new file,
+ * "a+" to append to and read from an existing file or create a new file,
  * or "s" to open a socket connection.
  *
  * When opening for writing ("w"), an optional number from 1 to 9 can be
@@ -1101,7 +1102,7 @@ cupsFileOpen(const char *filename,	/* I - Name of file */
   {
     case 'a' : /* Append file */
         fd = cups_open(filename,
-		       O_RDWR | O_CREAT | O_APPEND | O_LARGEFILE | O_BINARY);
+		       (mode[1] == '+' ? O_RDWR : O_WRONLY) | O_CREAT | O_APPEND | O_LARGEFILE | O_BINARY);
         break;
 
     case 'r' : /* Read file */


### PR DESCRIPTION
Currently logfiles are opened with read-access, due to cupsFileOpen()
converting "a" into `O_RDWR | O_CREAT | O_APPEND`. This should not be
necessary, as logfiles should be an append-only data structure.
Update cupsFileOpen() to open files with `O_WRONLY | O_CREAT | O_APPEND`
on mode "a" and add a fallback mode "a+" (see man:fopen(3)).
Currently only the logfiles and a test file are opened with "a".