### PR TITLE
Improve state handling in cases of memory allocation failure

### DIFF
--- a/cups/globals.c
+++ b/cups/globals.c
@@ -180,7 +180,7 @@ DllMain(HINSTANCE hinst,		/* I - DLL module handle */
 static _cups_globals_t *		/* O - Pointer to global data */
 cups_globals_alloc(void)
 {
-  _cups_globals_t *cg = malloc(sizeof(_cups_globals_t));
+  _cups_globals_t *cg = calloc(1, sizeof(_cups_globals_t));
 					/* Pointer to global data */
 #ifdef _WIN32
   HKEY		key;			/* Registry key */
@@ -200,7 +200,6 @@ cups_globals_alloc(void)
   * callback values...
   */
 
-  memset(cg, 0, sizeof(_cups_globals_t));
   cg->encryption     = (http_encryption_t)-1;
   cg->password_cb    = (cups_password_cb2_t)_cupsGetPassword;
   cg->trust_first    = -1;

--- a/filter/rastertopwg.c
+++ b/filter/rastertopwg.c
@@ -152,6 +152,23 @@ main(int  argc,				/* I - Number of command-line args */
       return (1);
     }
 
+    if (inheader.cupsColorOrder != CUPS_ORDER_CHUNKED)
+    {
+      _cupsLangPrintFilter(stderr, "ERROR", _("Unsupported raster data."));
+      fprintf(stderr, "DEBUG: Unsupported cupsColorOrder %d on page %d.\n",
+              inheader.cupsColorOrder, page);
+      return (1);
+    }
+
+    if (inheader.cupsBitsPerPixel != 1 &&
+        inheader.cupsBitsPerColor != 8 && inheader.cupsBitsPerColor != 16)
+    {
+      _cupsLangPrintFilter(stderr, "ERROR", _("Unsupported raster data."));
+      fprintf(stderr, "DEBUG: Unsupported cupsBitsPerColor %d on page %d.\n",
+              inheader.cupsBitsPerColor, page);
+      return (1);
+    }
+
     switch (inheader.cupsColorSpace)
     {
       case CUPS_CSPACE_W :
@@ -187,23 +204,6 @@ main(int  argc,				/* I - Number of command-line args */
 	  fprintf(stderr, "DEBUG: Unsupported cupsColorSpace %d on page %d.\n",
 	          inheader.cupsColorSpace, page);
 	  return (1);
-    }
-
-    if (inheader.cupsColorOrder != CUPS_ORDER_CHUNKED)
-    {
-      _cupsLangPrintFilter(stderr, "ERROR", _("Unsupported raster data."));
-      fprintf(stderr, "DEBUG: Unsupported cupsColorOrder %d on page %d.\n",
-              inheader.cupsColorOrder, page);
-      return (1);
-    }
-
-    if (inheader.cupsBitsPerPixel != 1 &&
-        inheader.cupsBitsPerColor != 8 && inheader.cupsBitsPerColor != 16)
-    {
-      _cupsLangPrintFilter(stderr, "ERROR", _("Unsupported raster data."));
-      fprintf(stderr, "DEBUG: Unsupported cupsBitsPerColor %d on page %d.\n",
-              inheader.cupsBitsPerColor, page);
-      return (1);
     }
 
     memcpy(&outheader, &inheader, sizeof(outheader));

--- a/scheduler/auth.c
+++ b/scheduler/auth.c
@@ -1612,7 +1612,6 @@ cupsdIsAuthorized(cupsd_client_t *con,	/* I - Connection */
   }
   else
 #endif /* AF_INET6 */
-  if (con->http->hostaddr->addr.sa_family == AF_INET)
   {
    /*
     * Copy IPv4 address...
@@ -1621,10 +1620,8 @@ cupsdIsAuthorized(cupsd_client_t *con,	/* I - Connection */
     address[0] = 0;
     address[1] = 0;
     address[2] = 0;
-    address[3] = ntohl(hostaddr->ipv4.sin_addr.s_addr);
+    address[3] = (con->http->hostaddr->addr.sa_family == AF_INET) ? ntohl(hostaddr->ipv4.sin_addr.s_addr) : 0;
   }
-  else
-    memset(address, 0, sizeof(address));
 
   hostlen = strlen(hostname);
 

--- a/scheduler/ipp.c
+++ b/scheduler/ipp.c
@@ -1165,11 +1165,21 @@ add_file(cupsd_client_t *con,		/* I - Connection to client */
 
   if (compressions)
     job->compressions = compressions;
+  else
+  {
+    cupsdSetJobState(job, IPP_JOB_ABORTED, CUPSD_JOB_PURGE,
+                     "Job aborted because the scheduler ran out of memory.");
+
+    if (con)
+      send_ipp_status(con, IPP_INTERNAL_ERROR,
+                      _("Unable to allocate memory for file types."));
+
+    return (-1);
+  }
 
   if (filetypes)
     job->filetypes = filetypes;
-
-  if (!compressions || !filetypes)
+  else
   {
     cupsdSetJobState(job, IPP_JOB_ABORTED, CUPSD_JOB_PURGE,
                      "Job aborted because the scheduler ran out of memory.");

--- a/tools/ippfind.c
+++ b/tools/ippfind.c
@@ -2505,6 +2505,9 @@ new_expr(ippfind_op_t op,		/* I - Operation */
 
      temp->num_args = num_args;
      temp->args     = malloc((size_t)num_args * sizeof(char *));
+     if (temp->args == NULL)
+         return (NULL);
+
      memcpy(temp->args, args, (size_t)num_args * sizeof(char *));
   }
 


### PR DESCRIPTION
Many lines of code assume that malloc will not fail. In cases where it does, sometimes the program does not know, and as a result, memory can leak and more disastrous consequences can happen before the program ultimately finds something is wrong and then calls exit();

This PR aims to better handle memory in these cases