### PR TITLE
Fix German translation

### DIFF
--- a/locale/cups_de.po
+++ b/locale/cups_de.po
@@ -75,7 +75,7 @@ msgid "\tDefault page size:"
 msgstr "\tVoreingestellte Seitengröße:"
 
 msgid "\tDefault pitch:"
-msgstr "\tVoreingestellte Neigung:"
+msgstr "\tVoreingestellte Gradation:"
 
 msgid "\tDefault port settings:"
 msgstr "\tVoreingestellte Porteinstellungen:"
@@ -96,7 +96,7 @@ msgstr "\tSchnittstelle: %s.ppd"
 
 #, c-format
 msgid "\tInterface: %s/ppd/%s.ppd"
-msgstr "\tSchnittstelle: %s/ppp/%s.ppd"
+msgstr "\tSchnittstelle: %s/ppd/%s.ppd"
 
 #, c-format
 msgid "\tLocation: %s"


### PR DESCRIPTION
"Default pitch" is "Voreingestellte Gradation"

"Neigung" doesn't fit, since that just describes the tilting of something, "Gradation" with its description fits better for character sizes.