### PR TITLE
ippeveprinter.c: Check the created `path` string instead of `command`

### DIFF
--- a/tools/ippeveprinter.c
+++ b/tools/ippeveprinter.c
@@ -1634,9 +1634,9 @@ create_printer(
     {
       snprintf(path, sizeof(path), "%s/command/%s", cg->cups_serverbin, command);
 
-      if (access(command, X_OK))
+      if (access(path, X_OK))
       {
-        _cupsLangPrintf(stderr, _("Unable to execute command \"%s\": %s"), command, strerror(errno));
+        _cupsLangPrintf(stderr, _("Unable to execute command \"%s\": %s"), path, strerror(errno));
 	return (NULL);
       }
 


### PR DESCRIPTION
If a user passes the command by only its name, we have to check the path string we created instead of command string alone.