### PR TITLE
config-scripts: Fix --enable-libtool-unsupported

### DIFF
--- a/config-scripts/cups-libtool.m4
+++ b/config-scripts/cups-libtool.m4
@@ -9,20 +9,21 @@ dnl Licensed under Apache License v2.0.  See the file "LICENSE" for more
 dnl information.
 dnl
 
-AC_ARG_ENABLE([libtool_unsupported], AS_HELP_STRING([--enable-libtool-unsupported=/path/to/libtool], [build with libtool (UNSUPPORTED)]), [
-    AS_IF([test x$enable_libtool_unsupported != xno], [
-	AS_IF([test x$enable_libtool_unsupported = xyes], [
-	    AC_MSG_ERROR([Use --enable-libtool-unsupported=/path/to/libtool.])
-	])
-	LIBTOOL="$enable_libtool_unsupported"
-	enable_shared="no"
-	AC_MSG_WARN([WARNING: libtool is not supported.])
-    ], [
-	LIBTOOL=""
-    ])
-])
+AC_ARG_ENABLE([libtool_unsupported],
+    AS_HELP_STRING([--enable-libtool-unsupported=/path/to/libtool],
+        [build with libtool (UNSUPPORTED)]),
+    [], [enable_libtool_unsupported=no])
 
-AS_IF([test x$LIBTOOL != x], [
+AS_IF([test x$enable_libtool_unsupported != xno], [
+    AS_IF([test x$enable_libtool_unsupported = xyes], [
+        AC_MSG_ERROR([Use --enable-libtool-unsupported=/path/to/libtool.])
+    ],[
+        AC_MSG_WARN([libtool is not supported.])
+    ])
+
+    LIBTOOL="$enable_libtool_unsupported"
+    enable_shared="no"
+
     DSO="\$(LIBTOOL) --mode=link --tag=CC ${CC}"
     DSOXX="\$(LIBTOOL) --mode=link --tag=CXX ${CXX}"
 


### PR DESCRIPTION
Alternative fix for PR https://github.com/OpenPrinting/cups/pull/392.

Also see comment https://github.com/OpenPrinting/cups/pull/392#issuecomment-1124018535.

When the LIBTOOL variable is set in the user's environment the build will use libtool even when --enable-libtool-unsupported is not used.

This can lead to unexpected failures when LIBTOOL is set to rlibtool rather than GNU libtool.

To solve this the build now relies on the enable_libtool_unsupported varaiable set by --enable-libtool-unsupported.

Gentoo bug: https://bugs.gentoo.org/show_bug.cgi?id=843638