### PR TITLE
Remove useless depth argument from static function cups_get_printer_uri

### DIFF
--- a/backend/snmp-supplies.c
+++ b/backend/snmp-supplies.c
@@ -626,7 +626,7 @@ backend_init_supplies(
     fprintf(stderr, "DEBUG2: prtGeneralCurrentLocalization=%d\n",
             packet.object_value.integer);
 
-    _cupsSNMPCopyOID(oid, prtLocalizationCharacterSet, CUPS_SNMP_MAX_OID);
+    _cupsSNMPCopyOID(oid, prtLocalizationCharacterSet);
     oid[prtLocalizationCharacterSetOffset - 2] = packet.object_value.integer;
 
 

--- a/cups/ppd-util.c
+++ b/cups/ppd-util.c
@@ -30,8 +30,7 @@
 
 static int	cups_get_printer_uri(http_t *http, const char *name,
 		                     char *host, int hostsize, int *port,
-				     char *resource, int resourcesize,
-				     int depth);
+				     char *resource, int resourcesize);
 
 
 /*
@@ -138,8 +137,6 @@ cupsGetPPD3(http_t     *http,		/* I  - HTTP connection or @code CUPS_HTTP_DEFAUL
   int		port;			/* Port number */
   http_status_t	status;			/* HTTP status from server */
   char		tempfile[1024] = "";	/* Temporary filename */
-  _cups_globals_t *cg = _cupsGlobals();	/* Pointer to library globals */
-
 
  /*
   * Range check input...
@@ -188,6 +185,7 @@ cupsGetPPD3(http_t     *http,		/* I  - HTTP connection or @code CUPS_HTTP_DEFAUL
   {
     char	ppdname[1024];		/* PPD filename */
     struct stat	ppdinfo;		/* PPD file information */
