### PR TITLE
host_os_name value in config-scripts has changed to 'solaris'

### DIFF
--- a/config-scripts/cups-compiler.m4
+++ b/config-scripts/cups-compiler.m4
@@ -202,7 +202,7 @@ AS_IF([test -n "$GCC"], [
     ])
 ], [
     # Add vendor-specific compiler options...
-    AS_CASE([$host_os_name], [sunos*], [
+    AS_CASE([$host_os_name], [sunos* | solaris*], [
 	# Solaris
 	AS_IF([test -z "$OPTIM"], [
 	    OPTIM="-xO2"

--- a/config-scripts/cups-defaults.m4
+++ b/config-scripts/cups-defaults.m4
@@ -335,7 +335,7 @@ AS_IF([test x$default_printcap != xno], [
     AS_IF([test "x$default_printcap" = "xdefault"], [
 	AS_CASE([$host_os_name], [darwin*], [
 	    CUPS_DEFAULT_PRINTCAP="/Library/Preferences/org.cups.printers.plist"
-	], [sunos*], [
+	], [sunos* | solaris*], [
 	    CUPS_DEFAULT_PRINTCAP="/etc/printers.conf"
 	], [*], [
 	    CUPS_DEFAULT_PRINTCAP="/etc/printcap"

--- a/config-scripts/cups-directories.m4
+++ b/config-scripts/cups-directories.m4
@@ -184,7 +184,7 @@ AC_SUBST([CUPS_DOCROOT])
 
 # Locale data
 AS_IF([test "$localedir" = "\${datarootdir}/locale"], [
-    AS_CASE(["$host_os_name"], [linux* | gnu* | *bsd* | darwin*], [
+    AS_CASE(["$host_os_name"], [linux* | gnu* | *bsd* | darwin* | solaris*], [
 	CUPS_LOCALEDIR="$datarootdir/locale"
     ], [*], [
 	# This is the standard System V location...
@@ -266,6 +266,10 @@ AC_ARG_WITH([rundir], AS_HELP_STRING([--with-rundir], [set transient run-time st
     AS_CASE(["$host_os_name"], [darwin*], [
 	# Darwin (macOS)
 	CUPS_STATEDIR="$CUPS_SERVERROOT"
+    ], [sun* | solaris*], [
+	AS_IF([test -d /system/volatile], [
+	     CUPS_STATEDIR="/system/volatile/cups"
+	])
     ], [*], [
 	# All others
 	CUPS_STATEDIR="$localstatedir/run/cups"

--- a/config-scripts/cups-gssapi.m4
+++ b/config-scripts/cups-gssapi.m4
@@ -30,7 +30,7 @@ AS_IF([test x$enable_gssapi = xyes], [
 	], [
 	    AC_MSG_RESULT([no])
 	])
-    ], [sunos*], [
+    ], [sunos* | solaris*], [
 	# Solaris has a non-standard krb5-config, don't use it!
 	SAVELIBS="$LIBS"
 	AC_CHECK_LIB([gss], [gss_display_status], [

--- a/config-scripts/cups-sharedlibs.m4
+++ b/config-scripts/cups-sharedlibs.m4
@@ -28,7 +28,7 @@ AS_IF([test x$enable_shared != xno], [
 	DSO="\$(CC)"
 	DSOXX="\$(CXX)"
 	DSOFLAGS="$DSOFLAGS -Wl,-h\`basename \$@\` -G"
-    ], [linux* | gnu* | *bsd*], [
+    ], [linux* | gnu* | *bsd* | solaris*], [
 	LIBCUPS="lib$cupsbase.so.2"
 	AS_IF([test "x$cupsimagebase" != x], [
 	    LIBCUPSIMAGE="lib$cupsimagebase.so.2"
@@ -102,7 +102,7 @@ AS_IF([test "$DSO" != ":"], [
     # Tell the run-time linkers where to find a DSO.  Some platforms
     # need this option, even when the library is installed in a
     # standard location...
-    AS_CASE([$host_os_name], [sunos*], [
+    AS_CASE([$host_os_name], [sunos* | solaris*], [
 	# Solaris...
 	AS_IF([test $exec_prefix != /usr], [
 	    DSOFLAGS="-R$libdir $DSOFLAGS"

--- a/config-scripts/cups-threads.m4
+++ b/config-scripts/cups-threads.m4
@@ -38,7 +38,7 @@ AS_IF([test x$ac_cv_header_pthread_h = xyes], [
 
 	    # Solaris requires -D_POSIX_PTHREAD_SEMANTICS to be POSIX-
 	    # compliant... :(
-	    AS_IF([test $host_os_name = sunos], [
+	    AS_IF([test $host_os_name = solaris], [
 		PTHREAD_FLAGS="$PTHREAD_FLAGS -D_POSIX_PTHREAD_SEMANTICS"
 	    ])
 	    break


### PR DESCRIPTION
Variable _host_os_name_ value has changed on Solaris from _sunos_ to _solaris_ some time ago. This change updates config-scripts to keep values used for Solaris 5.10 (sunos), but also sets relevant options on Solaris 5.11 (solaris). This change decreases the number of _configure_ options necessary to build CUPS on current Solaris.

Please consider merge.

Thank you,
m.