### PR TITLE
Support retrieving localizations from PPDs with cupsLocalizeDestValue()

### DIFF
--- a/cups/ppd-cache.c
+++ b/cups/ppd-cache.c
@@ -1353,7 +1353,8 @@ _ppdCacheCreateWithPPD(ppd_file_t *ppd)	/* I - PPD file */
       */
 
       snprintf(msg_id, sizeof(msg_id), "media-source.%s", pwg_name);
-      pwg_add_message(pc->strings, msg_id, choice->text);
+      ppd_attr = ppdLocalizeAttr(ppd, "InputSlot", choice->choice);
+      pwg_add_message(pc->strings, msg_id, ppd_attr ? ppd_attr->text : choice->text);
     }
   }
 
@@ -1424,7 +1425,8 @@ _ppdCacheCreateWithPPD(ppd_file_t *ppd)	/* I - PPD file */
       */
 
       snprintf(msg_id, sizeof(msg_id), "media-type.%s", pwg_name);
-      pwg_add_message(pc->strings, msg_id, choice->text);
+      ppd_attr = ppdLocalizeAttr(ppd, "MediaType", choice->choice);
+      pwg_add_message(pc->strings, msg_id, ppd_attr ? ppd_attr->text : choice->text);
     }
   }
 
@@ -1458,7 +1460,8 @@ _ppdCacheCreateWithPPD(ppd_file_t *ppd)	/* I - PPD file */
       */
 
       snprintf(msg_id, sizeof(msg_id), "output-bin.%s", pwg_keyword);
-      pwg_add_message(pc->strings, msg_id, choice->text);
+      ppd_attr = ppdLocalizeAttr(ppd, "OutputBin", choice->choice);
+      pwg_add_message(pc->strings, msg_id, ppd_attr ? ppd_attr->text : choice->text);
     }
   }
 
@@ -1934,7 +1937,8 @@ _ppdCacheCreateWithPPD(ppd_file_t *ppd)	/* I - PPD file */
       */
 
       snprintf(msg_id, sizeof(msg_id), "finishing-template.%s", choice->choice);
-      pwg_add_message(pc->strings, msg_id, choice->text);
+      ppd_attr = ppdLocalizeAttr(ppd, "cupsFinishingTemplate", choice->choice);
+      pwg_add_message(pc->strings, msg_id, ppd_attr ? ppd_attr->text : choice->text);
     }
   }
 

--- a/scheduler/printers.c
+++ b/scheduler/printers.c
@@ -4027,7 +4027,7 @@ load_ppd(cupsd_printer_t *p)		/* I - Printer */
     ippAddStrings(p->ppd_attrs, IPP_TAG_PRINTER, IPP_CONST_TAG(IPP_TAG_KEYWORD), "job-creation-attributes-supported", sizeof(job_creation_print) / sizeof(job_creation_print[0]), NULL, job_creation_print);
   }
 
-  if ((ppd = _ppdOpenFile(ppd_name, _PPD_LOCALIZATION_NONE)) != NULL)
+  if ((ppd = _ppdOpenFile(ppd_name, _PPD_LOCALIZATION_DEFAULT)) != NULL)
   {
    /*
     * Add make/model and other various attributes...


### PR DESCRIPTION
The first commit in this pull request makes cupsd include "printer-strings-uri" when listing its supported printer attributes. This makes the cupsLocalize* functions work when connected to the CUPS server (rather than directly to a printer). As a convenient side effect, it also makes ippeveprinter properly advertise the attribute.

The second commit updates .strings file creation to use localized names from PPDs when available for values of the "media-type", "media-source", "output-bin", and "finishing-template" attributes. This allows clients to retrieve localized names for these attributes using cupsLocalizeDestValue() instead of the legacy PPD API.  I've only tested it with "media-type", but the other three should work as well.