### PR TITLE
Add --with-systemd-timeoutstartsec configure option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Changes in CUPS v2.4.0 (TBA)
 ---------------------------
 
 - Added configure option --with-idle-exit-timeout (Issue #294)
+- Added --with-systemd-timeoutstartsec configure option (Issue #298)
 - DigestOptions now are applied for MD5 Digest authentication defined
   by RFC 2069 as well (Issue #287)
 - Fixed compilation on Solaris (Issue #293)

--- a/config-scripts/cups-defaults.m4
+++ b/config-scripts/cups-defaults.m4
@@ -441,3 +441,18 @@ AC_ARG_WITH([idle_exit_timeout], AS_HELP_STRING([--with-idle-exit-timeout], [set
 ])
 
 AC_SUBST([EXIT_TIMEOUT])
+
+dnl set TimeoutStartSec for cups.service
+dnl - if used as --without-*, it sets TimeoutStartSec to infinity
+AC_ARG_WITH([systemd-timeoutstartsec],
+    AS_HELP_STRING([--with-systemd-timeoutstartsec],
+	[set TimeoutStartSec value in cups.service, default=default value in systemd]), [
+    AS_IF([ test "x$withval" = "xno" ], [
+	TIMEOUTSTARTSEC="TimeoutStartSec=infinity"
+    ], [
+	TIMEOUTSTARTSEC="TimeoutStartSec=$withval"
+    ])
+], [
+    TIMEOUTSTARTSEC=""
+])
+AC_SUBST([TIMEOUTSTARTSEC])

--- a/configure
+++ b/configure
@@ -652,6 +652,7 @@ ac_subst_vars='LTLIBOBJS
 LIBOBJS
 UNINSTALL_LANGUAGES
 INSTALL_LANGUAGES
+TIMEOUTSTARTSEC
 EXIT_TIMEOUT
 SYSTEMD_WANTED_BY
 CUPS_WEBIF
@@ -941,6 +942,7 @@ with_snmp_community
 with_ipp_port
 enable_webif
 with_idle_exit_timeout
+with_systemd_timeoutstartsec
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1670,6 +1672,9 @@ Optional Packages:
   --with-idle-exit-timeout
                           set the default value for IdleExitTimeout,
                           default=60
+  --with-systemd-timeoutstartsec
+                          set TimeoutStartSec value in cups.service,
+                          default=default value in systemd
 
 Some influential environment variables:
   CC          C compiler command
@@ -12130,6 +12135,30 @@ else $as_nop
 
 fi
 
+
+
+
+
+# Check whether --with-systemd-timeoutstartsec was given.
+if test ${with_systemd_timeoutstartsec+y}
+then :
+  withval=$with_systemd_timeoutstartsec;
+    if  test "x$withval" = "xno"
+then :
+
+	TIMEOUTSTARTSEC="TimeoutStartSec=infinity"
+
+else $as_nop
+
+	TIMEOUTSTARTSEC="TimeoutStartSec=$withval"
+
+fi
+
+else $as_nop
+
+    TIMEOUTSTARTSEC=""
+
+fi
 
 
 

--- a/scheduler/cups.service.in
+++ b/scheduler/cups.service.in
@@ -8,6 +8,7 @@ Requires=cups.socket
 ExecStart=@sbindir@/cupsd -l
 Type=notify
 Restart=on-failure
+@TIMEOUTSTARTSEC@
 
 [Install]
 Also=cups.socket cups.path


### PR DESCRIPTION
cupsd can be killed by systemd if the daemon takes too much time when
starting - f.e. when loading many queues and/or not enough memory for
loading the daemon quicker.

TimeoutStartSec directive for systemd services defines the time after
which the daemon is killed - if set to 'infinity', a service is not
killed.