### PR TITLE
Remove pointless casts

### DIFF
--- a/cups/file.c
+++ b/cups/file.c
@@ -2306,7 +2306,7 @@ cups_fill(cups_file_t *fp)		/* I - CUPS file */
 	  return (-1);
 	}
 
-	bytes = ((unsigned char)ptr[1] << 8) | (unsigned char)ptr[0];
+	bytes = (ptr[1] << 8) | ptr[0];
 	ptr   += 2 + bytes;
 
 	if (ptr > end)

--- a/cups/http.c
+++ b/cups/http.c
@@ -729,7 +729,7 @@ httpFreeCredentials(
        credential = (http_credential_t *)cupsArrayNext(credentials))
   {
     cupsArrayRemove(credentials, credential);
-    free((void *)credential->data);
+    free(credential->data);
     free(credential);
   }
 
@@ -3266,9 +3266,9 @@ httpWrite2(http_t     *http,		/* I - HTTP connection */
                     CUPS_LLCAST length));
 
       if (http->data_encoding == HTTP_ENCODING_CHUNKED)
-	bytes = (ssize_t)http_write_chunk(http, buffer, length);
+	bytes = http_write_chunk(http, buffer, length);
       else
-	bytes = (ssize_t)http_write(http, buffer, length);
+	bytes = http_write(http, buffer, length);
 
       DEBUG_printf(("2httpWrite2: Wrote " CUPS_LLFMT " bytes...",
                     CUPS_LLCAST bytes));

--- a/cups/ipp-file.c
+++ b/cups/ipp-file.c
@@ -692,11 +692,11 @@ parse_value(_ipp_file_t      *f,	/* I  - IPP data file */
 		yres;		/* Y resolution */
 	  char	*ptr;		/* Pointer into value */
 
-	  xres = yres = (int)strtol(value, (char **)&ptr, 10);
+	  xres = yres = (int)strtol(value, &ptr, 10);
 	  if (ptr > value && xres > 0)
 	  {
 	    if (*ptr == 'x')
-	      yres = (int)strtol(ptr + 1, (char **)&ptr, 10);
+	      yres = (int)strtol(ptr + 1, &ptr, 10);
 	  }
 
 	  if (ptr <= value || xres <= 0 || yres <= 0 || !ptr || (_cups_strcasecmp(ptr, "dpi") && _cups_strcasecmp(ptr, "dpc") && _cups_strcasecmp(ptr, "dpcm") && _cups_strcasecmp(ptr, "other")))

--- a/cups/raster-interpret.c
+++ b/cups/raster-interpret.c
@@ -353,10 +353,10 @@ _cupsRasterInterpretPPD(
                                         h->cupsBorderlessScalingFactor);
   h->ImagingBoundingBox[3] = (unsigned)(top *
                                         h->cupsBorderlessScalingFactor);
-  h->cupsImagingBBox[0]    = (float)left;
-  h->cupsImagingBBox[1]    = (float)bottom;
-  h->cupsImagingBBox[2]    = (float)right;
-  h->cupsImagingBBox[3]    = (float)top;
+  h->cupsImagingBBox[0]    = left;
+  h->cupsImagingBBox[1]    = bottom;
+  h->cupsImagingBBox[2]    = right;
+  h->cupsImagingBBox[3]    = top;
 
  /*
   * Use the callback to validate the page header...

--- a/cups/raster-stream.c
+++ b/cups/raster-stream.c
@@ -693,8 +693,8 @@ _cupsRasterReadHeader(
 
           if (r->header.HWResolution[0] > 0)
           {
-	    r->header.PageSize[0]     = (unsigned)(r->header.cupsWidth * 72 / r->header.HWResolution[0]);
-	    r->header.PageSize[1]     = (unsigned)(r->header.cupsHeight * 72 / r->header.HWResolution[1]);
+	    r->header.PageSize[0]     = (r->header.cupsWidth * 72 / r->header.HWResolution[0]);
+	    r->header.PageSize[1]     = (r->header.cupsHeight * 72 / r->header.HWResolution[1]);
 	    r->header.cupsPageSize[0] = (float)(r->header.cupsWidth * 72.0 / r->header.HWResolution[0]);
 	    r->header.cupsPageSize[1] = (float)(r->header.cupsHeight * 72.0 / r->header.HWResolution[1]);
           }


### PR DESCRIPTION
These variables were already in the target type anyway, or implicitly converted to void *.