### PR TITLE
Include printer-strings-uri in printer attributes list

### DIFF
--- a/cups/ipp-support.c
+++ b/cups/ipp-support.c
@@ -1764,6 +1764,7 @@ ippCreateRequestedArray(ipp_t *request)	/* I - IPP request */
     "printer-state-change-time",
     "printer-state-message",
     "printer-state-reasons",
+    "printer-strings-uri",
     "printer-supply",
     "printer-supply-description",
     "printer-supply-info-uri",


### PR DESCRIPTION
Omitting it meant that ippeveprinter would always omit the attribute even when passed a strings file with the -S parameter.