### PR TITLE
Mem leak

### DIFF
--- a/backend/usb-darwin.c
+++ b/backend/usb-darwin.c
@@ -1416,7 +1416,7 @@ static kern_return_t load_classdriver(CFStringRef	    driverPath,
   CFStringRef	bundle = driverPath ? driverPath : kUSBGenericTOPrinterClassDriver;
   char 		bundlestr[1024];	/* Bundle path */
   CFURLRef	url;			/* URL for driver */
-  CFPlugInRef	plugin = NULL;		/* Plug-in address */
+  CFPlugInRef	plugin;		/* Plug-in address */
 
 
   CFStringGetCString(bundle, bundlestr, sizeof(bundlestr), kCFStringEncodingUTF8);
@@ -1429,32 +1429,34 @@ static kern_return_t load_classdriver(CFStringRef	    driverPath,
                                             _CUPS_FILE_CHECK_DIRECTORY, 1,
                                             Iterating ? NULL : _cupsFileCheckFilter, NULL);
 
-  if (result && driverPath)
-    return (load_classdriver(NULL, interface, printerDriver));
-  else if (result)
+  if (result)
+  {
+    if (driverPath)
+      return (load_classdriver(NULL, interface, printerDriver));
     return (kr);
+  }
 
  /*
   * Try loading the class driver...
   */
 
-  url = CFURLCreateWithFileSystemPath(NULL, bundle, kCFURLPOSIXPathStyle, true);
+  url = CFURLCreateWithFileSystemPath(kCFAllocatorDefault, bundle, kCFURLPOSIXPathStyle, true);
 
-  if (url)
-  {
-    plugin = CFPlugInCreate(NULL, url);
-    CFRelease(url);
-  }
-  else
-    plugin = NULL;
+  if (url == NULL)
+      return (kr);
+  
+  plugin = CFPlugInCreate(kCFAllocatorDefault, url);
+  CFRelease(url);
 
   if (plugin)
   {
     CFArrayRef factories = CFPlugInFindFactoriesForPlugInTypeInPlugIn(kUSBPrinterClassTypeID, plugin);
-    if (factories != NULL && CFArrayGetCount(factories) > 0)
+    if (factories == NULL)
+      return (kr);
+    if (CFArrayGetCount(factories) > 0)
     {
       CFUUIDRef factoryID = CFArrayGetValueAtIndex(factories, 0);
-      IUnknownVTbl **iunknown = CFPlugInInstanceCreate(NULL, factoryID, kUSBPrinterClassTypeID);
+      IUnknownVTbl **iunknown = CFPlugInInstanceCreate(kCFAllocatorDefault, factoryID, kUSBPrinterClassTypeID);
       if (iunknown != NULL)
       {
 	kr = (*iunknown)->QueryInterface(iunknown, CFUUIDGetUUIDBytes(kUSBPrinterClassInterfaceID), (LPVOID *)&driver);
@@ -1476,8 +1478,8 @@ static kern_return_t load_classdriver(CFStringRef	    driverPath,
 	}
 	(*iunknown)->Release(iunknown);
       }
-      CFRelease(factories);
     }
+    CFRelease(factories);
   }
 
   fprintf(stderr, "DEBUG: load_classdriver(%s) (kr:0x%08x)\n", bundlestr, (int)kr);
@@ -1885,16 +1887,23 @@ static kern_return_t registry_close(void)
 static CFStringRef copy_value_for_key(CFStringRef deviceID,
 				      CFStringRef *keys)
 {
-  CFStringRef	value = NULL;
-  CFArrayRef	kvPairs = deviceID != NULL ? CFStringCreateArrayBySeparatingStrings(NULL, deviceID, CFSTR(";")) : NULL;
-  CFIndex	max = kvPairs != NULL ? CFArrayGetCount(kvPairs) : 0;
-  CFIndex	idx = 0;
+  CFStringRef value;
+  CFArrayRef kvPairs;
+  CFIndex max;
+  CFIndex idx;
 
-  while (idx < max && value == NULL)
+  if (deviceID == NULL)
+    return NULL;
+
+  value = NULL;
+  kvPairs = CFStringCreateArrayBySeparatingStrings(kCFAllocatorDefault, deviceID, CFSTR(";"));
+  max = CFArrayGetCount(kvPairs);
+
+  for (idx = 0; idx < max; idx++)
   {
     CFStringRef kvpair = CFArrayGetValueAtIndex(kvPairs, idx);
     CFIndex idxx = 0;
-    while (keys[idxx] != NULL && value == NULL)
+    for (idxx = 0; keys[idxx] != NULL; idxx++)
     {
       CFRange range = CFStringFind(kvpair, keys[idxx], kCFCompareCaseInsensitive);
       if (range.length != -1)
@@ -1919,14 +1928,17 @@ static CFStringRef copy_value_for_key(CFStringRef deviceID,
 	  value = theString2;
 	}
       }
-      idxx++;
+
+      if (value != NULL)
+      {
+        CFRelease(kvPairs);
+        return value;
+      }
     }
-    idx++;
   }
 
-  if (kvPairs != NULL)
-    CFRelease(kvPairs);
-  return value;
+  CFRelease(kvPairs);
+  return NULL;
 }
 
 
