### PR TITLE
Fix backchannel status checking bugs

### DIFF
--- a/cups/backchannel.c
+++ b/cups/backchannel.c
@@ -63,9 +63,9 @@ cupsBackChannelRead(char   *buffer,	/* I - Buffer to read into */
     else
       status = select(4, &input, NULL, NULL, &tval);
   }
-  while (status < 0 && errno != EINTR && errno != EAGAIN);
+  while (status < 0 && (errno == EINTR || errno == EAGAIN));
 
-  if (status < 0)
+  if (status <= 0)
     return (-1);			/* Timeout! */
 
  /*
@@ -125,7 +125,7 @@ cupsBackChannelWrite(
       else
 	status = select(4, NULL, &output, NULL, &tval);
     }
-    while (status < 0 && errno != EINTR && errno != EAGAIN);
+    while (status < 0 && (errno == EINTR || errno == EAGAIN));
 
     if (status <= 0)
       return (-1);			/* Timeout! */
@@ -173,8 +173,8 @@ cups_setup(fd_set         *set,		/* I - Set for select() */
            struct timeval *tval,	/* I - Timer value */
 	   double         timeout)	/* I - Timeout in seconds */
 {
-  tval->tv_sec = (int)timeout;
-  tval->tv_usec = (int)(1000000.0 * (timeout - tval->tv_sec));
+  tval->tv_sec = (time_t)timeout;
+  tval->tv_usec = (suseconds_t)(1000000.0 * (timeout - tval->tv_sec));
 
   FD_ZERO(set);
   FD_SET(3, set);


### PR DESCRIPTION
Checking for merely (status < 0) is a bug because the check for timeout is deliberate.

Note that you have an if (timeout < 0) at the beginning

So if the timeout is set to a value, it should check for that value.

The condition on the while is also suspicious, though.

It should be while (status < 0 && (errno == EINTR || errno == EAGAIN))

Co-Authored-By: aaaaaa123456789 <aaaaaa123456789@acidch.at>