### PR TITLE
Change (argc < 6 || argc > 7) to (argc != 6 && argc != 7)

### DIFF
--- a/backend/lpd.c
+++ b/backend/lpd.c
@@ -165,7 +165,7 @@ main(int  argc,				/* I - Number of command-line arguments (6 or 7) */
            _cupsLangString(cupsLangDefault(), _("LPD/LPR Host or Printer")));
     return (CUPS_BACKEND_OK);
   }
-  else if (argc < 6 || argc > 7)
+  else if (argc != 6 && argc != 7)
   {
     _cupsLangPrintf(stderr,
                     _("Usage: %s job-id user title copies options [file]"),

--- a/backend/socket.c
+++ b/backend/socket.c
@@ -113,7 +113,7 @@ main(int  argc,				/* I - Number of command-line arguments (6 or 7) */
            _cupsLangString(cupsLangDefault(), _("AppSocket/HP JetDirect")));
     return (CUPS_BACKEND_OK);
   }
-  else if (argc < 6 || argc > 7)
+  else if (argc != 6 && argc != 7)
   {
     _cupsLangPrintf(stderr,
                     _("Usage: %s job-id user title copies options [file]"),

--- a/backend/usb.c
+++ b/backend/usb.c
@@ -164,7 +164,7 @@ main(int  argc,				/* I - Number of command-line arguments (6 or 7) */
     list_devices();
     return (CUPS_BACKEND_OK);
   }
-  else if (argc < 6 || argc > 7)
+  else if (argc != 6 && argc != 7)
   {
     _cupsLangPrintf(stderr,
                     _("Usage: %s job-id user title copies options [file]"),

--- a/filter/commandtops.c
+++ b/filter/commandtops.c
@@ -46,7 +46,7 @@ main(int  argc,				/* I - Number of command-line arguments */
   * Check for valid arguments...
   */
 
-  if (argc < 6 || argc > 7)
+  if (argc != 6 && argc != 7)
   {
    /*
     * We don't have the correct number of arguments; write an error message

--- a/filter/gziptoany.c
+++ b/filter/gziptoany.c
@@ -34,7 +34,7 @@ main(int  argc,				/* I - Number of command-line arguments */
   * Check command-line...
   */
 
-  if (argc < 6 || argc > 7)
+  if (argc != 6 && argc != 7)
   {
     _cupsLangPrintf(stderr,
                     _("Usage: %s job-id user title copies options [file]"),

--- a/filter/pstops.c
+++ b/filter/pstops.c
@@ -217,7 +217,7 @@ main(int  argc,				/* I - Number of command-line args */
   * Check command-line...
   */
 
-  if (argc < 6 || argc > 7)
+  if (argc != 6 && argc != 7)
   {
     _cupsLangPrintf(stderr,
                     _("Usage: %s job-id user title copies options [file]"),

--- a/filter/rastertoepson.c
+++ b/filter/rastertoepson.c
@@ -988,7 +988,7 @@ main(int  argc,				/* I - Number of command-line arguments */
   * Check command-line...
   */
 
-  if (argc < 6 || argc > 7)
+  if (argc != 6 && argc != 7)
   {
    /*
     * We don't have the correct number of arguments; write an error message

--- a/filter/rastertohp.c
+++ b/filter/rastertohp.c
@@ -657,7 +657,7 @@ main(int  argc,				/* I - Number of command-line arguments */
   * Check command-line...
   */
 
-  if (argc < 6 || argc > 7)
+  if (argc != 6 && argc != 7)
   {
    /*
     * We don't have the correct number of arguments; write an error message

--- a/filter/rastertolabel.c
+++ b/filter/rastertolabel.c
@@ -1110,7 +1110,7 @@ main(int  argc,				/* I - Number of command-line arguments */
   * Check command-line...
   */
 
-  if (argc < 6 || argc > 7)
+  if (argc != 6 && argc != 7)
   {
    /*
     * We don't have the correct number of arguments; write an error message

--- a/filter/rastertopwg.c
+++ b/filter/rastertopwg.c
@@ -56,7 +56,7 @@ main(int  argc,				/* I - Number of command-line args */
   const char		*val;		/* Option value */
 
 
-  if (argc < 6 || argc > 7)
+  if (argc != 6 && argc != 7)
   {
     puts("Usage: rastertopwg job user title copies options [filename]");
     return (1);

--- a/monitor/bcp.c
+++ b/monitor/bcp.c
@@ -42,7 +42,7 @@ main(int  argc,				/* I - Number of command-line args */
   * Check command-line...
   */
 
-  if (argc < 6 || argc > 7)
+  if (argc != 6 && argc != 7)
   {
     _cupsLangPrintf(stderr,
                     _("Usage: %s job-id user title copies options [file]"),

--- a/monitor/tbcp.c
+++ b/monitor/tbcp.c
@@ -41,7 +41,7 @@ main(int  argc,				/* I - Number of command-line args */
   * Check command-line...
   */
 
-  if (argc < 6 || argc > 7)
+  if (argc != 6 && argc != 7)
   {
     _cupsLangPrintf(stderr,
                     _("Usage: %s job-id user title copies options [file]"),


### PR DESCRIPTION
They both do the same thing, but the latter is more clear.