### PR TITLE
UBSan: Contain pos - fp->bufpos in parentheses

### DIFF
--- a/cups/file.c
+++ b/cups/file.c
@@ -1825,7 +1825,7 @@ cupsFileSeek(cups_file_t *fp,		/* I - CUPS file */
       */
 
       fp->pos = pos;
-      fp->ptr = fp->buf + pos - fp->bufpos;
+      fp->ptr = fp->buf + (pos - fp->bufpos);
       fp->eof = 0;
 
       return (pos);


### PR DESCRIPTION
Yes I know this shouldn't change the behavior in theory, but clang insists it does in practice, so to quiet the UBSan, I put parenthesis around pos - fp->bufpos.