### PR TITLE
cups/http-addr.c: Set listen backlog size to INT_MAX

### DIFF
--- a/cups/http-addr.c
+++ b/cups/http-addr.c
@@ -249,7 +249,7 @@ httpAddrListen(http_addr_t *addr,	/* I - Address to bind to */
   * Listen...
   */
 
-  if (listen(fd, 128))
+  if (listen(fd, INT_MAX))
   {
     _cupsSetHTTPError(HTTP_STATUS_ERROR);
 


### PR DESCRIPTION
Use a listen queue size of INT_MAX, which should default to the maximum supported queue size on the system.

This avoids the problem of the listening backlog queue getting full when there are too many requests at the same time. The problem was observed with the previous backlog size (128) by customers when submitting large batches of print jobs, resulting in some jobs getting lost.