### PR TITLE
Prefer atof over strtod

### DIFF
--- a/cgi-bin/admin.c
+++ b/cgi-bin/admin.c
@@ -3510,8 +3510,8 @@ get_option_value(
     uval = cgiGetVariable("PageSize.Units");
 
     if (!val || !lval || !uval ||
-        (width = strtod(val, NULL)) == 0.0 ||
-        (length = strtod(lval, NULL)) == 0.0 ||
+        (width = atof(val)) == 0.0 ||
+        (length = atof(lval)) == 0.0 ||
         (strcmp(uval, "pt") && strcmp(uval, "in") && strcmp(uval, "ft") &&
 	 strcmp(uval, "cm") && strcmp(uval, "mm") && strcmp(uval, "m")))
       return (NULL);
@@ -3543,7 +3543,7 @@ get_option_value(
       case PPD_CUSTOM_CURVE :
       case PPD_CUSTOM_INVCURVE :
       case PPD_CUSTOM_REAL :
-	  if ((number = strtod(val, NULL)) == 0.0 ||
+	  if ((number = atof(val)) == 0.0 ||
 	      number < cparam->minimum.custom_real ||
 	      number > cparam->maximum.custom_real)
 	    return (NULL);
@@ -3564,7 +3564,7 @@ get_option_value(
       case PPD_CUSTOM_POINTS :
           snprintf(keyword, sizeof(keyword), "%s.Units", coption->keyword);
 
-	  if ((number = strtod(val, NULL)) == 0.0 ||
+	  if ((number = atof(val)) == 0.0 ||
 	      (uval = cgiGetVariable(keyword)) == NULL ||
 	      (strcmp(uval, "pt") && strcmp(uval, "in") && strcmp(uval, "ft") &&
 	       strcmp(uval, "cm") && strcmp(uval, "mm") && strcmp(uval, "m")))
@@ -3624,7 +3624,7 @@ get_option_value(
 	case PPD_CUSTOM_CURVE :
 	case PPD_CUSTOM_INVCURVE :
 	case PPD_CUSTOM_REAL :
-	    if ((number = strtod(val, NULL)) == 0.0 ||
+	    if ((number = atof(val)) == 0.0 ||
 		number < cparam->minimum.custom_real ||
 		number > cparam->maximum.custom_real)
 	      return (NULL);
@@ -3645,7 +3645,7 @@ get_option_value(
 	case PPD_CUSTOM_POINTS :
 	    snprintf(keyword, sizeof(keyword), "%s.Units", coption->keyword);
 
-	    if ((number = strtod(val, NULL)) == 0.0 ||
+	    if ((number = atof(val)) == 0.0 ||
 		(uval = cgiGetVariable(keyword)) == NULL ||
 		(strcmp(uval, "pt") && strcmp(uval, "in") &&
 		 strcmp(uval, "ft") && strcmp(uval, "cm") &&

--- a/cups/string.c
+++ b/cups/string.c
@@ -517,7 +517,7 @@ _cupsStrScand(const char   *buf,	/* I - Pointer to number */
 
   *tempptr = '\0';
 
-  return (strtod(temp, NULL));
+  return (atof(temp));
 }
 
 

--- a/man/mantohtml.c
+++ b/man/mantohtml.c
@@ -506,7 +506,7 @@ main(int  argc,				/* I - Number of command-line args */
         * Indent...
 	*/
 
-	float amount = 3.0;		/* Indentation */
+	float amount = 3.0f;		/* Indentation */
 
         if (line[3])
           amount = (float)atof(line + 4);
@@ -552,7 +552,7 @@ main(int  argc,				/* I - Number of command-line args */
         * .HP i
 	*/
 
-	float amount = 3.0;		/* Indentation */
+	float amount = 3.0f;		/* Indentation */
 
         if (line[3])
           amount = (float)atof(line + 4);
@@ -585,10 +585,10 @@ main(int  argc,				/* I - Number of command-line args */
         * .TP i
 	*/
 
-	float amount = 3.0;		/* Indentation */
+	float amount = 3.0f;		/* Indentation */
 
         if (line[3])
-          amount = (float)atof(line + 4);
+          amount = (float)atof(line + 4, NULL);
 
 	fputs(end_fonts[font], outfile);
 	font = 0;
@@ -624,7 +624,7 @@ main(int  argc,				/* I - Number of command-line args */
         * .IP x i
 	*/
 
-        float amount = 3.0;		/* Indentation */
+        float amount = 3.0f;		/* Indentation */
         const char *newlist = NULL;	/* New list style */
         const char *newtype = NULL;	/* New list numbering type */
 


### PR DESCRIPTION
This is much simpler to call over strtod and is supported on more older platforms.