### PR TITLE
Change cupsd.conf to force authentication when accessing administration

### DIFF
--- a/conf/cupsd.conf.in
+++ b/conf/cupsd.conf.in
@@ -38,6 +38,8 @@ IdleExitTimeout @EXIT_TIMEOUT@
 
 # Restrict access to the admin pages...
 <Location /admin>
+  AuthType Default
+  Require user @SYSTEM
   Order allow,deny
 </Location>
 


### PR DESCRIPTION
With the current default configuration, someone can request to Find New Printers without being authenticated and with no way to be authenticated. Without authentication cups does not detects printers on the network. The person might not realize that it's because authentication is missing. It seems natural to always offer to authenticate when accessing the administration page.

Co-Authored-By: Dominic Mayers <dominic.mayers@meditationstudies.org>