### PR TITLE
Free memory leaked by Darwin's Core Foundation

### DIFF
--- a/cups/tls-darwin.c
+++ b/cups/tls-darwin.c
@@ -899,10 +899,8 @@ void
 _httpFreeCredentials(
     http_tls_credentials_t credentials)	/* I - Internal credentials */
 {
-  if (!credentials)
-    return;
-
-  CFRelease(credentials);
+  if (credentials)
+    CFRelease(credentials);
 }
 
 
@@ -1671,9 +1669,10 @@ _httpTLSStart(http_t *http)		/* I - HTTP connection */
 	    if (cg->client_cert_cb)
 	    {
 	      names = NULL;
-	      if (!(error = SSLCopyDistinguishedNames(http->tls, &dn_array)) &&
-		  dn_array)
-	      {
+        error = SSLCopyDistinguishedNames(http->tls, &dn_array);
+        if (dn_array)
+        {
+          if (!error) {
 		if ((names = cupsArrayNew(NULL, NULL)) != NULL)
 		{
 		  for (i = 0, count = CFArrayGetCount(dn_array); i < count; i++)
@@ -1694,9 +1693,9 @@ _httpTLSStart(http_t *http)		/* I - HTTP connection */
 		    }
 		  }
 		}
-
-		CFRelease(dn_array);
 	      }
+		CFRelease(dn_array);
+        }
 
 	      if (!error)
 	      {
@@ -1792,12 +1791,13 @@ _httpTLSStop(http_t *http)		/* I - HTTP connection */
     usleep(1000);
 
   CFRelease(http->tls);
+  http->tls = NULL;
 
   if (http->tls_credentials)
+  {
     CFRelease(http->tls_credentials);
-
-  http->tls             = NULL;
-  http->tls_credentials = NULL;
+    http->tls_credentials = NULL;
+  }
 }
 
 

--- a/ppdc/ppdc-catalog.cxx
+++ b/ppdc/ppdc-catalog.cxx
@@ -107,13 +107,14 @@ ppdcCatalog::ppdcCatalog(const char *l,	// I - Locale
 
 	plist = CFPropertyListCreateWithStream(kCFAllocatorDefault, stream, 0, kCFPropertyListImmutable, NULL, NULL);
 
-	if (plist && CFGetTypeID(plist) == CFDictionaryGetTypeID())
-	  CFDictionaryApplyFunction((CFDictionaryRef)plist, (CFDictionaryApplierFunction)apple_add_message, this);
+  if (plist)
+  {
+    if (CFGetTypeID(plist) == CFDictionaryGetTypeID())
+      CFDictionaryApplyFunction((CFDictionaryRef)plist, (CFDictionaryApplierFunction)apple_add_message, this);
+    CFRelease(plist);
+  }
 
-	if (plist)
-	  CFRelease(plist);
-
-	CFRelease(stream);
+  CFRelease(stream);
       }
 
       CFRelease(url);


### PR DESCRIPTION
There is an unlikely but still possible edge case where factories is leaked if the array being returned is not NULL but has a count of 0. This is because the CFRelease is at the end of the if statement brackets, when it should be at the end of the plugin bracket.