### PR TITLE
Use XOR for integers that are always 1 or 0

### DIFF
--- a/cups/ppd.c
+++ b/cups/ppd.c
@@ -651,8 +651,8 @@ _ppdOpen(
   while ((mask = ppd_read(fp, &line, keyword, name, text, &string, 1, pg)) != 0)
   {
     DEBUG_printf(("2_ppdOpen: mask=%x, keyword=\"%s\", name=\"%s\", "
-                  "text=\"%s\", string=%d chars...", mask, keyword, name, text,
-		  string ? (int)strlen(string) : 0));
+                  "text=\"%s\", string=%u chars...", mask, keyword, name, text,
+		  string ? (unsigned)strlen(string) : 0));
 
     if (strncmp(keyword, "Default", 7) && !string &&
         pg->ppd_conform != PPD_CONFORM_RELAXED)
@@ -3075,7 +3075,7 @@ ppd_read(cups_file_t    *fp,		/* I - File to read from */
 	  colon = 1;
 
 	if (ch == '\"' && colon)
-	  endquote = !endquote;
+	  endquote ^= 1;
       }
     }
 

--- a/man/mantohtml.c
+++ b/man/mantohtml.c
@@ -75,28 +75,26 @@ main(int  argc,				/* I - Number of command-line args */
   * Open files as needed...
   */
 
-  if (argc > 1)
+  if (argc == 0)
   {
-    if ((infile = fopen(argv[1], "r")) == NULL)
-    {
-      perror(argv[1]);
-      return (1);
-    }
-  }
-  else
     infile = stdin;
-
-  if (argc > 2)
-  {
-    if ((outfile = fopen(argv[2], "w")) == NULL)
-    {
-      perror(argv[2]);
-      fclose(infile);
-      return (1);
-    }
   }
-  else
+  else if ((infile = fopen(argv[1], "r")) == NULL)
+  {
+    perror(argv[1]);
+    return (1);
+  }
+
+  if (argc != 3)
+  {
     outfile = stdout;
+  }
+  else if ((outfile = fopen(argv[2], "w")) == NULL)
+  {
+    perror(argv[2]);
+    fclose(infile);
+    return (1);
+  }
 
  /*
   * Read from input and write the output...
@@ -967,7 +965,7 @@ html_alternate(const char *s,		/* I - String */
     while ((!isspace(*s & 255) || quote) && *s)
     {
       if (*s == '\"')
-        quote = !quote;
+        quote ^= 1;
 
       if (*s == '\\' && s[1])
       {
@@ -989,7 +987,7 @@ html_alternate(const char *s,		/* I - String */
       link = 0;
     }
 
-    i = 1 - i;
+    i ^= 1;
 
    /*
     * Skip trailing whitespace...

--- a/scheduler/cups-driverd.cxx
+++ b/scheduler/cups-driverd.cxx
@@ -1978,7 +1978,6 @@ load_ppd(const char  *filename,		/* I - Real filename */
   cups_array_t	*products,		/* Product array */
 		*psversions,		/* PSVersion array */
 		*cups_languages;	/* cupsLanguages array */
-  int		new_ppd;		/* Is this a new PPD? */
   struct				/* LanguageVersion translation table */
   {
     const char	*version,		/* LanguageVersion string */
@@ -2278,9 +2277,7 @@ load_ppd(const char  *filename,		/* I - Real filename */
   * Record the PPD file...
   */
 
-  new_ppd = !ppd;
-
-  if (new_ppd)
+  if (!ppd)
   {
    /*
     * Add new PPD file...

--- a/scheduler/cupsfilter.c
+++ b/scheduler/cupsfilter.c
@@ -856,8 +856,7 @@ exec_filter(const char *filter,		/* I - Filter to execute */
 #if defined(__APPLE__)
   char		processPath[1024],	/* CFProcessPath environment variable */
 		linkpath[1024];		/* Link path for symlinks... */
-  int		linkbytes;		/* Bytes for link path */
-
+  ssize_t		linkbytes;		/* Bytes for link path */
 
  /*
   * Add special voodoo magic for macOS - this allows macOS
@@ -963,7 +962,7 @@ exec_filters(mime_type_t   *srctype,	/* I - Source type */
              int           num_options,	/* I - Number of filter options */
 	     cups_option_t *options)	/* I - Filter options */
 {
-  int		i;			/* Looping var */
+  unsigned		i;			/* Looping var */
   const char	*argv[8],		/* Command-line arguments */
 		*envp[21],		/* Environment variables */
 		*temp;			/* Temporary string */
@@ -1115,7 +1114,7 @@ exec_filters(mime_type_t   *srctype,	/* I - Source type */
     argv[4] = "1";
 
   for (i = 0; argv[i]; i ++)
-    fprintf(stderr, "DEBUG: argv[%d]=\"%s\"\n", i, argv[i]);
+    fprintf(stderr, "DEBUG: argv[%u]=\"%s\"\n", i, argv[i]);
 
   i = 0;
 #ifdef __APPLE__
@@ -1163,25 +1162,22 @@ exec_filters(mime_type_t   *srctype,	/* I - Source type */
   envp[i] = NULL;
 
   for (i = 0; envp[i]; i ++)
-    fprintf(stderr, "DEBUG: envp[%d]=\"%s\"\n", i, envp[i]);
+    fprintf(stderr, "DEBUG: envp[%u]=\"%s\"\n", i, envp[i]);
 
  /*
   * Execute all of the filters...
   */
 
   pids            = cupsArrayNew((cups_array_func_t)compare_pids, NULL);
-  current         = 0;
-  filterfds[0][0] = -1;
+  current         = 1;
+  filterfds[0][0] = infile ? -1 : 0;
   filterfds[0][1] = -1;
   filterfds[1][0] = -1;
   filterfds[1][1] = -1;
 
-  if (!infile)
-    filterfds[0][0] = 0;
-
   for (filter = (mime_filter_t *)cupsArrayFirst(filters);
        filter;
-       filter = next, current = 1 - current)
+       filter = next, current ^= 1)
   {
     next = (mime_filter_t *)cupsArrayNext(filters);
 
@@ -1191,31 +1187,31 @@ exec_filters(mime_type_t   *srctype,	/* I - Source type */
       snprintf(program, sizeof(program), "%s/filter/%s", ServerBin,
 	       filter->filter);
 
-    if (filterfds[!current][1] > 1)
+    if (filterfds[current][1] > 1)
     {
-      close(filterfds[1 - current][0]);
-      close(filterfds[1 - current][1]);
+      close(filterfds[current][0]);
+      close(filterfds[current][1]);
 
-      filterfds[1 - current][0] = -1;
-      filterfds[1 - current][1] = -1;
+      filterfds[current][0] = -1;
+      filterfds[current][1] = -1;
     }
 
     if (next)
-      open_pipe(filterfds[1 - current]);
+      open_pipe(filterfds[current]);
     else if (outfile)
     {
-      filterfds[1 - current][1] = open(outfile, O_CREAT | O_TRUNC | O_WRONLY,
-                                       0666);
+      filterfds[current][1] = open(outfile, O_CREAT | O_TRUNC | O_WRONLY,
+                                   0666);
 
-      if (filterfds[1 - current][1] < 0)
+      if (filterfds[current][1] < 0)
         fprintf(stderr, "ERROR: Unable to create \"%s\" - %s\n", outfile,
 	        strerror(errno));
     }
     else
-      filterfds[1 - current][1] = 1;
+      filterfds[current][1] = 1;
 
     pid = exec_filter(program, (char **)argv, (char **)envp,
-                      filterfds[current][0], filterfds[1 - current][1]);
+                      filterfds[current ^ 1][0], filterfds[current][1]);
 
     if (pid > 0)
     {

--- a/scheduler/job.c
+++ b/scheduler/job.c
@@ -1201,12 +1201,12 @@ cupsdContinueJob(cupsd_job_t *job)	/* I - Job */
       filterfds[slot][1] = job->print_pipes[1];
     }
 
-    pid = cupsdStartProcess(command, argv, envp, filterfds[!slot][0],
+    pid = cupsdStartProcess(command, argv, envp, filterfds[slot ^ 1][0],
                             filterfds[slot][1], job->status_pipes[1],
 		            job->back_pipes[0], job->side_pipes[0], 0,
 			    job->profile, job, job->filters + i);
 
-    cupsdClosePipe(filterfds[!slot]);
+    cupsdClosePipe(filterfds[slot ^ 1]);
 
     if (pid == 0)
     {
@@ -1228,7 +1228,7 @@ cupsdContinueJob(cupsd_job_t *job)	/* I - Job */
       argv[6] = NULL;
     }
 
-    slot = !slot;
+    slot ^= 1;
   }
 
   cupsArrayDelete(filters);
@@ -1262,7 +1262,7 @@ cupsdContinueJob(cupsd_job_t *job)	/* I - Job */
       filterfds[slot][0] = -1;
       filterfds[slot][1] = -1;
 
-      pid = cupsdStartProcess(command, argv, envp, filterfds[!slot][0],
+      pid = cupsdStartProcess(command, argv, envp, filterfds[slot ^ 1][0],
 			      filterfds[slot][1], job->status_pipes[1],
 			      job->back_pipes[1], job->side_pipes[1],
 			      backroot, job->bprofile, job, &(job->backend));
@@ -1338,8 +1338,8 @@ cupsdContinueJob(cupsd_job_t *job)	/* I - Job */
   FilterLevel -= job->cost;
   job->cost = 0;
 
-  for (slot = 0; slot < 2; slot ++)
-    cupsdClosePipe(filterfds[slot]);
+  cupsdClosePipe(filterfds[0]);
+  cupsdClosePipe(filterfds[1]);
 
   cupsArrayDelete(filters);
 

--- a/tools/ippfind.c
+++ b/tools/ippfind.c
@@ -1803,7 +1803,7 @@ eval_expr(ippfind_srv_t  *service,	/* I - Service */
           result = service->is_local;
           break;
       case IPPFIND_OP_IS_REMOTE :
-          result = !service->is_local;
+          result = service->is_local ^ 1;
           break;
       case IPPFIND_OP_DOMAIN_REGEX :
           result = !regexec(&(expression->re), service->domain, 0, NULL, 0);
@@ -1863,7 +1863,7 @@ eval_expr(ippfind_srv_t  *service,	/* I - Service */
     }
 
     if (expression->invert)
-      result = !result;
+      result ^= 1;
 
     if (logic == IPPFIND_OP_AND && !result)
       return (0);

--- a/vcnet/config.h
+++ b/vcnet/config.h
@@ -100,8 +100,8 @@ typedef unsigned long useconds_t;
  * Version of software...
  */
 
-#define CUPS_SVERSION "CUPS v2.4.2"
-#define CUPS_MINIMAL "CUPS/2.4.2"
+#define CUPS_SVERSION "CUPS v2.4.3"
+#define CUPS_MINIMAL "CUPS/2.4.3"
 
 
 /*

--- a/vcnet/libcups2_native.nuspec
+++ b/vcnet/libcups2_native.nuspec
@@ -3,7 +3,7 @@
     <metadata>
         <id>libcups2_native</id>
         <title>OpenPrinting CUPS Library for VS2019+</title>
-        <version>2.4.3.4</version>
+        <version>2.4.3.5</version>
         <authors>Michael R Sweet, OpenPrinting</authors>
         <owners>michaelrsweet</owners>
         <projectUrl>https://github.com/OpenPrinting/cups</projectUrl>
@@ -16,7 +16,7 @@ and other Unix®-like operating systems. The CUPS library provides a convenient 
         <copyright>Copyright © 2020-2022 by OpenPrinting, Copyright © 2007-2019 by Apple Inc., Copyright © 1997-2007 by Easy Software Products.</copyright>
         <tags>http ipp native</tags>
 	<dependencies>
-	    <dependency id="libcups2_native.redist" version="2.4.3.4" />
+	    <dependency id="libcups2_native.redist" version="2.4.3.5" />
 	</dependencies>
     </metadata>
     <files>

--- a/vcnet/libcups2_native.redist.nuspec
+++ b/vcnet/libcups2_native.redist.nuspec
@@ -3,7 +3,7 @@
     <metadata>
         <id>libcups2_native.redist</id>
         <title>OpenPrinting CUPS Library for VS2019+ Redist</title>
-        <version>2.4.3.4</version>
+        <version>2.4.3.5</version>
         <authors>Michael R Sweet, OpenPrinting</authors>
         <owners>michaelrsweet</owners>
         <projectUrl>https://github.com/OpenPrinting/cups</projectUrl>


### PR DESCRIPTION
1 - current, !current, and 1 ^ current have the same effect, even if they are not equivalent, since current simply alternates between 1 and 0. So by starting current at 1 instead of 0, and using ^1 to alternate, we could more efficiently execute filters.