@@ -2047,25 +2059,26 @@ static void parse_options(char *options,
 static void setup_cfLanguage(void)
 {
   CFStringRef	lang[1] = {NULL};
-  CFArrayRef	langArray = NULL;
-  const char	*requestedLang = NULL;
+  CFArrayRef	langArray;
+  const char	*requestedLang;
 
   if ((requestedLang = getenv("APPLE_LANGUAGE")) == NULL)
     requestedLang = getenv("LANG");
 
-  if (requestedLang != NULL)
+  if (requestedLang == NULL)
   {
-    lang[0] = CFStringCreateWithCString(kCFAllocatorDefault, requestedLang, kCFStringEncodingUTF8);
-    langArray = CFArrayCreate(kCFAllocatorDefault, (const void **)lang, sizeof(lang) / sizeof(lang[0]), &kCFTypeArrayCallBacks);
-
-    CFPreferencesSetValue(CFSTR("AppleLanguages"), langArray, kCFPreferencesCurrentApplication, kCFPreferencesAnyUser, kCFPreferencesAnyHost);
-    fprintf(stderr, "DEBUG: usb: AppleLanguages=\"%s\"\n", requestedLang);
-
-    CFRelease(lang[0]);
-    CFRelease(langArray);
-  }
-  else
     fputs("DEBUG: usb: LANG and APPLE_LANGUAGE environment variables missing.\n", stderr);
+    return;
+  }
+
+  lang[0] = CFStringCreateWithCString(kCFAllocatorDefault, requestedLang, kCFStringEncodingUTF8);
+  langArray = CFArrayCreate(kCFAllocatorDefault, (const void **)lang, sizeof(lang) / sizeof(lang[0]), &kCFTypeArrayCallBacks);
+
+  CFPreferencesSetValue(CFSTR("AppleLanguages"), langArray, kCFPreferencesCurrentApplication, kCFPreferencesAnyUser, kCFPreferencesAnyHost);
+  fprintf(stderr, "DEBUG: usb: AppleLanguages=\"%s\"\n", requestedLang);
+
+  CFRelease(lang[0]);
+  CFRelease(langArray);
 }
 
 #pragma mark -

--- a/cgi-bin/cgi.h
+++ b/cgi-bin/cgi.h
@@ -102,6 +102,8 @@ extern void		cgiStartHTML(const char *title);
 extern void		cgiStartMultipart(void);
 extern int		cgiSupportsMultipart(void);
 extern const char	*cgiText(const char *message);
+extern int		cgiArrayExists(const char *name, int element);
+extern int		cgiVariableExists(const char *name);
 
 #  ifdef __cplusplus
 }

--- a/cgi-bin/classes.c
+++ b/cgi-bin/classes.c
@@ -334,7 +334,7 @@ show_all_classes(http_t     *http,	/* I - Connection to server */
     */
 
     if ((var = cgiGetVariable("QUERY")) != NULL &&
-        !cgiGetVariable("CLEAR"))
+        !cgiVariableExists("CLEAR"))
       search = cgiCompileSearch(var);
     else
       search = NULL;

