### PR TITLE
Prevent memory leaks in case of errors

### DIFF
--- a/ppdc/ppdc.cxx
+++ b/ppdc/ppdc.cxx
@@ -32,7 +32,7 @@ int					// O - Exit status
 main(int  argc,				// I - Number of command-line arguments
      char *argv[])			// I - Command-line arguments
 {
-  int			i, j;		// Looping vars
+  int			i;		// Looping var
   ppdcCatalog		*catalog;	// Message catalog
   const char		*outdir;	// Output directory
   ppdcSource		*src;		// PPD source file data
@@ -186,6 +186,7 @@ main(int  argc,				// I - Number of command-line arguments
         	  _cupsLangPrintf(stderr,
 				  _("ppdc: Unable to find localization for "
 				    "\"%s\" - %s"), argv[i], strerror(errno));
+                  catalog->release();
                   return (1);
 		}
 	      }
@@ -253,6 +254,9 @@ main(int  argc,				// I - Number of command-line arguments
 	_cupsLangPrintf(stderr,
 	                _("ppdc: Unable to create output directory %s: %s"),
 	        outdir, strerror(errno));
+        if (locales)
+          locales->release();
+        src->release();
         return (1);
       }
     }
@@ -328,9 +332,10 @@ main(int  argc,				// I - Number of command-line arguments
 
 	if (strstr(outname, ".PPD"))
 	{
+	  size_t j;
 	  // Convert PCFileName to lowercase...
 	  for (j = 0;
-	       outname[j] && j < (int)(sizeof(pcfilename) - 1);
+	       j < (sizeof(pcfilename) - 1) && outname[j];
 	       j ++)
 	    pcfilename[j] = (char)tolower(outname[j] & 255);
 


### PR DESCRIPTION
If for some reason, a localization is unable to be found or an output directory is unable to be made, we should release the memory instead of keeping it