### PR TITLE
Fix cupsEncodeOptions2 recursive call for collections

### DIFF
--- a/cups/encode.c
+++ b/cups/encode.c
@@ -653,7 +653,7 @@ _cupsEncodeOption(
 	  }
 
 	  ippSetCollection(ipp, &attr, i, collection);
-	  cupsEncodeOptions2(collection, num_cols, cols, IPP_TAG_JOB);
+	  cupsEncodeOptions2(collection, num_cols, cols, group_tag);
 	  cupsFreeOptions(num_cols, cols);
 	  ippDelete(collection);
 	  break;


### PR DESCRIPTION
`IPP_TAG_JOB` is hardcoded here. Shouldn't the current `group_tag` be passed instead?