### PR TITLE
Change options to be an unsigned integer instead of casting to one

### DIFF
--- a/cups/backend.c
+++ b/cups/backend.c
@@ -40,7 +40,7 @@ cupsBackendDeviceURI(char **argv)	/* I - Command-line arguments */
   const char	*device_uri,		/* Device URI */
 		*auth_info_required;	/* AUTH_INFO_REQUIRED env var */
   _cups_globals_t *cg = _cupsGlobals();	/* Global info */
-  int		options;		/* Resolve options */
+  unsigned int options;                 /* Resolve options */
   ppd_file_t	*ppd;			/* PPD file */
   ppd_attr_t	*ppdattr;		/* PPD attribute */
 


### PR DESCRIPTION
The function that takes options expects an unsigned integer, so marking options as such is a safe bet