### PR TITLE
Prefer fcntl over ioctl

### DIFF
--- a/cups/getifaddrs-internal.h
+++ b/cups/getifaddrs-internal.h
@@ -45,7 +45,7 @@ typedef int socklen_t;
 #    ifdef HAVE_GETIFADDRS
 #      include <ifaddrs.h>
 #    else
-#      include <sys/ioctl.h>
+#      include <fcntl.h>
 #      ifdef HAVE_SYS_SOCKIO_H
 #        include <sys/sockio.h>
 #      endif /* HAVE_SYS_SOCKIO_H */

--- a/cups/getifaddrs.c
+++ b/cups/getifaddrs.c
@@ -59,7 +59,7 @@ _cups_getifaddrs(struct ifaddrs **addrs)/* O - List of interfaces */
   conf.ifc_len = sizeof(buffer);
   conf.ifc_buf = buffer;
 
-  if (ioctl(sock, SIOCGIFCONF, &conf) < 0)
+  if (fcntl(sock, SIOCGIFCONF, &conf) < 0)
   {
    /*
     * Couldn't get the list of interfaces...
@@ -101,7 +101,7 @@ _cups_getifaddrs(struct ifaddrs **addrs)/* O - List of interfaces */
     * Check the status of the interface...
     */
 
-    if (ioctl(sock, SIOCGIFFLAGS, &request) < 0)
+    if (fcntl(sock, SIOCGIFFLAGS, &request) < 0)
       continue;
 
    /*
@@ -134,7 +134,7 @@ _cups_getifaddrs(struct ifaddrs **addrs)/* O - List of interfaces */
     * Try to get the netmask for the interface...
     */
 
-    if (!ioctl(sock, SIOCGIFNETMASK, &request))
+    if (!fcntl(sock, SIOCGIFNETMASK, &request))
     {
      /*
       * Got it, make a copy...
@@ -156,7 +156,7 @@ _cups_getifaddrs(struct ifaddrs **addrs)/* O - List of interfaces */
       * Have a broadcast address, so get it!
       */
 
-      if (!ioctl(sock, SIOCGIFBRDADDR, &request))
+      if (!fcntl(sock, SIOCGIFBRDADDR, &request))
       {
        /*
 	* Got it, make a copy...
@@ -174,7 +174,7 @@ _cups_getifaddrs(struct ifaddrs **addrs)/* O - List of interfaces */
       * Point-to-point interface; grab the remote address...
       */
 
-      if (!ioctl(sock, SIOCGIFDSTADDR, &request))
+      if (!fcntl(sock, SIOCGIFDSTADDR, &request))
       {
 	temp->ifa_dstaddr = malloc(sizeof(request.ifr_dstaddr));
 	memcpy(temp->ifa_dstaddr, &(request.ifr_dstaddr),

--- a/scheduler/select.c
+++ b/scheduler/select.c
@@ -136,7 +136,7 @@
  *         c. cupsdRemoveSelect() writes a single pollfd struct to
  *            /dev/poll with the file descriptor and the POLLREMOVE
  *            flag.
- *         d. cupsdDoSelect() uses the DP_POLL ioctl to retrieve
+ *         d. cupsdDoSelect() uses the DP_POLL fcntl to retrieve
  *            events from /dev/poll and then loops through the
  *            returned pollfd array, looking up the file descriptors
  *            as needed.
@@ -165,7 +165,7 @@
  *   cupsdDoSelect().
  *
  *   Since /dev/poll will never be able to use a shadow array, it may
- *   not make sense to implement support for it.  ioctl() overhead will
+ *   not make sense to implement support for it.  fcntl() overhead will
  *   impact performance as well, so my guess would be that, for CUPS,
  *   /dev/poll will yield a net performance loss.
  */

--- a/tools/ippeveprinter.c
+++ b/tools/ippeveprinter.c
@@ -1681,7 +1681,7 @@ create_printer(
     * Extract up to 3 icons...
     */
 
-    for (i = 1, iconsptr = strchr(printer->icons, ','); iconsptr && i < 3; i ++, iconsptr = strchr(iconsptr, ','))
+    for (i = 1, iconsptr = strchr(printer->icons[i], ','); iconsptr && i < 3; i ++, iconsptr = strchr(iconsptr, ','))
     {
       *iconsptr++ = '\0';
       printer->icons[i] = iconsptr;

--- a/tools/ipptool.c
+++ b/tools/ipptool.c
@@ -4208,7 +4208,7 @@ timeout_cb(http_t *http,		/* I - Connection to server */
     buffered = 0;
 
 #elif defined(SIOCOUTQ)			/* Others except Windows */
-  if (ioctl(httpGetFd(http), SIOCOUTQ, &buffered))
+  if (fcntl(httpGetFd(http), SIOCOUTQ, &buffered))
     buffered = 0;
 
 #else					/* Windows (not possible) */


### PR DESCRIPTION
fcntl is standardized and should be used for files and sockets, while ioctl can just be used for devices.