### PR TITLE
Fix configure syntax error

### DIFF
--- a/config-scripts/cups-network.m4
+++ b/config-scripts/cups-network.m4
@@ -12,7 +12,7 @@ dnl
 AC_CHECK_HEADER([resolv.h], [
     AC_DEFINE([HAVE_RESOLV_H], [1], [Have the <resolv.h> header?])
 ], [
-]. [
+], [
     #include <sys/socket.h>
     #include <netinet/in.h>
     #include <arpa/inet.h>


### PR DESCRIPTION
Tested locally; `configure` will need to be regenerated. Fixes https://github.com/OpenPrinting/cups/issues/301