### PR TITLE
scheduler/ipp.c: Convert incoming ColorModel attribute

### DIFF
--- a/scheduler/ipp.c
+++ b/scheduler/ipp.c
@@ -2340,6 +2340,18 @@ add_printer(cupsd_client_t  *con,	/* I - Client connection */
 
   set_device_uri = 0;
 
+  if ((attr = ippFindAttribute(con->request, "ColorModel", IPP_TAG_NAME)) != NULL)
+  {
+    const char * keyword = NULL;
+
+    if (!strcmp(attr->values[0].string.text, "FastGray") || !strcmp(attr->values[0].string.text, "Gray") || !strcmp(attr->values[0].string.text, "DeviceGray"))
+      keyword = "monochrome";
+    else
+      keyword = "color";
+
+    printer->num_options = cupsAddOption("print-color-mode", keyword, printer->num_options, &printer->options);
+  }
+
   if ((attr = ippFindAttribute(con->request, "device-uri",
                                IPP_TAG_URI)) != NULL)
   {


### PR DESCRIPTION
If a client uses PPD option ColorModel (which is converted into
attribute to be sent via IPP) for changing the default color option
(which happens via CUPS-Add-Modify-Printer operation), we have to
convert ColorModel into print-color-mode attribute, so the
print-color-mode-default attribute gets updated.

The change survives reboot because print-color-mode is saved as an
option in printer's entry in /etc/cups/printers.conf.