### PR TITLE
Add --with-idle-exit-timeout configure option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ CHANGES - OpenPrinting CUPS 2.4rc1 - 2021-11-12
 Changes in CUPS v2.4.0 (TBA)
 ---------------------------
 
+- Added configure option --with-idle-exit-timeout (Issue #294)
 - DigestOptions now are applied for MD5 Digest authentication defined
   by RFC 2069 as well (Issue #287)
 - Fixed compilation on Solaris (Issue #293)

--- a/conf/cupsd.conf.in
+++ b/conf/cupsd.conf.in
@@ -28,6 +28,9 @@ DefaultAuthType Basic
 # Web interface setting...
 WebInterface @CUPS_WEBIF@
 
+# Timeout after cupsd exits if idle (applied only if cupsd runs on-demand - with -l)
+IdleExitTimeout @EXIT_TIMEOUT@
+
 # Restrict access to the server...
 <Location />
   Order allow,deny

--- a/config-scripts/cups-defaults.m4
+++ b/config-scripts/cups-defaults.m4
@@ -428,3 +428,16 @@ AS_IF([test $CUPS_WEBIF = Yes || test $CUPS_BROWSING = Yes], [
   SYSTEMD_WANTED_BY="$SYSTEMD_WANTED_BY multi-user.target"], [
   ])
 AC_SUBST([SYSTEMD_WANTED_BY])
+
+dnl Set default value of IdleExitTimeout
+AC_ARG_WITH([idle_exit_timeout], AS_HELP_STRING([--with-idle-exit-timeout], [set the default value for IdleExitTimeout, default=60]), [
+    AS_IF([test "x$withval" = "xno"], [
+	EXIT_TIMEOUT=0
+    ], [
+	EXIT_TIMEOUT=$withval
+    ])
+], [
+    EXIT_TIMEOUT=60
+])
+
+AC_SUBST([EXIT_TIMEOUT])

--- a/configure
+++ b/configure
@@ -652,6 +652,7 @@ ac_subst_vars='LTLIBOBJS
 LIBOBJS
 UNINSTALL_LANGUAGES
 INSTALL_LANGUAGES
+EXIT_TIMEOUT
 SYSTEMD_WANTED_BY
 CUPS_WEBIF
 DEFAULT_IPP_PORT
@@ -939,6 +940,7 @@ with_snmp_address
 with_snmp_community
 with_ipp_port
 enable_webif
+with_idle_exit_timeout
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1665,6 +1667,9 @@ Optional Packages:
   --with-snmp-address     set SNMP query address, default=auto
   --with-snmp-community   set SNMP community, default=public
   --with-ipp-port         set port number for IPP, default=631
+  --with-idle-exit-timeout
+                          set the default value for IdleExitTimeout,
+                          default=60
 
 Some influential environment variables:
   CC          C compiler command
@@ -12101,6 +12106,31 @@ then :
 
   SYSTEMD_WANTED_BY="$SYSTEMD_WANTED_BY multi-user.target"
 fi
+
+
+
+# Check whether --with-idle_exit_timeout was given.
+if test ${with_idle_exit_timeout+y}
+then :
+  withval=$with_idle_exit_timeout;
+    if test "x$withval" = "xno"
+then :
+
+	EXIT_TIMEOUT=0
+
+else $as_nop
+
+	EXIT_TIMEOUT=$withval
+
+fi
+
+else $as_nop
+
+    EXIT_TIMEOUT=60
+
+fi
+
+
 
 
 


### PR DESCRIPTION
**Updated message:**

The option enables setting IdleExitTimeout to a desired value - f.e.
setting to zero will disable automatic shutdown, which is useful on servers,
where cupsd is expected to run even if there is no web interface, no jobs
and CUPS doesn't share queues.


_Original message:_

On servers, CUPS is expected to be running permanently, even if there
are no jobs and no web interface, and CUPS doesn't share queues.

The option will set IdleExitTimeout to 0 if used - if not used or used
with 'disable', it sets the directive to default 60s.