### PR TITLE
Misalignment of programming document in cups web interface Fix 

### DIFF
--- a/doc/help/api-admin.html
+++ b/doc/help/api-admin.html
@@ -245,7 +245,7 @@ span.string {
 --></style>
 </head>
 <body>
-<div class="header">
+<div class="body">
 <!--
   Administrative API header for CUPS.
 

--- a/doc/help/api-filter.html
+++ b/doc/help/api-filter.html
@@ -245,7 +245,7 @@ span.string {
 --></style>
 </head>
 <body>
-<div class="header">
+<div class="body">
 <!--
   Filter and backend programming header for CUPS.
 

--- a/doc/help/api-ppd.html
+++ b/doc/help/api-ppd.html
@@ -245,7 +245,7 @@ span.string {
 --></style>
 </head>
 <body>
-<div class="header">
+<div class="body">
 <!--
   PPD API header for CUPS.
 

--- a/doc/help/cupspm.html
+++ b/doc/help/cupspm.html
@@ -245,7 +245,7 @@ span.string {
 --></style>
 </head>
 <body>
-<div class="header">
+<div class="body">
 <h1 class="title">CUPS Programming Manual</h1>
 <p>Michael R Sweet</p>
 <p>Copyright © 2021-2022 by OpenPrinting. All Rights Reserved.</p>

--- a/doc/help/postscript-driver.html
+++ b/doc/help/postscript-driver.html
@@ -245,7 +245,7 @@ span.string {
 --></style>
 </head>
 <body>
-<div class="header">
+<div class="body">
 <!--
   PostScript printer driver documentation for CUPS.
 

--- a/doc/help/ppd-compiler.html
+++ b/doc/help/ppd-compiler.html
@@ -245,7 +245,7 @@ span.string {
 --></style>
 </head>
 <body>
-<div class="header">
+<div class="body">
 <!--
   PPD compiler documentation for CUPS.
 

--- a/doc/help/raster-driver.html
+++ b/doc/help/raster-driver.html
@@ -245,7 +245,7 @@ span.string {
 --></style>
 </head>
 <body>
-<div class="header">
+<div class="body">
 <!--
   Raster printer driver documentation for CUPS.
 


### PR DESCRIPTION
This fixes issue #344 , Basically, cups web interface has its own header and footer, therefore we shouldn't include them in these html files since they might overlap and cause misalignment. In this modification, I merely changed their class from header to body so that they don't clash with cups web interface header.