### PR TITLE
Standardize all operations that use bitwise ORs to construct numbers

### DIFF
--- a/backend/ieee1284.c
+++ b/backend/ieee1284.c
@@ -157,7 +157,7 @@ backendGetDeviceID(
       * bytes.  The 1284 spec says the length is stored MSB first...
       */
 
-      length = (int)((((unsigned)device_id[0] & 255) << 8) + ((unsigned)device_id[1] & 255));
+      length = (int)((((unsigned char)device_id[0]) << 8) | ((unsigned char)device_id[1]));
 
      /*
       * Check to see if the length is larger than our buffer; first
@@ -166,7 +166,7 @@ backendGetDeviceID(
       */
 
       if (length > device_id_size || length < 14)
-	length = (int)((((unsigned)device_id[1] & 255) << 8) + ((unsigned)device_id[0] & 255));
+	length = (int)((((unsigned char)device_id[1]) << 8) | ((unsigned char)device_id[0]));
 
       if (length > device_id_size)
 	length = device_id_size;

--- a/backend/usb-libusb.c
+++ b/backend/usb-libusb.c
@@ -1065,7 +1065,7 @@ get_device_id(usb_printer_t *printer,	/* I - Printer */
   * bytes.  The 1284 spec says the length is stored MSB first...
   */
 
-  length = (int)((((unsigned)buffer[0] & 255) << 8) | ((unsigned)buffer[1] & 255));
+  length = (int)((((unsigned char)buffer[0]) << 8) | ((unsigned char)buffer[1]));
 
  /*
   * Check to see if the length is larger than our buffer or less than 14 bytes
@@ -1076,7 +1076,7 @@ get_device_id(usb_printer_t *printer,	/* I - Printer */
   */
 
   if (length > bufsize || length < 14)
-    length = (int)((((unsigned)buffer[1] & 255) << 8) | ((unsigned)buffer[0] & 255));
+    length = (int)((((unsigned char)buffer[1]) << 8) | ((unsigned char)buffer[0]));
 
   if (length > bufsize)
     length = bufsize;

--- a/cups/dest-options.c
+++ b/cups/dest-options.c
@@ -1621,7 +1621,7 @@ cups_collection_string(
 		  const ipp_uchar_t *date = ippGetDate(member, j);
 					/* Date value */
 
-		  year = ((unsigned)date[0] << 8) + (unsigned)date[1];
+		  year = (date[0] << 8) | date[1];
 
 		  if (date[9] == 0 && date[10] == 0)
 		    snprintf(temp, sizeof(temp), "%04u-%02u-%02uT%02u:%02u:%02uZ", year, date[2], date[3], date[4], date[5], date[6]);

--- a/cups/dir.c
+++ b/cups/dir.c
@@ -54,7 +54,7 @@ _cups_dir_time(FILETIME ft)		/* I - File time */
   * between them...
   */
 
-  val = ft.dwLowDateTime + ((ULONGLONG)ft.dwHighDateTime << 32);
+  val = ft.dwLowDateTime | ((ULONGLONG)ft.dwHighDateTime << 32);
   return ((time_t)(val / 10000000 - 11644732800));
 }
 

--- a/cups/file.c
+++ b/cups/file.c
@@ -2306,7 +2306,7 @@ cups_fill(cups_file_t *fp)		/* I - CUPS file */
 	  return (-1);
 	}
 
-	bytes = ((unsigned char)ptr[1] << 8) | (unsigned char)ptr[0];
+	bytes = (ptr[1] << 8) | ptr[0];
 	ptr   += 2 + bytes;
 
 	if (ptr > end)
@@ -2516,8 +2516,7 @@ cups_fill(cups_file_t *fp)		/* I - CUPS file */
 	  }
 	}
 
