### PR TITLE
Simplify bitwise operations.

### DIFF
--- a/backend/ieee1284.c
+++ b/backend/ieee1284.c
@@ -157,7 +157,7 @@ backendGetDeviceID(
       * bytes.  The 1284 spec says the length is stored MSB first...
       */
 
-      length = (int)((((unsigned)device_id[0] & 255) << 8) + ((unsigned)device_id[1] & 255));
+      length = (int)((((unsigned)device_id[0] & 255) << 8) | ((unsigned)device_id[1] & 255));
 
      /*
       * Check to see if the length is larger than our buffer; first
@@ -166,7 +166,7 @@ backendGetDeviceID(
       */
 
       if (length > device_id_size || length < 14)
-	length = (int)((((unsigned)device_id[1] & 255) << 8) + ((unsigned)device_id[0] & 255));
+	length = (int)((((unsigned)device_id[1] & 255) << 8) | ((unsigned)device_id[0] & 255));
 
       if (length > device_id_size)
 	length = device_id_size;

--- a/cups/dest-options.c
+++ b/cups/dest-options.c
@@ -1621,7 +1621,7 @@ cups_collection_string(
 		  const ipp_uchar_t *date = ippGetDate(member, j);
 					/* Date value */
 
-		  year = ((unsigned)date[0] << 8) + (unsigned)date[1];
+		  year = ((unsigned)date[0] << 8) | (unsigned)date[1];
 
 		  if (date[9] == 0 && date[10] == 0)
 		    snprintf(temp, sizeof(temp), "%04u-%02u-%02uT%02u:%02u:%02uZ", year, date[2], date[3], date[4], date[5], date[6]);

--- a/cups/ipp-support.c
+++ b/cups/ipp-support.c
@@ -740,9 +740,7 @@ ippAttributeString(
 
       case IPP_TAG_DATE :
           {
-            unsigned year;		/* Year */
-
-            year = ((unsigned)val->date[0] << 8) + (unsigned)val->date[1];
+            unsigned year = ((unsigned)val->date[0] << 8) | (unsigned)val->date[1];
 
 	    if (val->date[9] == 0 && val->date[10] == 0)
 	      snprintf(temp, sizeof(temp), "%04u-%02u-%02uT%02u:%02u:%02uZ",

--- a/cups/ipp.c
+++ b/cups/ipp.c
@@ -2910,9 +2910,8 @@ ippReadIO(void       *src,		/* I - Data source */
 
           ipp->request.any.version[0]  = buffer[0];
           ipp->request.any.version[1]  = buffer[1];
-          ipp->request.any.op_status   = (buffer[2] << 8) | buffer[3];
-          ipp->request.any.request_id  = (((((buffer[4] << 8) | buffer[5]) << 8) |
-	                        	 buffer[6]) << 8) | buffer[7];
+          ipp->request.any.op_status = (buffer[2] << 8) | buffer[3];
+          ipp->request.any.request_id = (buffer[4] << 24) | (buffer[5] << 16) | (buffer[6] << 8) | buffer[7];
 
           DEBUG_printf(("2ippReadIO: version=%d.%d", buffer[0], buffer[1]));
 	  DEBUG_printf(("2ippReadIO: op_status=%04x",
@@ -2961,8 +2960,7 @@ ippReadIO(void       *src,		/* I - Data source */
 	      goto rollback;
 	    }
 
-	    tag = (ipp_tag_t)((((((buffer[0] << 8) | buffer[1]) << 8) |
-	                        buffer[2]) << 8) | buffer[3]);
+	    tag = (ipp_tag_t)((buffer[0] << 24) | (buffer[1] << 16) | (buffer[2] << 8) | buffer[3]);
 
             if (tag & IPP_TAG_CUPS_CONST)
             {
@@ -3262,8 +3260,7 @@ ippReadIO(void       *src,		/* I - Data source */
 		  goto rollback;
 		}
 
-		n = (((((buffer[0] << 8) | buffer[1]) << 8) | buffer[2]) << 8) |
-		    buffer[3];
+		n = (buffer[0] << 24) | (buffer[1] << 16) | (buffer[2] << 8) | buffer[3];
 
                 if (attr->value_tag == IPP_TAG_RANGE)
                   value->range.lower = value->range.upper = n;
@@ -3363,14 +3360,9 @@ ippReadIO(void       *src,		/* I - Data source */
 		  goto rollback;
 		}
 
-                value->resolution.xres =
-		    (((((buffer[0] << 8) | buffer[1]) << 8) | buffer[2]) << 8) |
-		    buffer[3];
-                value->resolution.yres =
-		    (((((buffer[4] << 8) | buffer[5]) << 8) | buffer[6]) << 8) |
-		    buffer[7];
-                value->resolution.units =
-		    (ipp_res_t)buffer[8];
+                value->resolution.xres = (buffer[0] << 24) | (buffer[1] << 16) | (buffer[2] << 8) | buffer[3];
+                value->resolution.yres = (buffer[4] << 24) | (buffer[5] << 16) | (buffer[6] << 8) | buffer[7];
+                value->resolution.units = (ipp_res_t)buffer[8];
 	        break;
 
 	    case IPP_TAG_RANGE :
@@ -3389,12 +3381,8 @@ ippReadIO(void       *src,		/* I - Data source */
 		  goto rollback;
 		}
 
-                value->range.lower =
-		    (((((buffer[0] << 8) | buffer[1]) << 8) | buffer[2]) << 8) |
-		    buffer[3];
-                value->range.upper =
-		    (((((buffer[4] << 8) | buffer[5]) << 8) | buffer[6]) << 8) |
-		    buffer[7];
+                value->range.lower = (buffer[0] << 24) | (buffer[1] << 16) | (buffer[2] << 8) | buffer[3];
+                value->range.upper = (buffer[4] << 24) | (buffer[5] << 16) | (buffer[6] << 8) | buffer[7];
 	        break;
 
 	    case IPP_TAG_TEXTLANG :

--- a/cups/md5.c
+++ b/cups/md5.c
@@ -131,8 +131,8 @@ _cups_md5_process(_cups_md5_state_t *pms, const unsigned char *data /*[64]*/)
     int i;
 
     for (i = 0; i < 16; ++i, xp += 4)
-	X[i] = (unsigned)xp[0] + ((unsigned)xp[1] << 8) +
-	       ((unsigned)xp[2] << 16) + ((unsigned)xp[3] << 24);
+	X[i] = (unsigned)xp[0] | ((unsigned)xp[1] << 8) |
+	       ((unsigned)xp[2] << 16) | ((unsigned)xp[3] << 24);
 
 #  else  /* !ARCH_IS_BIG_ENDIAN */
 


### PR DESCRIPTION
It is much more clear to illustrate where each buffer element goes in the created integer to shift to the right spot and then bitwise OR instead of shifting the integer being made by 8 each time and bitwise OR said integer.