### PR TITLE
PPD for driverless IPP: Poll "media-col-database" separately if needed

### DIFF
--- a/scheduler/ipp.c
+++ b/scheduler/ipp.c
@@ -5392,7 +5392,7 @@ create_local_bg_thread(
   if (ippFindAttribute(response, "media-col-database", IPP_TAG_ZERO) ==
       NULL)
   {
-    ipp_t *response2 = NULL;
+    ipp_t *response2;
 
     cupsdLogMessage(CUPSD_LOG_DEBUG,
 		    "Polling \"media-col-database\" attribute separately.");


### PR DESCRIPTION
In the create_local_bg_thread() function for auto-generating a PPD file for a CUPS queue for a driverless printer, either via the "everywhere" model selection or an auto-created temporary queue we need to query the full capabilities information from the printer.

To get the full set of printer properties from a driverless IPP printer one does a "get-printer-attributes" IPP request with the attribute "requested-attributes" set to "all,media-col-database" (note that "all" does not include "media-col-database" because this attribute is often very long, it contains all valid combinations of media size, media type, media source, and margins). For some printers this fails and we fall back to just "all" and lose valuable information.

But some of those printers which do not support "requested-attributes" set to "all,media-col-database" support "requested-attributes" set to "media-col-database" alone and this we now make use of, by polling "media-col-database" separately and adding it to the IPP response of "all" if needed.

We discovered such a printer here:

    https://github.com/OpenPrinting/cups-filters/issues/492