### PR TITLE
cups/globals.c: Define DEBUG_printf on Win

### DIFF
--- a/cups/globals.c
+++ b/cups/globals.c
@@ -16,6 +16,8 @@
 #include "cups-private.h"
 #ifndef _WIN32
 #  include <pwd.h>
+#else
+#  include "debug-internal.h"
 #endif /* !_WIN32 */
 
 


### PR DESCRIPTION
Fixes Github action failure.

I wasn't sure whether the new ```DEBUG_printf()``` in ```cups_global_alloc()``` was intentional or a mistake, so the fix is based on the former (so it adds a new include). Do let me know whether it is a correct assumption or not.