-	tcrc = ((((((uLong)trailer[3] << 8) | (uLong)trailer[2]) << 8) |
-		(uLong)trailer[1]) << 8) | (uLong)trailer[0];
+	tcrc = ((uLong)trailer[3] << 24) | ((uLong)trailer[2] << 16) | ((uLong)trailer[1] << 8) | ((uLong)trailer[0]);
 
 	if (tcrc != fp->crc)
 	{

--- a/cups/http-addr.c
+++ b/cups/http-addr.c
@@ -746,9 +746,7 @@ httpGetHostByName(const char *name)	/* I - Hostname or IP address */
     if (ip[0] > 255 || ip[1] > 255 || ip[2] > 255 || ip[3] > 255)
       return (NULL);			/* Invalid byte ranges! */
 
-    cg->ip_addr = htonl((((((((unsigned)ip[0] << 8) | (unsigned)ip[1]) << 8) |
-                           (unsigned)ip[2]) << 8) |
-                         (unsigned)ip[3]));
+    cg->ip_addr = htonl((ip[0] << 24) | (ip[1] << 16) | (ip[2] << 8) | ip[3]);
 
    /*
     * Fill in the host entry and return it...

--- a/cups/http-addrlist.c
+++ b/cups/http-addrlist.c
@@ -746,10 +746,7 @@ httpAddrGetList(const char *hostname,	/* I - Hostname, IP address, or NULL for p
 	    return (NULL);
 
           first->addr.ipv4.sin_family = AF_INET;
-          first->addr.ipv4.sin_addr.s_addr = htonl((((((((unsigned)ip[0] << 8) |
-	                                               (unsigned)ip[1]) << 8) |
-						     (unsigned)ip[2]) << 8) |
-						   (unsigned)ip[3]));
+          first->addr.ipv4.sin_addr.s_addr = htonl((ip[0] << 24) | (ip[1] << 16) | (ip[2] << 8) | ip[3]);
           first->addr.ipv4.sin_port = htons(portnum);
 	}
       }

--- a/cups/ipp-support.c
+++ b/cups/ipp-support.c
@@ -742,7 +742,7 @@ ippAttributeString(
           {
             unsigned year;		/* Year */
 
-            year = ((unsigned)val->date[0] << 8) + (unsigned)val->date[1];
+            year = (val->date[0] << 8) | val->date[1];
 
 	    if (val->date[9] == 0 && val->date[10] == 0)
 	      snprintf(temp, sizeof(temp), "%04u-%02u-%02uT%02u:%02u:%02uZ",

--- a/cups/ipp.c
+++ b/cups/ipp.c
@@ -2911,8 +2911,7 @@ ippReadIO(void       *src,		/* I - Data source */
           ipp->request.any.version[0]  = buffer[0];
           ipp->request.any.version[1]  = buffer[1];
           ipp->request.any.op_status   = (buffer[2] << 8) | buffer[3];
-          ipp->request.any.request_id  = (((((buffer[4] << 8) | buffer[5]) << 8) |
-	                        	 buffer[6]) << 8) | buffer[7];
+          ipp->request.any.request_id  = (buffer[4] << 24) | (buffer[5] << 16) | (buffer[6] << 8) | buffer[7];
 
           DEBUG_printf(("2ippReadIO: version=%d.%d", buffer[0], buffer[1]));
 	  DEBUG_printf(("2ippReadIO: op_status=%04x",
@@ -2961,8 +2960,7 @@ ippReadIO(void       *src,		/* I - Data source */
 	      goto rollback;
 	    }
 
-	    tag = (ipp_tag_t)((((((buffer[0] << 8) | buffer[1]) << 8) |
-	                        buffer[2]) << 8) | buffer[3]);
+	    tag = (ipp_tag_t)((buffer[0] << 24) | (buffer[1] << 16) | (buffer[2] << 8) | buffer[3]);
 
             if (tag & IPP_TAG_CUPS_CONST)
             {
@@ -3262,8 +3260,7 @@ ippReadIO(void       *src,		/* I - Data source */
 		  goto rollback;
 		}
 
-		n = (((((buffer[0] << 8) | buffer[1]) << 8) | buffer[2]) << 8) |
-		    buffer[3];
+		n = (buffer[0] << 24) | (buffer[1] << 16) | (buffer[2] << 8) | buffer[3];
 
                 if (attr->value_tag == IPP_TAG_RANGE)
                   value->range.lower = value->range.upper = n;
@@ -3363,14 +3360,9 @@ ippReadIO(void       *src,		/* I - Data source */
 		  goto rollback;
 		}
 
-                value->resolution.xres =
-		    (((((buffer[0] << 8) | buffer[1]) << 8) | buffer[2]) << 8) |
-		    buffer[3];
-                value->resolution.yres =
-		    (((((buffer[4] << 8) | buffer[5]) << 8) | buffer[6]) << 8) |
-		    buffer[7];
-                value->resolution.units =
-		    (ipp_res_t)buffer[8];
+                value->resolution.xres = ((buffer[0] << 24) | (buffer[1] << 16) | (buffer[2] << 8) | buffer[3]);
+                value->resolution.yres = ((buffer[4] << 24) | (buffer[5] << 16) | (buffer[6] << 8) | buffer[7]);
+                value->resolution.units = (ipp_res_t)buffer[8];
 	        break;
 
 	    case IPP_TAG_RANGE :
@@ -3389,12 +3381,8 @@ ippReadIO(void       *src,		/* I - Data source */
 		  goto rollback;
 		}
 
-                value->range.lower =
-		    (((((buffer[0] << 8) | buffer[1]) << 8) | buffer[2]) << 8) |
-		    buffer[3];
-                value->range.upper =
-		    (((((buffer[4] << 8) | buffer[5]) << 8) | buffer[6]) << 8) |
-		    buffer[7];
+                value->range.lower = (buffer[0] << 24) | (buffer[1] << 16) | (buffer[2] << 8) | buffer[3];
+                value->range.upper = (buffer[4] << 24) | (buffer[5] << 16) | (buffer[6] << 8) | buffer[7];
 	        break;
 
 	    case IPP_TAG_TEXTLANG :

--- a/cups/md5.c
+++ b/cups/md5.c
@@ -128,11 +128,10 @@ _cups_md5_process(_cups_md5_state_t *pms, const unsigned char *data /*[64]*/)
      */
     unsigned int X[16];
     const unsigned char *xp = data;
-    int i;
+    unsigned int i;
 
     for (i = 0; i < 16; ++i, xp += 4)
-	X[i] = (unsigned)xp[0] + ((unsigned)xp[1] << 8) +
-	       ((unsigned)xp[2] << 16) + ((unsigned)xp[3] << 24);
+        X[i] = xp[0] | (xp[1] << 8) | (xp[2] << 16) | (xp[3] << 24);
 
 #  else  /* !ARCH_IS_BIG_ENDIAN */
 

--- a/cups/raster-stream.c
+++ b/cups/raster-stream.c
@@ -685,11 +685,11 @@ _cupsRasterReadHeader(
           r->header.cupsColorSpace   = appleheader[1] >= (sizeof(rawcspace) / sizeof(rawcspace[0])) ? CUPS_CSPACE_DEVICE1 : rawcspace[appleheader[1]];
           r->header.cupsNumColors    = appleheader[1] >= (sizeof(rawnumcolors) / sizeof(rawnumcolors[0])) ? 1 : rawnumcolors[appleheader[1]];
           r->header.cupsBitsPerColor = r->header.cupsBitsPerPixel / r->header.cupsNumColors;
-          r->header.cupsWidth        = ((((((unsigned)appleheader[12] << 8) | (unsigned)appleheader[13]) << 8) | (unsigned)appleheader[14]) << 8) | (unsigned)appleheader[15];
-          r->header.cupsHeight       = ((((((unsigned)appleheader[16] << 8) | (unsigned)appleheader[17]) << 8) | (unsigned)appleheader[18]) << 8) | (unsigned)appleheader[19];
+          r->header.cupsWidth        = (appleheader[12] << 24) | (appleheader[13] << 16) | (appleheader[14] << 8) | appleheader[15];
+          r->header.cupsHeight       = (appleheader[16] << 24) | (appleheader[17] << 16) | (appleheader[18] << 8) | appleheader[19];
           r->header.cupsBytesPerLine = r->header.cupsWidth * r->header.cupsBitsPerPixel / 8;
           r->header.cupsColorOrder   = CUPS_ORDER_CHUNKED;
-          r->header.HWResolution[0]  = r->header.HWResolution[1] = ((((((unsigned)appleheader[20] << 8) | (unsigned)appleheader[21]) << 8) | (unsigned)appleheader[22]) << 8) | (unsigned)appleheader[23];
+          r->header.HWResolution[0]  = r->header.HWResolution[1] = (appleheader[20] << 24) | (appleheader[21] << 16) | (appleheader[22] << 8) | appleheader[23];
 
           if (r->header.HWResolution[0] > 0)
           {

--- a/cups/sidechannel.c
+++ b/cups/sidechannel.c
@@ -226,7 +226,7 @@ cupsSideChannelRead(
   * Validate the data length in the message...
   */
 
-  templen = ((buffer[2] & 255) << 8) | (buffer[3] & 255);
+  templen = (((unsigned char)buffer[2]) << 8) | ((unsigned char)buffer[3]);
 
   if (templen > 0 && (!data || !datalen))
   {

--- a/scheduler/conf.c
+++ b/scheduler/conf.c
@@ -1863,8 +1863,7 @@ get_addr_and_mask(const char *value,	/* I - String from config file */
 	* Merge everything into a 32-bit IPv4 address in ip[3]...
 	*/
 
-	ip[3] = ((((((unsigned)val[0] << 8) | (unsigned)val[1]) << 8) |
-	         (unsigned)val[2]) << 8) | (unsigned)val[3];
+	ip[3] = (val[0] << 24) | (val[1] << 16) | (val[2] << 8) | val[3];
 
 	if (ipcount < 4)
 	  mask[3] = (0xffffffff << (32 - 8 * ipcount)) & 0xffffffff;
@@ -1932,8 +1931,7 @@ get_addr_and_mask(const char *value,	/* I - String from config file */
     * Merge everything into a 32-bit IPv4 address in ip[3]...
     */
 
-    ip[3] = ((((((unsigned)val[0] << 8) | (unsigned)val[1]) << 8) |
-             (unsigned)val[2]) << 8) | (unsigned)val[3];
+    ip[3] = (val[0] << 24) | (val[1] << 16) | (val[2] << 8) | val[3];
 
     if (ipcount < 4)
       mask[3] = (0xffffffff << (32 - 8 * ipcount)) & 0xffffffff;
@@ -1960,8 +1958,7 @@ get_addr_and_mask(const char *value,	/* I - String from config file */
                  mask + 3) != 4)
         return (0);
 
-      mask[3] |= (((((unsigned)mask[0] << 8) | (unsigned)mask[1]) << 8) |
-                  (unsigned)mask[2]) << 8;
+      mask[3] |= (mask[0] << 16) | (mask[1] << 8) | mask[2];
       mask[0] = mask[1] = mask[2] = 0;
     }
     else

--- a/scheduler/type.c
+++ b/scheduler/type.c
@@ -1140,7 +1140,7 @@ mime_check_rules(
 	  else
 	  {
 	    bufptr = fb->buffer + rules->offset - fb->offset;
-	    intv   = (unsigned)((((((bufptr[0] << 8) | bufptr[1]) << 8) | bufptr[2]) << 8) | bufptr[3]);
+	    intv   = (bufptr[0] << 24) | (bufptr[1] << 16) | (bufptr[2] << 8) | bufptr[3];
 	    result = (intv == rules->value.intv);
 	  }
 	  break;

--- a/tools/ippeveps.c
+++ b/tools/ippeveps.c
@@ -141,16 +141,16 @@ ascii85(const unsigned char *data,	/* I - Data to write */
     switch (leftcount)
     {
       case 0 :
-          b = (unsigned)((((((data[0] << 8) | data[1]) << 8) | data[2]) << 8) | data[3]);
+          b = (data[0] << 24) | (data[1] << 16) | (data[2] << 8) | data[3];
 	  break;
       case 1 :
-          b = (unsigned)((((((leftdata[0] << 8) | data[0]) << 8) | data[1]) << 8) | data[2]);
+          b = (leftdata[0] << 24) | (data[0] << 16) | (data[1] << 8) | data[2];
 	  break;
       case 2 :
-          b = (unsigned)((((((leftdata[0] << 8) | leftdata[1]) << 8) | data[0]) << 8) | data[1]);
+          b = (leftdata[0] << 24) | (leftdata[1] << 16) | (data[0] << 8) | data[1];
 	  break;
       case 3 :
-          b = (unsigned)((((((leftdata[0] << 8) | leftdata[1]) << 8) | leftdata[2]) << 8) | data[0]);
+          b = (leftdata[0] << 24) | (leftdata[1] << 16) | (leftdata[2] << 8) | data[0];
 	  break;
     }
 
@@ -209,7 +209,7 @@ ascii85(const unsigned char *data,	/* I - Data to write */
     if (leftcount > 0)
     {
       // Write the remaining bytes as needed...
-      b = (unsigned)((((((leftdata[0] << 8) | leftdata[1]) << 8) | leftdata[2]) << 8) | leftdata[3]);
+      b = (leftdata[0] << 24) | (leftdata[1] << 16) | (leftdata[2] << 8) | leftdata[3];
 
       c[4] = (b % 85) + '!';
       b /= 85;
@@ -638,8 +638,8 @@ jpeg_to_ps(const char    *filename,	/* I - Filename */
 	* SOFn marker, look for dimensions...
 	*/
 
-	width  = (bufptr[6] << 8) | bufptr[7];
 	height = (bufptr[4] << 8) | bufptr[5];
+	width  = (bufptr[6] << 8) | bufptr[7];
 	depth  = bufptr[8];
 	break;
       }


### PR DESCRIPTION
We don't need (unsigned) casts with & 255 either because casting to unsigned char does the same thing, on all platforms.