### PR TITLE
scheduler/ipp.c: Allocate device_uri via cupsdSetString()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changes in CUPS v2.4.3 (TBA)
 
 - Added a title with device uri for found network printers (Issues #402, #393)
 - Fixed configuration on RISC-V machines (Issue #404)
+- Fixed the `device_uri` invalid pointer for driverless printers with `.local` hostname (Issue #419)
 - Fixed an OpenSSL crash bug (Issue #409)
 - Use localhost when printing via printer application (Issue #353)
 

--- a/scheduler/ipp.c
+++ b/scheduler/ipp.c
@@ -5307,7 +5307,7 @@ create_local_bg_thread(
       return (NULL);
     }
 
-    printer->device_uri = uri;
+    cupsdSetString(&printer->device_uri, uri);
   }
 
   if (httpSeparateURI(HTTP_URI_CODING_ALL, printer->device_uri, scheme, sizeof(scheme), userpass, sizeof(userpass), host, sizeof(host), &port, resource, sizeof(resource)) < HTTP_URI_STATUS_OK)


### PR DESCRIPTION
If a driverless printer has .local in its URI, we resolve the
URI and save the resolved one as new device URI. The problem was that
a local pointer was assigned to the structure which is passed to the
function as parameter, so the pointer became invalid once the execution
left the create_local_bg_thread() function.

We need to allocate the device URI via cupsdSetString() - the string is
then freed when the printer is deleted or cupsd shuts down.

Fixes #419.