### PR TITLE
cups/getifaddrs-internal.h: Include versioning.h if ! HAVE_GETIFADDRS

### DIFF
--- a/cups/getifaddrs-internal.h
+++ b/cups/getifaddrs-internal.h
@@ -16,6 +16,7 @@
  */
 
 #  include "config.h"
+#  include "versioning.h"
 #  ifdef _WIN32
 #    define _WINSOCK_DEPRECATED_NO_WARNINGS 1
 #    include <io.h>


### PR DESCRIPTION
Without this compile fails on systems withou getifaddrs as _CUPS_PRIVATE
is undefined. Found on Solaris 10.