### PR TITLE
Set pcl_line and pcl_comp to NULL after free.

### DIFF
--- a/tools/ippevepcl.c
+++ b/tools/ippevepcl.c
@@ -108,6 +108,9 @@ pcl_end_page(
 
   free(pcl_line);
   free(pcl_comp);
+
+  pcl_line = NULL;
+  pcl_comp = NULL;
 }
 
 


### PR DESCRIPTION
In the event we make a mistake, it is better for the program to crash due to a null pointer access than a potential use-after-free exploit.