### PR TITLE
AIX: Add DSOFLAGS and LDFLAGS for shared library support.

### DIFF
--- a/config-scripts/cups-sharedlibs.m4
+++ b/config-scripts/cups-sharedlibs.m4
@@ -44,6 +44,15 @@ AS_IF([test x$enable_shared != xno], [
 	DSO="\$(CC)"
 	DSOXX="\$(CXX)"
 	DSOFLAGS="$DSOFLAGS -Wl,-no_warn_inits -dynamiclib -single_module -lc"
+    ], [aix*], [
+	LIBCUPS="lib$cupsbase.so.2"
+	AS_IF([test "x$cupsimagebase" != x], [
+	    LIBCUPSIMAGE="lib$cupsimagebase.so.2"
+	])
+	DSO="\$(CC)"
+	DSOXX="\$(CXX)"
+	DSOFLAGS="$DSOFLAGS -Wl,-G -o \`basename \$@\`
+	LDFLAGS="$LDFLAGS $TLSFLAGS -liconv -lz -lm"
     ], [*], [
 	AC_MSG_NOTICE([Warning: Shared libraries may not work, trying -shared option.])
 	LIBCUPS="lib$cupsbase.so.2"


### PR DESCRIPTION
The minimal configuration changes to CUPS for supporting AIX shared library generation.

Many thanks for your consideration.

Fixes: #389 