### PR TITLE
Fix passing wrong variable to cupsGetOption in testcups

### DIFF
--- a/cups/testcups.c
+++ b/cups/testcups.c
@@ -377,7 +377,7 @@ main(int  argc,				/* I - Number of command-line arguments */
 
   for (i = 0, dest_name = NULL; i < num_dests; i ++)
   {
-    if ((dval = cupsGetOption("printer-is-temporary", dests[i].num_options, dest[i].options)) != NULL && !strcmp(dval, "false"))
+    if ((dval = cupsGetOption("printer-is-temporary", dests[i].num_options, dests[i].options)) != NULL && !strcmp(dval, "false"))
     {
       dest_name = dests[i].name;
       break;


### PR DESCRIPTION
dest is a pointer to a struct, not the array, which is dests.

Honestly, I have no idea how this even compiled in the first place. Yes I know this is testcups, but still.