### PR TITLE
Fixed footer message for web pages

### DIFF
--- a/templates/trailer.tmpl
+++ b/templates/trailer.tmpl
@@ -1,5 +1,5 @@
       </div>
     </div>
-    <div class="footer">Copyright © 2021-2022 OpenPrinting. All rights reserved.</div>
+    <div class="footer">Copyright &copy; 2021-2022 OpenPrinting. All rights reserved.</div>
   </body>
 </html>

--- a/templates/trailer.tmpl
+++ b/templates/trailer.tmpl
@@ -1,5 +1,5 @@
       </div>
     </div>
-    <div class="footer">CUPS and the CUPS logo are trademarks of <a href="http://www.apple.com">Apple Inc.</a> Copyright &copy; 2007-2019 Apple Inc. All rights reserved.</div>
+    <div class="footer">Copyright © 2021-2022 OpenPrinting. All rights reserved.</div>
   </body>
 </html>


### PR DESCRIPTION
Fix for #346 

Changed the copyright info from Apple Inc. to Open Printing on the pages.