### PR TITLE
Fix trivial deprecations

### DIFF
--- a/backend/ipp.c
+++ b/backend/ipp.c
@@ -3248,7 +3248,6 @@ run_as_user(char       *argv[],		/* I - Command-line arguments */
   xpc_connection_t	conn;		/* Connection to XPC service */
   xpc_object_t		request;	/* Request message dictionary */
   __block xpc_object_t	response;	/* Response message dictionary */
-  dispatch_semaphore_t	sem;		/* Semaphore for waiting for response */
   int			status = CUPS_BACKEND_FAILED;
 					/* Status of request */
 
@@ -3315,24 +3314,9 @@ run_as_user(char       *argv[],		/* I - Command-line arguments */
   xpc_dictionary_set_fd(request, "stderr", 2);
   xpc_dictionary_set_fd(request, "side-channel", CUPS_SC_FD);
 
-  sem      = dispatch_semaphore_create(0);
-  response = NULL;
+  response = xpc_connection_send_message_with_reply_sync(conn, request);
 
-  xpc_connection_send_message_with_reply(conn, request,
-                                         dispatch_get_global_queue(0,0),
-					 ^(xpc_object_t reply)
-					 {
-					   /* Save the response and wake up */
-					   if (xpc_get_type(reply)
-					           == XPC_TYPE_DICTIONARY)
-					     response = xpc_retain(reply);
-
-					   dispatch_semaphore_signal(sem);
-					 });
-
-  dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
   xpc_release(request);
-  dispatch_release(sem);
 
   if (response)
   {
@@ -3366,24 +3350,8 @@ run_as_user(char       *argv[],		/* I - Command-line arguments */
   xpc_dictionary_set_int64(request, "command", kPMWaitForJob);
   xpc_dictionary_set_fd(request, "stderr", 2);
 
-  sem      = dispatch_semaphore_create(0);
-  response = NULL;
-
-  xpc_connection_send_message_with_reply(conn, request,
-                                         dispatch_get_global_queue(0,0),
-					 ^(xpc_object_t reply)
-					 {
-					   /* Save the response and wake up */
-					   if (xpc_get_type(reply)
-					           == XPC_TYPE_DICTIONARY)
-					     response = xpc_retain(reply);
-
-					   dispatch_semaphore_signal(sem);
-					 });
-
-  dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
+  response = xpc_connection_send_message_with_reply_sync(conn, request);
   xpc_release(request);
-  dispatch_release(sem);
 
   if (response)
   {

--- a/cups/usersys.c
+++ b/cups/usersys.c
@@ -593,8 +593,19 @@ cupsSetUserAgent(const char *user_agent)/* I - User-Agent string or @code NULL@ 
   * Gather Windows version information for the User-Agent string...
   */
 
-  version.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
-  GetVersionExA(&version);
+  typedef LONG NTSTATUS, *PNTSTATUS;
+  typedef NTSTATUS(WINAPI * RtlGetVersionPtr)(PRTL_OSVERSIONINFOW);
+
+  RtlGetVersionPtr RtlGetVersionInternal = (RtlGetVersionPtr)GetProcAddress(GetModuleHandleW(L"ntdll.dll"), "RtlGetVersion");
+  if (RtlGetVersionInternal)
+  {
+    version.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
+    RtlGetVersionInternal((PRTL_OSVERSIONINFOW)&version);
+  }
+  else
+  {
+    ZeroMemory(&version, sizeof(version));
+  }
   GetNativeSystemInfo(&sysinfo);
 
   switch (sysinfo.wProcessorArchitecture)

--- a/scheduler/sysman.c
+++ b/scheduler/sysman.c
@@ -538,7 +538,7 @@ sysEventThreadEntry(void)
   * this later.
   */
 
-  bzero(&timerContext, sizeof(timerContext));
+  memset(&timerContext, 0, sizeof(timerContext));
   timerContext.info = &threadData;
 
   threadData.timerRef =


### PR DESCRIPTION
We should use SecTrustCopyCertificateChain and then access the CFArray instead of using the deprecated SecTrustGetCertificateCount

Use xpc_connection_send_message_with_reply_sync instead of xpc_connection_send_message_with_reply

This also gives us the added benefit of not risking priority inversion, since xpc_connection_send_message_with_reply_sync takes care of that already.

Finally, use RtlGetVersion instead of deprecated GetVersionExA.