### PR TITLE
Document default repeat interval

### DIFF
--- a/doc/help/man-ipptoolfile.html
+++ b/doc/help/man-ipptoolfile.html
@@ -155,6 +155,7 @@ Multiple collection values can be supplied as needed, separated by commas.
 <dt><b>DELAY </b><i>seconds</i>[<i>,repeat-seconds</i>]
 <dd style="margin-left: 5.0em">Specifies a delay in seconds before this test will be run.
 If two values are specified, the second value is used as the delay between repeated tests.
+A default repeat interval of 5 seconds is used if this directive is not provided.
 <dt><b>DISPLAY </b><i>attribute-name</i>
 <dd style="margin-left: 5.0em">Specifies that value of the named attribute should be output as part of the
 test report.

--- a/man/ipptoolfile.5
+++ b/man/ipptoolfile.5
@@ -185,6 +185,7 @@ Uses the specified compression on the document data following the attributes in 
 \fBDELAY \fIseconds\fR[\fI,repeat-seconds\fR]
 Specifies a delay in seconds before this test will be run.
 If two values are specified, the second value is used as the delay between repeated tests.
+A default repeat interval of 5 seconds is used if this directive is not provided.
 .TP 5
 \fBDISPLAY \fIattribute-name\fR
 Specifies that value of the named attribute should be output as part of the


### PR DESCRIPTION
I was exploring how to make a print job retry after failure, and quickly found the REPEAT and DELAY directives. REPEAT mentioned what the default value was, but DELAY had no such explanation readily available.

I am interpreting the `5000000` seen here as 5 seconds, though I was unsure if I was off by an order of magnitude: https://github.com/OpenPrinting/cups/blob/32572321f87b72d430ce4c20fb259c7ceee5ec7b/tools/ipptool.c#L5305 Use seems to indicate I am correct though :)