### PR TITLE
UBSan: Array over-read when operating on _fields

### DIFF
--- a/cups/http.c
+++ b/cups/http.c
@@ -308,13 +308,25 @@ httpClearFields(http_t *http)		/* I - HTTP connection */
 
   if (http)
   {
-    memset(http->_fields, 0, sizeof(http->fields));
+    memset(http->_fields, 0, sizeof(http->_fields));
 
-    for (field = HTTP_FIELD_ACCEPT_LANGUAGE; field < HTTP_FIELD_MAX; field ++)
+    for (field = HTTP_FIELD_ACCEPT_LANGUAGE; field < HTTP_FIELD_ACCEPT_ENCODING; field ++)
     {
-      if (http->fields[field] && http->fields[field] != http->_fields[field])
+      if (!http->fields[field])
+        continue;
+
+      if (http->fields[field] != http->_fields[field])
         free(http->fields[field]);
 
+      http->fields[field] = NULL;
+    }
+
+    for (; field < HTTP_FIELD_MAX; field ++)
+    {
+      if (!http->fields[field])
+        continue;
+
+      free(http->fields[field]);
       http->fields[field] = NULL;
     }
 
@@ -3624,7 +3636,7 @@ http_add_field(http_t       *http,	/* I - HTTP connection */
 
   if (!append && http->fields[field])
   {
-    if (http->fields[field] != http->_fields[field])
+    if (field >= HTTP_FIELD_ACCEPT_ENCODING || http->fields[field] != http->_fields[field])
       free(http->fields[field]);
 
     http->fields[field] = NULL;
@@ -3674,7 +3686,7 @@ http_add_field(http_t       *http,	/* I - HTTP connection */
 
     char *mcombined;			/* New value string */
 
-    if (http->fields[field] == http->_fields[field])
+    if (field < HTTP_FIELD_ACCEPT_ENCODING && http->fields[field] == http->_fields[field])
     {
       if ((mcombined = malloc(total + 1)) != NULL)
       {


### PR DESCRIPTION
We are reading outside of the _fields boundaries and onto other fields when we iterate across all the fields, rather than comparing just those that are within _fields, and then always freeing the ones that are not.

This PR fixes that.