### PR TITLE
snmp: Validate input data

### DIFF
--- a/cups/snmp.c
+++ b/cups/snmp.c
@@ -1231,7 +1231,7 @@ asn1_get_integer(
     unsigned char *bufend,		/* I  - End of buffer */
     unsigned      length)		/* I  - Length of value */
 {
-  int	value;				/* Integer value */
+  unsigned	value;			/* Integer value */
 
 
   if (*buffer >= bufend)
@@ -1250,7 +1250,7 @@ asn1_get_integer(
        length --, (*buffer) ++)
     value = ((value & 0xffffff) << 8) | **buffer;
 
-  return (value);
+  return ((int)value);
 }
 
 
@@ -1359,7 +1359,7 @@ asn1_get_packed(
     unsigned char **buffer,		/* IO - Pointer in buffer */
     unsigned char *bufend)		/* I  - End of buffer */
 {
-  int	value;				/* Value */
+  unsigned	value;			/* Value */
 
 
   if (*buffer >= bufend)
@@ -1379,7 +1379,7 @@ asn1_get_packed(
     (*buffer) ++;
   }
 
-  return (value);
+  return ((int)value);
 }
 
 

--- a/cups/snmp.c
+++ b/cups/snmp.c
@@ -1239,6 +1239,8 @@ asn1_get_integer(
 
   if (length > sizeof(int))
   {
+    if (length > (bufend - *buffer))
+      length = bufend - *buffer;
     (*buffer) += length;
     return (0);
   }
@@ -1285,6 +1287,8 @@ asn1_get_length(unsigned char **buffer,	/* IO - Pointer in buffer */
       length = (length << 8) | **buffer;
   }
 
+  if (length > (bufend - *buffer))
+    length = bufend - *buffer;
   return (length);
 }
 
@@ -1307,7 +1311,7 @@ asn1_get_oid(
   int		number;			/* OID number */
 
 
-  if (*buffer >= bufend)
+  if (*buffer >= bufend || length > (bufend - *buffer))
     return (0);
 
   valend = *buffer + length;


### PR DESCRIPTION
It is possible to trigger a crash or endless loop in snmp on
32 bit architectures due to missing integer validation. It should
not be possible on 64 bit architectures if I am not mistaken.

I have also adjusted the code to prevent signed integer overflows
which are harmless in reality but undefined in C standards.
It would take compiler options on real hardware to let the program
crash.

Proof of Concept:

1. Create and run server with crashing payload

```
cat > poc.py << EOF
from socket import AF_INET, SOCK_DGRAM, socket
s=socket(AF_INET, SOCK_DGRAM)
s.bind(('',161))
print('Waiting for incoming SNMP data')
m, addr=s.recvfrom(1024)
print('Replying with crash payload')
s.sendto(b'\x30\x07\x02\x84\xDE\xAD\xBA\xBE\x00', addr)
EOF
sudo python poc.py
```

2. Run snmp backend (or try to "Add Printer")

`/usr/lib/cups/backend/snmp localhost`x