### PR TITLE
scheduler/printers.c: Check for CMYK as well (fixes #421)

### DIFF
--- a/scheduler/printers.c
+++ b/scheduler/printers.c
@@ -4547,7 +4547,7 @@ load_ppd(cupsd_printer_t *p)		/* I - Printer */
         ppd_option_t *color_model = ppdFindOption(ppd, "ColorModel");
 					// ColorModel PPD option
 
-        if (color_model && strcmp(color_model->defchoice, "RGB"))
+        if (color_model && strcmp(color_model->defchoice, "RGB") && strcmp(color_model->defchoice, "CMYK"))
           p->num_options = cupsAddOption("print-color-mode", "monochrome", p->num_options, &p->options);
       }
     }


### PR DESCRIPTION
In `load_ppd()` we would set the `print-color-mode` to `monochrome` only if the device supported color printing and the default PPD choice for ColorModel was RGB - this broke settings for color printing for models, which use `CMYK` for ColorModel.

With this patch we check for CMYK as well.

CUPS 3.0-