### PR TITLE
cups/ppd-cache.c: Prefer raster formats to PDF

### DIFF
--- a/cups/ppd-cache.c
+++ b/cups/ppd-cache.c
@@ -3368,14 +3368,14 @@ _ppdCreateFromIPP2(
       if (ippContainsString(attr, "application/vnd.cups-pdf"))
         cupsFilePuts(fp, "*cupsFilter2: \"application/pdf application/pdf 0 -\"\n");
       else
-        cupsFilePuts(fp, "*cupsFilter2: \"application/vnd.cups-pdf application/pdf 10 -\"\n");
+        cupsFilePuts(fp, "*cupsFilter2: \"application/vnd.cups-pdf application/pdf 200 -\"\n");
     }
     else
       cupsFilePuts(fp, "*cupsManualCopies: True\n");
     if (is_apple)
-      cupsFilePuts(fp, "*cupsFilter2: \"image/urf image/urf 100 -\"\n");
+      cupsFilePuts(fp, "*cupsFilter2: \"image/urf image/urf 0 -\"\n");
     if (is_pwg)
-      cupsFilePuts(fp, "*cupsFilter2: \"image/pwg-raster image/pwg-raster 100 -\"\n");
+      cupsFilePuts(fp, "*cupsFilter2: \"image/pwg-raster image/pwg-raster 10 -\"\n");
   }
 
   if (!is_apple && !is_pdf && !is_pwg)


### PR DESCRIPTION
Some printers print out garbled text if the job comes from evince and
the original PDF contains a specific font.

It is not certain whether cairo (PDF generator evince uses) has a bug in
PDF rendering or cairo renders a correct PDF, but in PDF version which
the printer doesn't support - but the switch to raster formats -
image/urf or image/pwg-raster works around the issue.

Related issues in Fedora:
https://bugzilla.redhat.com/show_bug.cgi?id=1904405
https://bugzilla.redhat.com/show_bug.cgi?id=1991678

The same workaround has been applied in cups-filters' PPD generator
(https://github.com/OpenPrinting/cups-filters/issues/331), proposing the
possible final solution - using PCLm format.