### PR TITLE
workflows.yaml: Fix Github Actions and various fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,12 +9,14 @@ on:
 jobs:
   build-linux:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
+    - name: show Ubuntu version
+      run: cat /etc/os-release | grep PRETTY_NAME | awk -F '=' '{print $2}'
     - name: update build environment
-      run: sudo apt-get update --fix-missing -y
+      run: sudo apt-get update --fix-missing -y && sudo apt-get upgrade --fix-missing -y
     - name: install prerequisites
       run: sudo apt-get install -y avahi-daemon libavahi-client-dev libssl-dev libpam-dev libusb-1.0-0-dev zlib1g-dev
     - name: configure
@@ -28,16 +30,18 @@ jobs:
 
   build-linux-i386:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
+    - name: show Ubuntu version
+      run: cat /etc/os-release | grep PRETTY_NAME | awk -F '=' '{print $2}'
     - name: setup multiarch for i386
       run: sudo dpkg --add-architecture i386
     - name: update build environment
-      run: sudo apt-get update --fix-missing -y
+      run: sudo apt-get update --fix-missing -y && sudo apt-get upgrade --fix-missing -y
     - name: install prerequisites
-      run: sudo apt-get install -y avahi-daemon libavahi-client-dev libavahi-client-dev:i386 libgnutls28-dev libgnutls28-dev:i386 libpam-dev libpam-dev:i386 libusb-1.0-0-dev libusb-1.0-0-dev:i386 zlib1g-dev zlib1g-dev:i386 crossbuild-essential-i386
+      run: sudo apt-get install -y avahi-daemon libavahi-client-dev libavahi-client-dev:i386 libgnutls28-dev libgnutls28-dev:i386 libpam-dev libpam-dev:i386 libusb-1.0-0-dev libusb-1.0-0-dev:i386 zlib1g-dev zlib1g-dev:i386 crossbuild-essential-i386 libgcc-s1:i386 libstdc++6:i386
     - name: configure
       env:
         CC: /usr/bin/i686-linux-gnu-gcc


### PR DESCRIPTION
- github action for Ubuntu 22.04 i386 fails during installing dependencies - try to upgrade the image before installing to prevent having an outdated image (in case Github doesn't update it...)
- use ubuntu-latest, so we automatically use the latest stable, but print out the pretty name in workflow to show which version it is (dont wanna to look up the names :))