### PR TITLE
scheduler: Protect MimeDatabase from parallel access (fixes #466)

### DIFF
--- a/scheduler/client.c
+++ b/scheduler/client.c
@@ -1052,7 +1052,11 @@ cupsdReadClient(cupsd_client_t *con)	/* I - Client to read from */
 
             if ((filename = get_file(con, &filestats, buf, sizeof(buf))) != NULL)
             {
+	      _cupsRWLockRead(&MimeDatabase->lock);
+
 	      type = mimeFileType(MimeDatabase, filename, NULL, NULL);
+
+	      _cupsRWUnlock(&MimeDatabase->lock);
 
               cupsdLogClient(con, CUPSD_LOG_DEBUG, "filename=\"%s\", type=%s/%s", filename, type ? type->super : "", type ? type->type : "");
 

--- a/scheduler/conf.c
+++ b/scheduler/conf.c
@@ -1560,11 +1560,14 @@ cupsdReadConfiguration(void)
 
     MimeDatabase = mimeNew();
     mimeSetErrorCallback(MimeDatabase, mime_error_cb, NULL);
+    _cupsRWInit(&MimeDatabase->lock);
 
+    _cupsRWLockWrite(&MimeDatabase->lock);
     MimeDatabase = mimeLoadTypes(MimeDatabase, mimedir);
     MimeDatabase = mimeLoadTypes(MimeDatabase, ServerRoot);
     MimeDatabase = mimeLoadFilters(MimeDatabase, mimedir, temp);
     MimeDatabase = mimeLoadFilters(MimeDatabase, ServerRoot, temp);
+    _cupsRWUnlock(&MimeDatabase->lock);
 
     if (!MimeDatabase)
     {

--- a/scheduler/ipp.c
+++ b/scheduler/ipp.c
@@ -8655,6 +8655,8 @@ print_job(cupsd_client_t  *con,		/* I - Client connection */
     strlcpy(type, "octet-stream", sizeof(type));
   }
 
+  _cupsRWLockRead(&MimeDatabase->lock);
+
   if (!strcmp(super, "application") && !strcmp(type, "octet-stream"))
   {
    /*
@@ -8679,6 +8681,8 @@ print_job(cupsd_client_t  *con,		/* I - Client connection */
   }
   else
     filetype = mimeType(MimeDatabase, super, type);
+
+  _cupsRWUnlock(&MimeDatabase->lock);
 
   if (filetype &&
       (!format ||
@@ -9899,6 +9903,8 @@ send_document(cupsd_client_t  *con,	/* I - Client connection */
     strlcpy(type, "octet-stream", sizeof(type));
   }
 
+  _cupsRWLockRead(&MimeDatabase->lock);
+
   if (!strcmp(super, "application") && !strcmp(type, "octet-stream"))
   {
    /*
@@ -9927,6 +9933,8 @@ send_document(cupsd_client_t  *con,	/* I - Client connection */
   }
   else
     filetype = mimeType(MimeDatabase, super, type);
+
+  _cupsRWUnlock(&MimeDatabase->lock);
 
   if (filetype)
   {
@@ -11417,6 +11425,8 @@ validate_job(cupsd_client_t  *con,	/* I - Client connection */
       return;
     }
 
+    _cupsRWLockRead(&MimeDatabase->lock);
+
     if ((strcmp(super, "application") || strcmp(type, "octet-stream")) &&
 	!mimeType(MimeDatabase, super, type))
     {
@@ -11427,8 +11437,13 @@ validate_job(cupsd_client_t  *con,	/* I - Client connection */
 		      format->values[0].string.text);
       ippAddString(con->response, IPP_TAG_UNSUPPORTED_GROUP, IPP_TAG_MIMETYPE,
                    "document-format", NULL, format->values[0].string.text);
+
+      _cupsRWUnlock(&MimeDatabase->lock);
+
       return;
     }
+
+    _cupsRWUnlock(&MimeDatabase->lock);
   }
 
  /*

--- a/scheduler/mime.h
+++ b/scheduler/mime.h
@@ -13,6 +13,7 @@
 #  include <cups/array.h>
 #  include <cups/ipp.h>
 #  include <cups/file.h>
+#  include <cups/thread-private.h>
 #  include <regex.h>
 
 
@@ -106,6 +107,7 @@ typedef struct _mime_s			/**** MIME Database ****/
   cups_array_t		*srcs;		/* Filters sorted by source type */
   mime_error_cb_t	error_cb;	/* Error message callback */
   void			*error_ctx;	/* Pointer for callback */
+  _cups_rwlock_t	lock;	/* Read/write lock for guarding data for background updates */
 } mime_t;
 
 


### PR DESCRIPTION
If multiple create_local_bg_thread threads are spawned, they can fight
over MimeDatabase (specifically over MimeDatabase->srcs array), ending
up in SIGSEGV if one thread uses the array, but the other deletes it.

I chose to use RW locks for protecting the pointer - IMHO we benefit
from multiple threads being able to read in parallel.