### PR TITLE
scheduler/printers.c: Don't remove processing temp queue

### DIFF
--- a/scheduler/printers.c
+++ b/scheduler/printers.c
@@ -883,6 +883,9 @@ cupsdDeleteTemporaryPrinters(int force) /* I - Force deletion instead of auto? *
   time_t          unused_time;          /* Last time for printer state change */
 
 
+  cupsdLogMessage(CUPSD_LOG_DEBUG2,
+		  "cupsdDeleteTemporaryPrinters: Removing unused temporary printers");
+
  /*
   * Allow temporary printers to stick around for 60 seconds after the last job
   * completes.
@@ -892,7 +895,8 @@ cupsdDeleteTemporaryPrinters(int force) /* I - Force deletion instead of auto? *
 
   for (p = (cupsd_printer_t *)cupsArrayFirst(Printers); p; p = (cupsd_printer_t *)cupsArrayNext(Printers))
   {
-    if (p->temporary && (force || p->state_time < unused_time))
+    if (p->temporary &&
+	(force || (p->state_time < unused_time && p->state != IPP_PSTATE_PROCESSING)))
       cupsdDeletePrinter(p, 0);
   }
 }


### PR DESCRIPTION
cupsdDeleteTemporaryPrinters() deletes temporary queues which their last
status was updated 1 minute ago or older. It doesn't take into account
the fact the printer can be processing a big print job and cupsd deletes
the temp queue either way.

The fix in the PR now set cupsd to ignore queues which are in processing
state. If the delay in job processing is caused by an error in printer,
the correct error should kick in IPP backend.