### PR TITLE
Fix uninit value based jump in ppd.c

### DIFF
--- a/cups/ppd.c
+++ b/cups/ppd.c
@@ -3430,7 +3430,7 @@ ppd_update_filters(ppd_file_t     *ppd,	/* I - PPD file */
 		srctype[256],
 		dstsuper[16],		/* Destination MIME media type */
 		dsttype[256],
-		program[1024],		/* Command to run */
+		program[1024] = {0},		/* Command to run */
 		*ptr,			/* Pointer into command to run */
 		buffer[1024],		/* Re-written cupsFilter value */
 		**filter;		/* Current filter */


### PR DESCRIPTION
Hi,
valgrind on ppc64le arch complains about jump based on uninitialized memory in ppd.c