### PR TITLE
Leave early if size parameter is 0 or less

### DIFF
--- a/backend/dnssd.c
+++ b/backend/dnssd.c
@@ -1270,7 +1270,11 @@ unquote(char       *dst,		/* I - Destination buffer */
         const char *src,		/* I - Source string */
 	size_t     dstsize)		/* I - Size of destination buffer */
 {
-  char	*dstend = dst + dstsize - 1;	/* End of destination buffer */
+  char	*dstend;
+  if (dstsize == 0)
+    return;
+
+  dstend = dst + dstsize - 1;	/* End of destination buffer */
 
 
   while (*src && dst < dstend)

--- a/cgi-bin/html.c
+++ b/cgi-bin/html.c
@@ -73,6 +73,8 @@ cgiFormEncode(char       *dst,		/* I - Destination string */
   static const char	*hex =		/* Hexadecimal characters */
 			"0123456789ABCDEF";
 
+ if (dstsize == 0)
+  return dst;
 
  /*
   * Mark the end of the string...

--- a/cups/dest-options.c
+++ b/cups/dest-options.c
@@ -1499,6 +1499,8 @@ cups_collection_string(
   const char		*mptr;		/* Pointer into member value */
   int			mlen;		/* Length of octetString */
 
+  if (bufsize == 0)
+    return 0;
 
   bufptr = buffer;
   bufend = buffer + bufsize - 1;

--- a/cups/dest.c
+++ b/cups/dest.c
@@ -3335,7 +3335,11 @@ cups_dnssd_unquote(char       *dst,	/* I - Destination buffer */
                    const char *src,	/* I - Source string */
 		   size_t     dstsize)	/* I - Size of destination buffer */
 {
-  char	*dstend = dst + dstsize - 1;	/* End of destination buffer */
+  char	*dstend;
+  if (dstsize == 0)
+    return;
+    
+  dstend = dst + dstsize - 1;	/* End of destination buffer */
 
 
   while (*src && dst < dstend)
@@ -4326,6 +4330,8 @@ cups_make_string(
       attr->value_tag != IPP_TAG_RANGE)
     return (attr->values[0].string.text);
 
+  if (bufsize == 0)
+    return (buffer);
  /*
   * Copy the values to the string, separating with commas and escaping strings
   * as needed...
@@ -4425,6 +4431,8 @@ cups_queue_name(
   const char	*ptr;			/* Pointer into serviceName */
   char		*nameptr;		/* Pointer into name */
 
+  if (namesize == 0)
+    return;
 
   for (nameptr = name, ptr = serviceName; *ptr && nameptr < (name + namesize - 1); ptr ++)
   {

--- a/cups/http-support.c
+++ b/cups/http-support.c
@@ -631,17 +631,19 @@ httpDecode64_2(char       *out,		/* I  - String to write to */
 	  pos ++;
 	  break;
       case 1 :
-          if (outptr < outend)
+          if (outptr < outend) {
             *outptr++ |= (char)((base64 >> 4) & 3);
           if (outptr < outend)
 	    *outptr = (char)((base64 << 4) & 255);
+          }
 	  pos ++;
 	  break;
       case 2 :
-          if (outptr < outend)
+          if (outptr < outend) {
             *outptr++ |= (char)((base64 >> 2) & 15);
           if (outptr < outend)
 	    *outptr = (char)((base64 << 6) & 255);
+          }
 	  pos ++;
 	  break;
       case 3 :
@@ -1025,7 +1027,7 @@ httpSeparateURI(
     */
 
     for (ptr = scheme, end = scheme + schemelen - 1;
-         *uri && *uri != ':' && ptr < end;)
+         ptr < end && *uri && *uri != ':';)
       if (strchr("ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                  "abcdefghijklmnopqrstuvwxyz"
 		 "0123456789-+.", *uri) != NULL)
@@ -1112,10 +1114,9 @@ httpSeparateURI(
         * Skip IPvFuture ("vXXXX.") prefix...
         */
 
-        uri ++;
-
-        while (isxdigit(*uri & 255))
+        do 
           uri ++;
+        while (isxdigit(*uri & 255));
 
         if (*uri != '.')
         {
@@ -2173,6 +2174,8 @@ http_copy_decode(char       *dst,	/* O - Destination buffer */
 	*end;				/* End of buffer */
   int	quoted;				/* Quoted character */
 
+  if (dstsize <= 0)
+    return (NULL);
 
  /*
   * Copy the src to the destination until we hit a terminating character

--- a/ppdc/ppdc-source.cxx
+++ b/ppdc/ppdc-source.cxx
@@ -1926,7 +1926,7 @@ ppdcSource::get_size(ppdcFile *fp)	// I - File to read
 char *					// O - Token string or NULL
 ppdcSource::get_token(ppdcFile *fp,	// I - File to read
                       char     *buffer,	// I - Buffer
-		      int      buflen)	// I - Length of buffer
+		      size_t      buflen)	// I - Length of buffer
 {
   char		*bufptr,		// Pointer into string buffer
 		*bufend;		// End of string buffer
@@ -1939,10 +1939,12 @@ ppdcSource::get_token(ppdcFile *fp,	// I - File to read
 		*nameptr;		// Name pointer
   ppdcVariable	*var;			// Variable pointer
 
+  if (buflen == 0)
+    return (NULL);
 
   // Mark the beginning and end of the buffer...
   bufptr = buffer;
-  bufend = buffer + buflen - 1;
+  bufend = bufptr + buflen - 1;
 
   // Loop intil we've read a token...
   quote     = 0;

--- a/ppdc/ppdc.h
+++ b/ppdc/ppdc.h
@@ -509,7 +509,7 @@ class ppdcSource			//// Source File
   ppdcChoice	*get_resolution(ppdcFile *fp);
   ppdcProfile	*get_simple_profile(ppdcFile *fp);
   ppdcMediaSize	*get_size(ppdcFile *fp);
-  char		*get_token(ppdcFile *fp, char *buffer, int buflen);
+  char		*get_token(ppdcFile *fp, char *buffer, size_t buflen);
   ppdcVariable	*get_variable(ppdcFile *fp);
   int		import_ppd(const char *f);
   int		quotef(cups_file_t *fp, const char *format, ...);

--- a/scheduler/ipp.c
+++ b/scheduler/ipp.c
@@ -11281,9 +11281,9 @@ url_encode_attr(ipp_attribute_t *attr,	/* I - Attribute */
     if (bufptr >= bufend)
       break;
 
-    *bufptr++ = '\'';
+    *bufptr = '\'';
 
-    bufptr = url_encode_string(attr->values[i].string.text, bufptr, (size_t)(bufend - bufptr + 1));
+    bufptr = url_encode_string(attr->values[i].string.text, bufptr, (size_t)(bufend - bufptr));
 
     if (bufptr >= bufend)
       break;
@@ -11309,9 +11309,8 @@ url_encode_string(const char *s,	/* I - String */
   static const char *hex = "0123456789ABCDEF";
 					/* Hex digits */
 
-
   bufptr = buffer;
-  bufend = buffer + bufsize - 1;
+  bufend = bufptr + bufsize - 1;
 
   while (*s && bufptr < bufend)
   {


### PR DESCRIPTION
This saves us a lot of work if it is possible for the size to be empty, and also so we do not write to any memory if somehow we get a 0 size buffer.