### PR TITLE
Fix UB in cups_raster_read debug message

### DIFF
--- a/cups/raster-stream.c
+++ b/cups/raster-stream.c
@@ -1409,7 +1409,7 @@ cups_raster_read(cups_raster_t *r,	/* I - Raster stream */
 		total;			/* Total bytes read */
 
 
-  DEBUG_printf(("4cups_raster_read(r=%p, buf=%p, bytes=" CUPS_LLFMT "), offset=" CUPS_LLFMT, (void *)r, (void *)buf, CUPS_LLCAST bytes, CUPS_LLCAST (r->iostart + r->bufptr - r->buffer)));
+  DEBUG_printf(("4cups_raster_read(r=%p, buf=%p, bytes=" CUPS_LLFMT "), offset=" CUPS_LLFMT, (void *)r, (void *)buf, CUPS_LLCAST bytes, CUPS_LLCAST (r->iostart + (ssize_t)(r->bufptr - r->buffer))));
 
   if (!r->compressed)
     return (cups_raster_io(r, buf, bytes));


### PR DESCRIPTION
The first time `cups_raster_read` is called, both `r->bufptr` and `r->buffer` are NULL.  The calculation here then ends up looking like adding a size_t to a NULL pointer, which triggers the ubsan detector. Since we just want an offset, cast the pointer difference to ssize_t like the code already does a few lines below.