### PR TITLE
Free memory leaked by by cgi-bin

### DIFF
--- a/cgi-bin/cgi.h
+++ b/cgi-bin/cgi.h
@@ -102,6 +102,8 @@ extern void		cgiStartHTML(const char *title);
 extern void		cgiStartMultipart(void);
 extern int		cgiSupportsMultipart(void);
 extern const char	*cgiText(const char *message);
+extern int		cgiArrayExists(const char *name, int element);
+extern int		cgiVariableExists(const char *name);
 
 #  ifdef __cplusplus
 }

--- a/cgi-bin/classes.c
+++ b/cgi-bin/classes.c
@@ -334,7 +334,7 @@ show_all_classes(http_t     *http,	/* I - Connection to server */
     */
 
     if ((var = cgiGetVariable("QUERY")) != NULL &&
-        !cgiGetVariable("CLEAR"))
+        !cgiVariableExists("CLEAR"))
       search = cgiCompileSearch(var);
     else
       search = NULL;

--- a/cgi-bin/help.c
+++ b/cgi-bin/help.c
@@ -39,6 +39,7 @@ main(int  argc,				/* I - Number of command-line arguments */
   cups_file_t	*fp;			/* Help file */
   char		line[1024];		/* Line from file */
   int		printable;		/* Show printable version? */
+  const char *topic_backup_pointer = NULL; /* To ensure topic does not leak */
 
 
  /*
@@ -47,7 +48,7 @@ main(int  argc,				/* I - Number of command-line arguments */
 
   cgiInitialize();
 
-  printable = cgiGetVariable("PRINTABLE") != NULL;
+  printable = cgiVariableExists("PRINTABLE");
 
  /*
   * Set the web interface section...
@@ -162,13 +163,14 @@ main(int  argc,				/* I - Number of command-line arguments */
     cgiStartHTML(cgiText(_("Online Help")));
 
     topic = cgiGetVariable("TOPIC");
+    topic_backup_pointer = topic;
   }
 
  /*
   * Do a search as needed...
   */
 
-  if (cgiGetVariable("CLEAR"))
+  if (cgiVariableExists("CLEAR"))
     cgiSetVariable("QUERY", "");
 
   query = cgiGetVariable("QUERY");
@@ -310,6 +312,8 @@ main(int  argc,				/* I - Number of command-line arguments */
       cupsArrayRestore(hi->sorted);
     }
   }
+
+  free(topic_backup_pointer);
 
  /*
   * Show the search and bookmark content...

--- a/cgi-bin/jobs.c
+++ b/cgi-bin/jobs.c
@@ -57,8 +57,10 @@ main(void)
   * Get the job ID, if any...
   */
 
-  if ((job_id_var = cgiGetVariable("JOB_ID")) != NULL)
+  if ((job_id_var = cgiGetVariable("JOB_ID")) != NULL) {
     job_id = atoi(job_id_var);
+    free(job_id_var);
+  }
   else
     job_id = 0;
 
@@ -66,7 +68,17 @@ main(void)
   * Do the operation...
   */
 
-  if ((op = cgiGetVariable("OP")) != NULL && job_id > 0 && cgiIsPOST())
+  if ((op = cgiGetVariable("OP")) == NULL)
+  {
+    /*
+     * Show a list of jobs...
+     */
+
+    cgiStartHTML(cgiText(_("Jobs")));
+    cgiShowJobs(http, NULL);
+    cgiEndHTML();
+  }
+  else if (job_id > 0 && cgiIsPOST())
   {
    /*
     * Do the operation...
@@ -92,6 +104,7 @@ main(void)
       cgiCopyTemplateLang("error-op.tmpl");
       cgiEndHTML();
     }
+    free(op);
   }
   else
   {
@@ -102,6 +115,7 @@ main(void)
     cgiStartHTML(cgiText(_("Jobs")));
     cgiShowJobs(http, NULL);
     cgiEndHTML();
+    free(op);
   }
 
  /*

--- a/cgi-bin/libcupscgi.exp
+++ b/cgi-bin/libcupscgi.exp
@@ -1,3 +1,4 @@
+_cgiArrayExists
 _cgiCheckVariables
 _cgiClearVariables
 _cgiCompileSearch
@@ -35,6 +36,7 @@ _cgiStartHTML
 _cgiStartMultipart
 _cgiSupportsMultipart
 _cgiText
+_cgiVariableExists
 _helpDeleteIndex
 _helpFindNode
 _helpLoadIndex

--- a/cgi-bin/printers.c
+++ b/cgi-bin/printers.c
@@ -180,6 +180,7 @@ main(void)
       cgiCopyTemplateLang("error-op.tmpl");
       cgiEndHTML();
     }
+    free(op);
   }
   else
   {
@@ -190,6 +191,7 @@ main(void)
     cgiStartHTML(cgiText(_("Printers")));
     cgiCopyTemplateLang("error-op.tmpl");
     cgiEndHTML();
+    free(op);
   }
 
  /*
@@ -201,6 +203,7 @@ main(void)
  /*
   * Return with no errors...
   */
+  free(op);
 
   return (0);
 }
@@ -350,9 +353,15 @@ show_all_printers(http_t     *http,	/* I - Connection to server */
     * Get a list of matching job objects.
     */
 
-    if ((var = cgiGetVariable("QUERY")) != NULL &&
-        !cgiGetVariable("CLEAR"))
-      search = cgiCompileSearch(var);
+    if ((var = cgiGetVariable("QUERY")) != NULL)
+    {
+      if (!cgiVariableExists("CLEAR"))
+        search = cgiCompileSearch(var);
+      else
+        search = NULL;
+      
+      free(var);
+    }
     else
       search = NULL;
 
@@ -367,7 +376,10 @@ show_all_printers(http_t     *http,	/* I - Connection to server */
     */
 
     if ((var = cgiGetVariable("FIRST")) != NULL)
+    {
       first = atoi(var);
+      free(var);
+    }
     else
       first = 0;
 

--- a/cgi-bin/template.c
+++ b/cgi-bin/template.c
@@ -436,11 +436,11 @@ cgi_copy(FILE *out,			/* I - Output file */
 	*/
 
         if (name[0] == '?')
-	  result = cgiGetArray(name + 1, element) != NULL;
+	  result = cgiArrayExists(name + 1, element);
 	else if (name[0] == '#')
-	  result = cgiGetVariable(name + 1) != NULL;
+	  result = cgiVariableExists(name + 1);
         else
-          result = cgiGetArray(name, element) != NULL;
+          result = cgiArrayExists(name, element);
 
 	result     = result && outptr[0];
 	compare[0] = '\0';


### PR DESCRIPTION
I am not going to sugar-coat this: there are potentially hundreds of tiny memory leaks.

The culprit is cgiGetVariable strdup the result, which allocates onto the heap, but many of these function calls assume that does not happen.

So far, I am taking the approach of freeing when done. However, given how much more messy that makes the code, I may just go along with returning a read-only pointer to the array itself, while not allowing any changes to happen.

I already made a function that checks if the result exists or is NULL without strdup, but this only checks if the variable exists.

What do you think?