### PR TITLE
Fix memleaks in http.c and encode.c

### DIFF
--- a/cups/encode.c
+++ b/cups/encode.c
@@ -655,6 +655,7 @@ _cupsEncodeOption(
 	  ippSetCollection(ipp, &attr, i, collection);
 	  cupsEncodeOptions2(collection, num_cols, cols, IPP_TAG_JOB);
 	  cupsFreeOptions(num_cols, cols);
+	  ippDelete(collection);
 	  break;
 
       default :

--- a/cups/http.c
+++ b/cups/http.c
@@ -4627,6 +4627,7 @@ http_tls_upgrade(http_t *http)		/* I - HTTP connection */
   * Restore the HTTP request data...
   */
 
+  httpClearFields(http);
   memcpy(http->_fields, myhttp._fields, sizeof(http->_fields));
   memcpy(http->fields, myhttp.fields, sizeof(http->fields));
 


### PR DESCRIPTION
Hi, 
there are two memory leaks found by valgrind in cups:

=25357== 41 bytes in 2 blocks are definitely lost in loss record 678 of 1,250
==25357==    at 0x484186F: malloc (vg_replace_malloc.c:381)
==25357==    by 0x4DB7FBE: strdup (strdup.c:42)
==25357==    by 0x4CB01EF: http_add_field (http.c:3676)
==25357==    by 0x4CB0E11: _httpUpdate (http.c:2891)
==25357==    by 0x4CB0EBA: UnknownInlinedFun (http.c:2948)
==25357==    by 0x4CB0EBA: httpUpdate (http.c:2918)
==25357==    by 0x4CB25A8: http_tls_upgrade (http.c:4620)
==25357==    by 0x4CC7A07: cupsGetResponse (request.c:438)
==25357==    by 0x4CCBD4A: cupsDoIORequest (request.c:232)
==25357==    by 0x125875: browse_poll_cancel_subscription (cups-browsed.c:11173)
==25357==    by 0x11339F: main (cups-browsed.c:12784)

==25357== 480 (72 direct, 408 indirect) bytes in 1 blocks are definitely lost in loss record 1,204 of 1,250
==25357==    at 0x4846464: calloc (vg_replace_malloc.c:1328)
==25357==    by 0x4CB7581: ippNew (ipp.c:2622)
==25357==    by 0x4CA5533: _cupsEncodeOption (encode.c:644)
==25357==    by 0x4CA67D7: UnknownInlinedFun (encode.c:851)
==25357==    by 0x4CA67D7: cupsEncodeOptions2 (encode.c:725)
==25357==    by 0x122C0E: update_cups_queues (cups-browsed.c:8813)
==25357==    by 0x4B0E980: g_timeout_dispatch (gmain.c:4933)
==25357==    by 0x4B0E12F: UnknownInlinedFun (gmain.c:3381)
==25357==    by 0x4B0E12F: g_main_context_dispatch (gmain.c:4099)
==25357==    by 0x4B63207: g_main_context_iterate.constprop.0 (gmain.c:4175)
==25357==    by 0x4B0D852: g_main_loop_run (gmain.c:4373)
==25357==    by 0x11324C: main (cups-browsed.c:12747)
