### PR TITLE
config-scripts/cups-common.m4: fix error message typo

### DIFF
--- a/config-scripts/cups-common.m4
+++ b/config-scripts/cups-common.m4
@@ -483,7 +483,7 @@ AS_CASE(["$COMPONENTS"], [all], [
     LIBHEADERS="\$(COREHEADERS)"
     LIBHEADERSPRIV="\$(COREHEADERSPRIV)"
 ], [*], [
-    AC_MSG_ERROR([Bad build component "$COMPONENT" specified.])
+    AC_MSG_ERROR([Bad build component "$COMPONENTS" specified.])
 ])
 
 AC_SUBST([BUILDDIRS])


### PR DESCRIPTION
$COMPONENT should be $COMPONENTS to properly print the bad build component, otherwise it's empty.