### PR TITLE
Maybe we shouldn't output the password in fprintf

### DIFF
--- a/backend/ipp.c
+++ b/backend/ipp.c
@@ -2929,9 +2929,8 @@ password_cb(const char *prompt,		/* I - Prompt (not used) */
 
 
   fprintf(stderr, "DEBUG: password_cb(prompt=\"%s\", http=%p, method=\"%s\", "
-                  "resource=\"%s\", password_tries=%p(%d)), password=%p\n",
-          prompt, http, method, resource, password_tries, *password_tries,
-          password);
+                  "resource=\"%s\", password_tries=%p(%d))\n",
+          prompt, http, method, resource, password_tries, *password_tries);
 
   (void)prompt;
   (void)method;


### PR DESCRIPTION
I don't see why we should know the address of the password, even in a debug context