### PR TITLE
Adds USB quirk for GoDEX label printers (fixes #440)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Changes in CUPS v2.4.3 (TBA)
 ----------------------------
 
 - Added a title with device uri for found network printers (Issues #402, #393)
+- Added quirk for GoDEX label printers (Issue #440)
 - Fixed `--enable-libtool-unsupported` (Issue #394)
 - Fixed configuration on RISC-V machines (Issue #404)
 - Fixed the `device_uri` invalid pointer for driverless printers with `.local`

--- a/backend/org.cups.usb-quirks
+++ b/backend/org.cups.usb-quirks
@@ -371,3 +371,6 @@
 
 # HP DesignJet 130 (Apple #5838)
 0x03f0 0x0314 no-reattach
+
+# GoDEX label printers (https://github.com/OpenPrinting/cups/issues/440)
+0x195f 0x0001 unidir no-reattach


### PR DESCRIPTION
I would commit this directly to OpenPrinting/cups, but I got:

remote: Resolving deltas: 100% (4/4), completed with 4 local objects.
remote: error: GH006: Protected branch update failed for refs/heads/master.
remote: error: At least 1 approving review is required by reviewers with write access.
To github.com:OpenPrinting/cups.git
 ! [remote rejected]     master -> master (protected branch hook declined)