--- a/cgi-bin/help.c
+++ b/cgi-bin/help.c
@@ -39,6 +39,7 @@ main(int  argc,				/* I - Number of command-line arguments */
   cups_file_t	*fp;			/* Help file */
   char		line[1024];		/* Line from file */
   int		printable;		/* Show printable version? */
+  const char *topic_backup_pointer = NULL; /* To ensure topic does not leak */
 
 
  /*
@@ -47,7 +48,7 @@ main(int  argc,				/* I - Number of command-line arguments */
 
   cgiInitialize();
 
-  printable = cgiGetVariable("PRINTABLE") != NULL;
+  printable = cgiVariableExists("PRINTABLE");
 
  /*
   * Set the web interface section...
@@ -162,13 +163,14 @@ main(int  argc,				/* I - Number of command-line arguments */
     cgiStartHTML(cgiText(_("Online Help")));
 
     topic = cgiGetVariable("TOPIC");
+    topic_backup_pointer = topic;
   }
 
  /*
   * Do a search as needed...
   */
 
-  if (cgiGetVariable("CLEAR"))
+  if (cgiVariableExists("CLEAR"))
     cgiSetVariable("QUERY", "");
 
   query = cgiGetVariable("QUERY");
@@ -310,6 +312,8 @@ main(int  argc,				/* I - Number of command-line arguments */
       cupsArrayRestore(hi->sorted);
     }
   }
+
+  free(topic_backup_pointer);
 
  /*
   * Show the search and bookmark content...

--- a/cgi-bin/ipp-var.c
+++ b/cgi-bin/ipp-var.c
@@ -448,14 +448,16 @@ cgiMoveJobs(http_t     *http,		/* I - Connection to server */
       * Move all active jobs on a destination...
       */
 
+      const char* section = cgiGetVariable("SECTION");
       snprintf(resource, sizeof(resource), "/%s/%s",
-               cgiGetVariable("SECTION"), dest);
+               section, dest);
 
       httpAssembleURIf(HTTP_URI_CODING_ALL, uri, sizeof(uri), "ipp", NULL,
                        "localhost", ippPort(), "/%s/%s",
-		       cgiGetVariable("SECTION"), dest);
+		       section, dest);
       ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_URI, "printer-uri",
                    NULL, uri);
+      free(section);
     }
 
     ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_URI, "job-printer-uri",
@@ -506,6 +508,8 @@ cgiMoveJobs(http_t     *http,		/* I - Connection to server */
       cgiSetVariable("JOB_PRINTER_NAME", job_printer_name);
       cgiCopyTemplateLang("job-moved.tmpl");
     }
+
+    free(job_printer_uri);
   }
 
   cgiEndHTML();
@@ -690,6 +694,7 @@ cgiPrintTestPage(http_t     *http,	/* I - Connection to server */
 		filename[1024];		/* Test page filename */
   const char	*datadir;		/* CUPS_DATADIR env var */
   const char	*user;			/* Username */
+  const char *section; /* Section */
 
 
  /*
@@ -711,12 +716,15 @@ cgiPrintTestPage(http_t     *http,	/* I - Connection to server */
   * Point to the printer/class...
   */
 
-  snprintf(resource, sizeof(resource), "/%s/%s", cgiGetVariable("SECTION"),
+  section = cgiGetVariable("SECTION");
+  snprintf(resource, sizeof(resource), "/%s/%s", section,
            dest);
 
   httpAssembleURIf(HTTP_URI_CODING_ALL, uri, sizeof(uri), "ipp", NULL,
-                   "localhost", ippPort(), "/%s/%s", cgiGetVariable("SECTION"),
+                   "localhost", ippPort(), "/%s/%s", section,
 		   dest);
+
+  free(section);
 
  /*
   * Build an IPP_PRINT_JOB request, which requires the following
@@ -1383,14 +1391,19 @@ cgiShowJobs(http_t     *http,		/* I - Connection to server */
     ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_URI, "printer-uri", NULL,
         	 "ipp://localhost/");
 
-  if ((which_jobs = cgiGetVariable("which_jobs")) != NULL && *which_jobs)
-    ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_KEYWORD, "which-jobs",
-                 NULL, which_jobs);
+  if ((which_jobs = cgiGetVariable("which_jobs")) != NULL)
+  {
+    if (*which_jobs)
+      ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_KEYWORD, "which-jobs",
+                   NULL, which_jobs);
+    free(which_jobs);
+  }
 
   if ((var = cgiGetVariable("FIRST")) != NULL)
   {
     if ((first = atoi(var)) < 0)
       first = 0;
+    free(var);
   }
   else
     first = 0;
