### PR TITLE
Fix check for existing color mode setting

### DIFF
--- a/scheduler/printers.c
+++ b/scheduler/printers.c
@@ -4570,7 +4570,7 @@ load_ppd(cupsd_printer_t *p)		/* I - Printer */
 
       urf[num_urf ++] = "SRGB24";
 
-      if (!cupsGetOption("printer-color-mode", p->num_options, p->options))
+      if (!cupsGetOption("print-color-mode", p->num_options, p->options))
       {
         // If the default color mode isn't set, use the default from the PPD
         // file...


### PR DESCRIPTION
Colour mode selection is not persisted correctly across restarts. Current check in scheduler/printers.c:4573 is for `printer-color-mode`, but every other reference to this option is `print-color-mode` (no "er"). This was causing the selected colour mode to be reset to the PPD default on restart.

Changing to `print-color-mode` should fix this.