### PR TITLE
Remove redundant checks in cupsdCloseClient

### DIFF
--- a/scheduler/sysman.c
+++ b/scheduler/sysman.c
@@ -163,8 +163,7 @@ cupsdSetBusyState(int working)          /* I - Doing significant work? */
   * Manage state changes...
   */
 
-  if (newbusy != busy)
-    busy = newbusy;
+  busy = newbusy;
 
 #ifdef __APPLE__
   if (cupsArrayCount(PrintingJobs) > 0 && !keep_awake)


### PR DESCRIPTION
This makes the logic easier to follow as well as removing checks for the return entirely unless TLS is enabled.

Please consider backporting this to 2.4.x as well.