+    _cups_globals_t* cg = _cupsGlobals();	/* Pointer to library globals */
 
 
     snprintf(ppdname, sizeof(ppdname), "%s/ppd/%s.ppd", cg->cups_serverroot,
@@ -331,7 +329,7 @@ cupsGetPPD3(http_t     *http,		/* I  - HTTP connection or @code CUPS_HTTP_DEFAUL
     }
   }
 
-  if (!cups_get_printer_uri(http, name, hostname, sizeof(hostname), &port, resource, sizeof(resource), 0))
+  if (!cups_get_printer_uri(http, name, hostname, sizeof(hostname), &port, resource, sizeof(resource)))
   {
     DEBUG_puts("2cupsGetPPD3: Unable to get printer URI.");
     return (HTTP_STATUS_NOT_FOUND);
@@ -549,8 +547,7 @@ cups_get_printer_uri(
     int        hostsize,		/* I - Size of hostname buffer */
     int        *port,			/* O - Port number */
     char       *resource,		/* I - Resource buffer */
-    int        resourcesize,		/* I - Size of resource buffer */
-    int        depth)			/* I - Depth of query */
+    int        resourcesize)		/* I - Size of resource buffer */
 {
   int		i;			/* Looping var */
   ipp_t		*request,		/* IPP request */
@@ -566,7 +563,7 @@ cups_get_printer_uri(
 		};
 
 
-  DEBUG_printf(("4cups_get_printer_uri(http=%p, name=\"%s\", host=%p, hostsize=%d, resource=%p, resourcesize=%d, depth=%d)", http, name, host, hostsize, resource, resourcesize, depth));
+  DEBUG_printf(("4cups_get_printer_uri(http=%p, name=\"%s\", host=%p, hostsize=%d, resource=%p, resourcesize=%d)", http, name, host, hostsize, resource, resourcesize));
 
  /*
   * Setup the printer URI...

--- a/cups/snmp-private.h
+++ b/cups/snmp-private.h
@@ -102,7 +102,7 @@ extern "C" {
 #  endif /* __cplusplus */
 
 extern void		_cupsSNMPClose(int fd) _CUPS_PRIVATE;
-extern int		*_cupsSNMPCopyOID(int *dst, const int *src, int dstsize)
+extern int		*_cupsSNMPCopyOID(int *dst, const int *src)
 			    _CUPS_PRIVATE;
 extern const char	*_cupsSNMPDefaultCommunity(void) _CUPS_PRIVATE;
 extern int		_cupsSNMPIsOID(cups_snmp_t *packet, const int *oid)

--- a/cups/snmp.c
+++ b/cups/snmp.c
@@ -29,7 +29,7 @@ static void		asn1_debug(const char *prefix, unsigned char *buffer,
 			           size_t len, int indent);
 static int		asn1_decode_snmp(unsigned char *buffer, size_t len,
 			                 cups_snmp_t *packet);
-static int		asn1_encode_snmp(unsigned char *buffer, size_t len,
+static ssize_t		asn1_encode_snmp(unsigned char *buffer, size_t len,
 			                 cups_snmp_t *packet);
 static int		asn1_get_integer(unsigned char **buffer,
 			                 unsigned char *bufend,
@@ -84,16 +84,13 @@ _cupsSNMPClose(int fd)			/* I - SNMP socket file descriptor */
 
 int *					/* O - New OID */
 _cupsSNMPCopyOID(int       *dst,	/* I - Destination OID */
-                 const int *src,	/* I - Source OID */
-		 int       dstsize)	/* I - Number of integers in dst */
+                 const int *src)	/* I - Source OID */
 {
-  int	i;				/* Looping var */
+  size_t	i;				/* Looping var */
 
 
-  DEBUG_printf(("4_cupsSNMPCopyOID(dst=%p, src=%p, dstsize=%d)", dst, src,
-                dstsize));
-
-  for (i = 0, dstsize --; src[i] >= 0 && i < dstsize; i ++)
+  DEBUG_printf(("4_cupsSNMPCopyOID(dst=%p, src=%p)", dst, src));
+  for (i = 0; i < CUPS_SNMP_MAX_OID - 1 && src[i] >= 0; i ++)
     dst[i] = src[i];
 
   dst[i] = -1;
@@ -161,7 +158,7 @@ int					/* O - 1 if equal, 0 if not equal */
 _cupsSNMPIsOID(cups_snmp_t *packet,	/* I - Response packet */
                const int   *oid)	/* I - OID */
 {
-  int	i;				/* Looping var */
+  size_t	i;				/* Looping var */
 
 
  /*
@@ -210,7 +207,7 @@ _cupsSNMPIsOIDPrefixed(
     cups_snmp_t *packet,		/* I - Response packet */
     const int   *prefix)		/* I - OID prefix */
 {
-  int	i;				/* Looping var */
+  size_t	i;				/* Looping var */
 
 
  /*
@@ -582,7 +579,7 @@ _cupsSNMPWalk(int            fd,	/* I - SNMP socket */
   * Copy the OID prefix and then loop until we have no more OIDs...
   */
 
-  _cupsSNMPCopyOID(packet.object_name, prefix, CUPS_SNMP_MAX_OID);
+  _cupsSNMPCopyOID(packet.object_name, prefix);
   lastoid[0] = -1;
 
   for (;;)
@@ -620,7 +617,7 @@ _cupsSNMPWalk(int            fd,	/* I - SNMP socket */
       return (count > 0 ? count : -1);
     }
 
-    _cupsSNMPCopyOID(lastoid, packet.object_name, CUPS_SNMP_MAX_OID);
+    _cupsSNMPCopyOID(lastoid, packet.object_name);
 
     count ++;
 
@@ -645,7 +642,7 @@ _cupsSNMPWrite(
     const unsigned request_id,		/* I - Request ID */
     const int      *oid)		/* I - OID */
 {
-  int		i;			/* Looping var */
+  size_t		i;			/* Looping var */
   cups_snmp_t	packet;			/* SNMP message packet */
   unsigned char	buffer[CUPS_SNMP_MAX_PACKET];
 					/* SNMP message buffer */
@@ -683,7 +680,7 @@ _cupsSNMPWrite(
 
   strlcpy(packet.community, community, sizeof(packet.community));
 
-  for (i = 0; oid[i] >= 0 && i < (CUPS_SNMP_MAX_OID - 1); i ++)
+  for (i = 0; i < (CUPS_SNMP_MAX_OID - 1) && oid[i] >= 0; i ++)
     packet.object_name[i] = oid[i];
   packet.object_name[i] = -1;
 
@@ -755,7 +752,7 @@ asn1_debug(const char    *prefix,	/* I - Prefix string */
 
     size_t j;
 
-    fprintf(stderr, "%sHex Dump (%d bytes):\n", prefix, (int)len);
+    fprintf(stderr, "%sHex Dump (%u bytes):\n", prefix, (unsigned)len);
 
     for (i = 0; i < len; i += 16)
     {
@@ -810,40 +807,40 @@ asn1_debug(const char    *prefix,	/* I - Prefix string */
       case CUPS_ASN1_BOOLEAN :
           integer = asn1_get_integer(&buffer, bufend, value_length);
 
-          fprintf(stderr, "%s%*sBOOLEAN %d bytes %d\n", prefix, indent, "",
+          fprintf(stderr, "%s%*sBOOLEAN %u bytes %d\n", prefix, indent, "",
 	          value_length, integer);
           break;
 
       case CUPS_ASN1_INTEGER :
           integer = asn1_get_integer(&buffer, bufend, value_length);
 
-          fprintf(stderr, "%s%*sINTEGER %d bytes %d\n", prefix, indent, "",
+          fprintf(stderr, "%s%*sINTEGER %u bytes %d\n", prefix, indent, "",
 	          value_length, integer);
           break;
 
       case CUPS_ASN1_COUNTER :
           integer = asn1_get_integer(&buffer, bufend, value_length);
 
-          fprintf(stderr, "%s%*sCOUNTER %d bytes %u\n", prefix, indent, "",
-	          value_length, (unsigned)integer);
+          fprintf(stderr, "%s%*sCOUNTER %u bytes %d\n", prefix, indent, "",
+	          value_length, integer);
           break;
 
       case CUPS_ASN1_GAUGE :
           integer = asn1_get_integer(&buffer, bufend, value_length);
 
-          fprintf(stderr, "%s%*sGAUGE %d bytes %u\n", prefix, indent, "",
-	          value_length, (unsigned)integer);
+          fprintf(stderr, "%s%*sGAUGE %u bytes %d\n", prefix, indent, "",
+	          value_length, integer);
           break;
 
       case CUPS_ASN1_TIMETICKS :
           integer = asn1_get_integer(&buffer, bufend, value_length);
 
-          fprintf(stderr, "%s%*sTIMETICKS %d bytes %u\n", prefix, indent, "",
-	          value_length, (unsigned)integer);
+          fprintf(stderr, "%s%*sTIMETICKS %u bytes %d\n", prefix, indent, "",
+	          value_length, integer);
           break;
 
       case CUPS_ASN1_OCTET_STRING :
-          fprintf(stderr, "%s%*sOCTET STRING %d bytes \"%s\"\n", prefix,
+          fprintf(stderr, "%s%*sOCTET STRING %u bytes \"%s\"\n", prefix,
 	          indent, "", value_length,
 		  asn1_get_string(&buffer, bufend, value_length, string,
 				  sizeof(string)));
@@ -852,7 +849,7 @@ asn1_debug(const char    *prefix,	/* I - Prefix string */
       case CUPS_ASN1_HEX_STRING :
 	  asn1_get_string(&buffer, bufend, value_length, string,
 			  sizeof(string));
-          fprintf(stderr, "%s%*sHex-STRING %d bytes", prefix,
+          fprintf(stderr, "%s%*sHex-STRING %u bytes", prefix,
 	          indent, "", value_length);
           for (i = 0; i < value_length; i ++)
 	    fprintf(stderr, " %02X", string[i] & 255);
@@ -860,7 +857,7 @@ asn1_debug(const char    *prefix,	/* I - Prefix string */
           break;
 
       case CUPS_ASN1_NULL_VALUE :
-          fprintf(stderr, "%s%*sNULL VALUE %d bytes\n", prefix, indent, "",
+          fprintf(stderr, "%s%*sNULL VALUE %u bytes\n", prefix, indent, "",
 	          value_length);
 
 	  buffer += value_length;
@@ -870,7 +867,7 @@ asn1_debug(const char    *prefix,	/* I - Prefix string */
           integer = asn1_get_oid(&buffer, bufend, value_length, oid,
 	                         CUPS_SNMP_MAX_OID);
 
-          fprintf(stderr, "%s%*sOID %d bytes ", prefix, indent, "",
+          fprintf(stderr, "%s%*sOID %u bytes ", prefix, indent, "",
 	          value_length);
 	  for (i = 0; i < (unsigned)integer; i ++)
 	    fprintf(stderr, ".%d", oid[i]);
@@ -878,7 +875,7 @@ asn1_debug(const char    *prefix,	/* I - Prefix string */
           break;
 
       case CUPS_ASN1_SEQUENCE :
-          fprintf(stderr, "%s%*sSEQUENCE %d bytes\n", prefix, indent, "",
+          fprintf(stderr, "%s%*sSEQUENCE %u bytes\n", prefix, indent, "",
 	          value_length);
           asn1_debug(prefix, buffer, value_length, indent + 4);
 
@@ -886,7 +883,7 @@ asn1_debug(const char    *prefix,	/* I - Prefix string */
           break;
 
       case CUPS_ASN1_GET_NEXT_REQUEST :
-          fprintf(stderr, "%s%*sGet-Next-Request-PDU %d bytes\n", prefix,
+          fprintf(stderr, "%s%*sGet-Next-Request-PDU %u bytes\n", prefix,
 	          indent, "", value_length);
           asn1_debug(prefix, buffer, value_length, indent + 4);
 
@@ -894,7 +891,7 @@ asn1_debug(const char    *prefix,	/* I - Prefix string */
           break;
 
       case CUPS_ASN1_GET_REQUEST :
-          fprintf(stderr, "%s%*sGet-Request-PDU %d bytes\n", prefix, indent, "",
+          fprintf(stderr, "%s%*sGet-Request-PDU %u bytes\n", prefix, indent, "",
 	          value_length);
           asn1_debug(prefix, buffer, value_length, indent + 4);
 
@@ -902,7 +899,7 @@ asn1_debug(const char    *prefix,	/* I - Prefix string */
           break;
 
       case CUPS_ASN1_GET_RESPONSE :
-          fprintf(stderr, "%s%*sGet-Response-PDU %d bytes\n", prefix, indent,
+          fprintf(stderr, "%s%*sGet-Response-PDU %u bytes\n", prefix, indent,
 	          "", value_length);
           asn1_debug(prefix, buffer, value_length, indent + 4);
 
@@ -910,7 +907,7 @@ asn1_debug(const char    *prefix,	/* I - Prefix string */
           break;
 
       default :
-          fprintf(stderr, "%s%*sUNKNOWN(%x) %d bytes\n", prefix, indent, "",
+          fprintf(stderr, "%s%*sUNKNOWN(%x) %u bytes\n", prefix, indent, "",
 	          value_type, value_length);
 
 	  buffer += value_length;
@@ -1082,7 +1079,7 @@ asn1_decode_snmp(unsigned char *buffer,	/* I - Buffer */
  * 'asn1_encode_snmp()' - Encode a SNMP packet.
  */
 
-static int				/* O - Length on success, -1 on error */
+static ssize_t				/* O - Length on success, -1 on error */
 asn1_encode_snmp(unsigned char *buffer,	/* I - Buffer */
                  size_t        bufsize,	/* I - Size of buffer */
                  cups_snmp_t   *packet)	/* I - SNMP packet */
@@ -1217,7 +1214,7 @@ asn1_encode_snmp(unsigned char *buffer,	/* I - Buffer */
         break;
   }
 
-  return ((int)(bufptr - buffer));
+  return ((ssize_t)(bufptr - buffer));
 }
 
 
@@ -1248,7 +1245,7 @@ asn1_get_integer(
   }
 
   for (value = (**buffer & 0x80) ? ~0 : 0;
-       length > 0 && *buffer < bufend;
+       length && *buffer < bufend;
        length --, (*buffer) ++)
     value = ((value & 0xffffff) << 8) | **buffer;
 
@@ -1275,7 +1272,7 @@ asn1_get_length(unsigned char **buffer,	/* IO - Pointer in buffer */
 
   if (length & 128)
   {
-    int	count;				/* Number of bytes for length */
+    unsigned	count;				/* Number of bytes for length */
 
     if ((count = length & 127) > sizeof(unsigned))
     {
@@ -1288,7 +1285,7 @@ asn1_get_length(unsigned char **buffer,	/* IO - Pointer in buffer */
     }
 
     for (length = 0;
-	 count > 0 && *buffer < bufend;
+	 count && *buffer < bufend;
 	 count --, (*buffer) ++)
       length = (length << 8) | **buffer;
   }


### PR DESCRIPTION
This is safe to do since this function is not supposed to be exposed via the ABI, nor is there a pointer to this function, so as long as every other function in the file accommodates this change, nothing should happen.

In addition, depth is always 0 and only used for one debug print statement anyway, so we can and should remove it, instead of simply declaring it unused.