### PR TITLE
CodeQL: paths-ignore has no effect

### DIFF
--- a/.github/codeql.yml
+++ b/.github/codeql.yml
@@ -1,6 +1,3 @@
-paths-ignore:
-  - locale
-
 query-filters:
   - exclude:
       id: cpp/cleartext-transmission


### PR DESCRIPTION
It only has an effect in JavaScript, Python, and Ruby, and this setting throws warnings, so let's just remove it.