@@ -1410,12 +1423,20 @@ cgiShowJobs(http_t     *http,		/* I - Connection to server */
     * Get a list of matching job objects.
     */
 
-    if ((query = cgiGetVariable("QUERY")) != NULL &&
-        !cgiGetVariable("CLEAR"))
+    if ((query = cgiGetVariable("QUERY")) == NULL)
+    {
+        query  = NULL;
+        search = NULL;
+    }
+    else if (!cgiVariableExists("CLEAR"))
+    {
       search = cgiCompileSearch(query);
+      free(query);
+    }
     else
     {
-      query  = NULL;
+      free(query);
+      query = NULL;
       search = NULL;
     }
 

--- a/cgi-bin/jobs.c
+++ b/cgi-bin/jobs.c
@@ -57,8 +57,10 @@ main(void)
   * Get the job ID, if any...
   */
 
-  if ((job_id_var = cgiGetVariable("JOB_ID")) != NULL)
+  if ((job_id_var = cgiGetVariable("JOB_ID")) != NULL) {
     job_id = atoi(job_id_var);
+    free(job_id_var);
+  }
   else
     job_id = 0;
 
@@ -66,7 +68,17 @@ main(void)
   * Do the operation...
   */
 
-  if ((op = cgiGetVariable("OP")) != NULL && job_id > 0 && cgiIsPOST())
+  if (op = cgiGetVariable("OP") == NULL)
+  {
+    /*
+     * Show a list of jobs...
+     */
+
+    cgiStartHTML(cgiText(_("Jobs")));
+    cgiShowJobs(http, NULL);
+    cgiEndHTML();
+  }
+  else if (job_id > 0 && cgiIsPOST())
   {
    /*
     * Do the operation...
@@ -92,6 +104,7 @@ main(void)
       cgiCopyTemplateLang("error-op.tmpl");
       cgiEndHTML();
     }
+    free(op);
   }
   else
   {
@@ -102,6 +115,7 @@ main(void)
     cgiStartHTML(cgiText(_("Jobs")));
     cgiShowJobs(http, NULL);
     cgiEndHTML();
+    free(op);
   }
 
  /*

--- a/cgi-bin/libcupscgi.exp
+++ b/cgi-bin/libcupscgi.exp
@@ -1,3 +1,4 @@
+_cgiArrayExists
 _cgiCheckVariables
 _cgiClearVariables
 _cgiCompileSearch
@@ -35,6 +36,7 @@ _cgiStartHTML
 _cgiStartMultipart
 _cgiSupportsMultipart
 _cgiText
+_cgiVariableExists
 _helpDeleteIndex
 _helpFindNode
 _helpLoadIndex

--- a/cgi-bin/printers.c
+++ b/cgi-bin/printers.c
@@ -180,6 +180,7 @@ main(void)
       cgiCopyTemplateLang("error-op.tmpl");
       cgiEndHTML();
     }
+    free(op);
   }
   else
   {
@@ -190,6 +191,7 @@ main(void)
     cgiStartHTML(cgiText(_("Printers")));
     cgiCopyTemplateLang("error-op.tmpl");
     cgiEndHTML();
+    free(op);
   }
 
  /*
@@ -201,6 +203,7 @@ main(void)
  /*
   * Return with no errors...
   */
+  free(op);
 
   return (0);
 }
@@ -350,9 +353,15 @@ show_all_printers(http_t     *http,	/* I - Connection to server */
     * Get a list of matching job objects.
     */
 
-    if ((var = cgiGetVariable("QUERY")) != NULL &&
-        !cgiGetVariable("CLEAR"))
-      search = cgiCompileSearch(var);
+    if ((var = cgiGetVariable("QUERY")) != NULL)
+    {
+      if (!cgiVariableExists("CLEAR"))
+        search = cgiCompileSearch(var);
+      else
+        search = NULL;
+      
+      free(var);
+    }
     else
       search = NULL;
 
@@ -367,7 +376,10 @@ show_all_printers(http_t     *http,	/* I - Connection to server */
     */
 
     if ((var = cgiGetVariable("FIRST")) != NULL)
+    {
       first = atoi(var);
+      free(var);
+    }
     else
       first = 0;
 

--- a/cgi-bin/template.c
+++ b/cgi-bin/template.c
@@ -436,11 +436,11 @@ cgi_copy(FILE *out,			/* I - Output file */
 	*/
 
         if (name[0] == '?')
-	  result = cgiGetArray(name + 1, element) != NULL;
+	  result = cgiArrayExists(name + 1, element);
 	else if (name[0] == '#')
-	  result = cgiGetVariable(name + 1) != NULL;
+	  result = cgiVariableExists(name + 1);
         else
-          result = cgiGetArray(name, element) != NULL;
+          result = cgiArrayExists(name, element);
 
 	result     = result && outptr[0];
 	compare[0] = '\0';

--- a/cgi-bin/var.c
+++ b/cgi-bin/var.c
@@ -163,11 +163,13 @@ cgiGetArray(const char *name,		/* I - Name of array variable */
 {
   _cgi_var_t	*var;			/* Pointer to variable */
 
+  if (element < 0)
+    return (NULL);
 
   if ((var = cgi_find_variable(name)) == NULL)
     return (NULL);
 
-  if (element < 0 || element >= var->nvalues)
+  if (element >= var->nvalues)
     return (NULL);
 
   if (var->values[element] == NULL)
@@ -232,6 +234,50 @@ cgiGetVariable(const char *name)	/* I - Name of variable */
   var = cgi_find_variable(name);
 
   return ((var == NULL) ? NULL : strdup(var->values[var->nvalues - 1]));
+}
+
+/*
+ * 'cgiVariableExists()' - Get a CGI variable from the database.
+ *
+ * Returns 0 if the variable doesn't exist, 1 if it does
+ */
+
+int					/* O - 1 if variable exists */
+cgiVariableExists(const char *name)	/* I - Name of variable */
+{
+  const _cgi_var_t	*var;		/* Returned variable */
+
+
+  var = cgi_find_variable(name);
+
+  return (var && var->values[var->nvalues - 1]);
+}
+
+/*
+ * 'cgiArrayExists()' - Get a CGI variable from the database.
+ *
+ * Returns 0 if the variable doesn't exist, 1 if it does
+ */
+
+int					/* O - 1 if variable exists */
+cgiArrayExists(const char *name,		/* I - Name of array variable */
+            int        element)		/* I - Element number (0 to N) */
+{
+  _cgi_var_t	*var;			/* Pointer to variable */
+
+  if (element < 0)
+    return 0;
+
+  if ((var = cgi_find_variable(name)) == NULL)
+    return 0;
+
+  if ( element >= var->nvalues)
+    return 0;
+
+  if (var->values[element] == NULL)
+    return 0;
+
+  return 1;
 }
 
 

--- a/cups/language.c
+++ b/cups/language.c
@@ -248,7 +248,7 @@ _cupsAppleLocale(CFStringRef languageName,	/* I - Apple language ID */
                  char        *locale,		/* I - Buffer for locale */
 		 size_t      localesize)	/* I - Size of buffer */
 {
-  int		i;			/* Looping var */
+  size_t		i;			/* Looping var */
   CFStringRef	localeName;		/* Locale as a CF string */
 #ifdef DEBUG
   char          temp[1024];             /* Temporary string */
@@ -280,7 +280,7 @@ _cupsAppleLocale(CFStringRef languageName,	/* I - Apple language ID */
     */
 
     for (i = 0;
-	 i < (int)(sizeof(apple_language_locale) /
+	 i < (sizeof(apple_language_locale) /
 		   sizeof(apple_language_locale[0]));
 	 i ++)
     {

--- a/cups/tls-darwin.c
+++ b/cups/tls-darwin.c
@@ -899,10 +899,8 @@ void
 _httpFreeCredentials(
     http_tls_credentials_t credentials)	/* I - Internal credentials */
 {
-  if (!credentials)
-    return;
-
-  CFRelease(credentials);
+  if (credentials)
+    CFRelease(credentials);
 }
 
 
@@ -1671,9 +1669,10 @@ _httpTLSStart(http_t *http)		/* I - HTTP connection */
 	    if (cg->client_cert_cb)
 	    {
 	      names = NULL;
-	      if (!(error = SSLCopyDistinguishedNames(http->tls, &dn_array)) &&
-		  dn_array)
-	      {
+        error = SSLCopyDistinguishedNames(http->tls, &dn_array);
+        if (dn_array)
+        {
+          if (!error) {
 		if ((names = cupsArrayNew(NULL, NULL)) != NULL)
 		{
 		  for (i = 0, count = CFArrayGetCount(dn_array); i < count; i++)
@@ -1694,9 +1693,9 @@ _httpTLSStart(http_t *http)		/* I - HTTP connection */
 		    }
 		  }
 		}
-
-		CFRelease(dn_array);
 	      }
+		CFRelease(dn_array);
+        }
 
 	      if (!error)
 	      {
@@ -1792,12 +1791,12 @@ _httpTLSStop(http_t *http)		/* I - HTTP connection */
     usleep(1000);
 
   CFRelease(http->tls);
+  http->tls = NULL;
 
-  if (http->tls_credentials)
+  if (http->tls_credentials) {
     CFRelease(http->tls_credentials);
-
-  http->tls             = NULL;
-  http->tls_credentials = NULL;
+    http->tls_credentials = NULL;
+  }
 }
 
 

--- a/ppdc/ppdc-catalog.cxx
+++ b/ppdc/ppdc-catalog.cxx
@@ -107,11 +107,11 @@ ppdcCatalog::ppdcCatalog(const char *l,	// I - Locale
 
 	plist = CFPropertyListCreateWithStream(kCFAllocatorDefault, stream, 0, kCFPropertyListImmutable, NULL, NULL);
 
-	if (plist && CFGetTypeID(plist) == CFDictionaryGetTypeID())
-	  CFDictionaryApplyFunction((CFDictionaryRef)plist, (CFDictionaryApplierFunction)apple_add_message, this);
-
-	if (plist)
-	  CFRelease(plist);
+  if (plist) {
+    if (CFGetTypeID(plist) == CFDictionaryGetTypeID())
+      CFDictionaryApplyFunction((CFDictionaryRef)plist, (CFDictionaryApplierFunction)apple_add_message, this);
+    CFRelease(plist);
+  }
 
 	CFRelease(stream);
       }

--- a/tools/ippeveprinter.c
+++ b/tools/ippeveprinter.c
@@ -1681,7 +1681,7 @@ create_printer(
     * Extract up to 3 icons...
     */
 
-    for (i = 1, iconsptr = strchr(icons, ','); iconsptr && i < 3; i ++, iconsptr = strchr(iconsptr, ','))
+    for (i = 1, iconsptr = strchr(printer->icons[i], ','); iconsptr && i < 3; i ++, iconsptr = strchr(iconsptr, ','))
     {
       *iconsptr++ = '\0';
       printer->icons[i] = iconsptr;
@@ -6862,7 +6862,10 @@ process_job(ippeve_job_t *job)		/* I - Job */
     }
 
     if (mystdout < 0)
-      mystdout = open("/dev/null", O_WRONLY | O_BINARY);
+    {
+      if ((mystdout = open("/dev/null", O_WRONLY | O_BINARY)) < 0)
+        fprintf(stderr, "[Job %d] Unable to redirect command output to /dev/null: %s", job->id, strerror(errno));
+    }
 
     if (pipe(mypipe))
     {
@@ -6876,14 +6879,20 @@ process_job(ippeve_job_t *job)		/* I - Job */
       * Child comes here...
       */
 
-      close(1);
-      dup2(mystdout, 1);
-      close(mystdout);
+      if (mystdout >= 0)
+      {
+	close(1);
+        dup2(mystdout, 1);
+        close(mystdout);
+      }
 
-      close(2);
-      dup2(mypipe[1], 2);
-      close(mypipe[0]);
-      close(mypipe[1]);
+      if (mypipe[1] >= 0)
+      {
+	close(2);
+	dup2(mypipe[1], 2);
+	close(mypipe[0]);
+	close(mypipe[1]);
+      }
 
       execve(job->printer->command, myargv, myenvp);
       exit(errno);


### PR DESCRIPTION
I am not going to sugar-coat this: there are potentially hundreds of tiny memory leaks. 

The culprit is cgiGetVariable strdup the result, which allocates onto the heap, but many of these function calls assume that does not happen.

So far, I am taking the approach of freeing when done. However, given how much more messy that makes the code, I may just go along with returning a read-only pointer to the array itself, while not allowing any changes to happen. 

I already made a function that checks if the result exists or is NULL without strdup, but this only checks if the variable exists.

What do you think?