### PR TITLE
Save strings file path in printers.conf

### DIFF
--- a/scheduler/printers.c
+++ b/scheduler/printers.c
@@ -1024,6 +1024,10 @@ cupsdLoadAllPrinters(void)
     {
       cupsdSetString(&p->organizational_unit, value ? value : "");
     }
+    else if (!_cups_strcasecmp(line, "Strings"))
+    {
+      cupsdSetString(&p->strings, value ? value : "");
+    }
     else if (!_cups_strcasecmp(line, "DeviceURI"))
     {
       if (value)
@@ -1512,6 +1516,9 @@ cupsdSaveAllPrinters(void)
 
     if (printer->organizational_unit)
       cupsFilePutConf(fp, "OrganizationalUnit", printer->organizational_unit);
+
+    if (printer->strings)
+      cupsFilePutConf(fp, "Strings", printer->strings);
 
     cupsFilePutConf(fp, "DeviceURI", printer->device_uri);
 


### PR DESCRIPTION
Losing this attribute after save/load meant that a printer loaded from printers.conf would advertise the `printer-strings-uri` attribute if supported, but cupsd would return 404 when a client actually requested the strings using that URI.