### PR TITLE
Change strncmp parameter

### DIFF
--- a/cups/ppd-cache.c
+++ b/cups/ppd-cache.c
@@ -4160,7 +4160,7 @@ _ppdCreateFromIPP2(
 
 	PRINTF_COLOROPTION("Gray16", _("Deep Gray"), CUPS_CSPACE_SW, 16)
       }
-      else if (!strcasecmp(keyword, "srgb_8") || !strncmp(keyword, "SRGB24", 7) || !strcmp(keyword, "color"))
+      else if (!strcasecmp(keyword, "srgb_8") || !strncmp(keyword, "SRGB24", 6) || !strcmp(keyword, "color"))
       {
 	PRINTF_COLORMODEL
 


### PR DESCRIPTION
Either the parameter being passed should be 6, not 7, because of the null terminator in the string literal, or strcmp should be used instead.