### PR TITLE
Simplify redundant bitwise operations

### DIFF
--- a/backend/ieee1284.c
+++ b/backend/ieee1284.c
@@ -157,7 +157,7 @@ backendGetDeviceID(
       * bytes.  The 1284 spec says the length is stored MSB first...
       */
 
-      length = (int)((((unsigned)device_id[0] & 255) << 8) + ((unsigned)device_id[1] & 255));
+      length = (int)((((unsigned char)device_id[0]) << 8) | ((unsigned char)device_id[1]));
 
      /*
       * Check to see if the length is larger than our buffer; first
@@ -166,7 +166,7 @@ backendGetDeviceID(
       */
 
       if (length > device_id_size || length < 14)
-	length = (int)((((unsigned)device_id[1] & 255) << 8) + ((unsigned)device_id[0] & 255));
+	length = (int)((((unsigned char)device_id[1]) << 8) | ((unsigned char)device_id[0]));
 
       if (length > device_id_size)
 	length = device_id_size;

--- a/backend/usb-libusb.c
+++ b/backend/usb-libusb.c
@@ -1046,8 +1046,7 @@ get_device_id(usb_printer_t *printer,	/* I - Printer */
               char          *buffer,	/* I - String buffer */
               size_t        bufsize)	/* I - Number of bytes in buffer */
 {
-  int	length;				/* Length of device ID */
-
+  size_t	length;				/* Length of device ID */
 
   if (libusb_control_transfer(printer->handle,
 			      LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_ENDPOINT_IN |
@@ -1065,7 +1064,7 @@ get_device_id(usb_printer_t *printer,	/* I - Printer */
   * bytes.  The 1284 spec says the length is stored MSB first...
   */
 
-  length = (int)((((unsigned)buffer[0] & 255) << 8) | ((unsigned)buffer[1] & 255));
+  length = ((((unsigned char)buffer[0]) << 8) | ((unsigned char)buffer[1]));
 
  /*
   * Check to see if the length is larger than our buffer or less than 14 bytes
@@ -1076,7 +1075,7 @@ get_device_id(usb_printer_t *printer,	/* I - Printer */
   */
 
   if (length > bufsize || length < 14)
-    length = (int)((((unsigned)buffer[1] & 255) << 8) | ((unsigned)buffer[0] & 255));
+    length = ((((unsigned char)buffer[1]) << 8) | ((unsigned char)buffer[0]));
 
   if (length > bufsize)
     length = bufsize;
@@ -1098,7 +1097,7 @@ get_device_id(usb_printer_t *printer,	/* I - Printer */
   * nul-terminate.
   */
 
-  memmove(buffer, buffer + 2, (size_t)length);
+  memmove(buffer, buffer + 2, length);
   buffer[length] = '\0';
 
   return (0);

--- a/cups/http-support.c
+++ b/cups/http-support.c
@@ -729,7 +729,7 @@ httpEncode64_2(char       *out,		/* I - String to write to */
       if (inlen > 1)
         *outptr ++ = base64[(((in[0] & 255) << 4) | ((in[1] & 255) >> 4)) & 63];
       else
-        *outptr ++ = base64[((in[0] & 255) << 4) & 63];
+        *outptr ++ = base64[(in[0] << 4) & 63];
     }
 
     in ++;
@@ -748,7 +748,7 @@ httpEncode64_2(char       *out,		/* I - String to write to */
       if (inlen > 1)
         *outptr ++ = base64[(((in[0] & 255) << 2) | ((in[1] & 255) >> 6)) & 63];
       else
-        *outptr ++ = base64[((in[0] & 255) << 2) & 63];
+        *outptr ++ = base64[(in[0] << 2) & 63];
     }
 
     in ++;

--- a/cups/sidechannel.c
+++ b/cups/sidechannel.c
@@ -226,7 +226,7 @@ cupsSideChannelRead(
   * Validate the data length in the message...
   */
 
-  templen = ((buffer[2] & 255) << 8) | (buffer[3] & 255);
+  templen = (((unsigned char)buffer[2]) << 8) | ((unsigned char)buffer[3]);
 
   if (templen > 0 && (!data || !datalen))
   {


### PR DESCRIPTION
The conversion to unsigned char means the & 255 is not needed, as well in places where the more smaller & operator make the previous & 255 redundant