### PR TITLE
[Mistake Bug-Fix]: Fix cupsfilter by setting both array elements to -1

### DIFF
--- a/scheduler/cupsfilter.c
+++ b/scheduler/cupsfilter.c
@@ -1197,7 +1197,7 @@ exec_filters(mime_type_t   *srctype,	/* I - Source type */
       close(filterfds[1 - current][1]);
 
       filterfds[1 - current][0] = -1;
-      filterfds[1 - current][0] = -1;
+      filterfds[1 - current][1] = -1;
     }
 
     if (next)


### PR DESCRIPTION
We mistakenly set filterfds[1 - current][0] = -1; twice instead of doing that and doing filterfds[1 - current][1] = -1;