### PR TITLE
Increase log level for "Expiring subscriptions..."

### DIFF
--- a/scheduler/subscriptions.c
+++ b/scheduler/subscriptions.c
@@ -621,7 +621,7 @@ cupsdExpireSubscriptions(
   curtime = time(NULL);
   update  = 0;
 
-  cupsdLogMessage(CUPSD_LOG_INFO, "Expiring subscriptions...");
+  cupsdLogMessage(CUPSD_LOG_DEBUG, "Expiring subscriptions...");
 
   for (sub = (cupsd_subscription_t *)cupsArrayFirst(Subscriptions);
        sub;


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/195090.

NixOS systems with Avahi enabled would previously spam the journal with
this log message once a second: this hides that spam behind the log level.