### PR TITLE
Detect strlcpy truncation without calling strlen

### DIFF
--- a/cups/tls-darwin.c
+++ b/cups/tls-darwin.c
@@ -1223,8 +1223,7 @@ _httpTLSSetOptions(int options,		/* I - Options */
 int					/* O - 0 on success, -1 on failure */
 _httpTLSStart(http_t *http)		/* I - HTTP connection */
 {
-  char			hostname[256],	/* Hostname */
-			*hostptr;	/* Pointer into hostname */
+  char			hostname[256];	/* Hostname */
   _cups_globals_t	*cg = _cupsGlobals();
 					/* Pointer to library globals */
   OSStatus		error;		/* Error code */
@@ -1594,10 +1593,15 @@ _httpTLSStart(http_t *http)		/* I - HTTP connection */
       * Otherwise make sure the hostname we have does not end in a trailing dot.
       */
 
-      strlcpy(hostname, http->hostname, sizeof(hostname));
-      if ((hostptr = hostname + strlen(hostname) - 1) >= hostname &&
-	  *hostptr == '.')
-	*hostptr = '\0';
+      size_t host_len = strlcpy(hostname, http->hostname, sizeof(hostname));
+      if (host_len)
+      {
+        if (host_len > sizeof(hostname) - 1) // Did truncation occur?
+          host_len = strlen(hostname);
+
+        if (hostname[host_len - 1] == '.')
+          hostname[host_len - 1] = '\0';
+      }
     }
 
     error = SSLSetPeerDomainName(http->tls, hostname, strlen(hostname));

--- a/cups/tls-gnutls.c
+++ b/cups/tls-gnutls.c
@@ -1261,8 +1261,7 @@ _httpTLSSetOptions(int options,		/* I - Options */
 int					/* O - 0 on success, -1 on failure */
 _httpTLSStart(http_t *http)		/* I - Connection to server */
 {
-  char			hostname[256],	/* Hostname */
-			*hostptr;	/* Pointer into hostname */
+  char			hostname[256];	/* Hostname */
   int			status;		/* Status of handshake */
   gnutls_certificate_credentials_t *credentials;
 					/* TLS credentials */
@@ -1352,10 +1351,15 @@ _httpTLSStart(http_t *http)		/* I - Connection to server */
       * Otherwise make sure the hostname we have does not end in a trailing dot.
       */
 
-      strlcpy(hostname, http->hostname, sizeof(hostname));
-      if ((hostptr = hostname + strlen(hostname) - 1) >= hostname &&
-	  *hostptr == '.')
-	*hostptr = '\0';
+      size_t host_len = strlcpy(hostname, http->hostname, sizeof(hostname));
+      if (host_len)
+      {
+        if (host_len > sizeof(hostname) - 1) // Did truncation occur?
+          host_len = strlen(hostname);
+
+        if (hostname[host_len - 1] == '.')
+          hostname[host_len - 1] = '\0';
+      }
     }
 
     status = gnutls_server_name_set(http->tls, GNUTLS_NAME_DNS, hostname, strlen(hostname));

--- a/cups/tls-sspi.c
+++ b/cups/tls-sspi.c
@@ -930,8 +930,7 @@ _httpTLSSetOptions(int options,		/* I - Options */
 int					/* O - 0 on success, -1 on failure */
 _httpTLSStart(http_t *http)		/* I - HTTP connection */
 {
-  char	hostname[256],			/* Hostname */
-	*hostptr;			/* Pointer into hostname */
+  char	hostname[256];			/* Hostname */
 
 
   DEBUG_printf(("3_httpTLSStart(http=%p)", http));
@@ -962,10 +961,15 @@ _httpTLSStart(http_t *http)		/* I - HTTP connection */
       * Otherwise make sure the hostname we have does not end in a trailing dot.
       */
 
-      strlcpy(hostname, http->hostname, sizeof(hostname));
-      if ((hostptr = hostname + strlen(hostname) - 1) >= hostname &&
-	  *hostptr == '.')
-	*hostptr = '\0';
+      size_t host_len = strlcpy(hostname, http->hostname, sizeof(hostname));
+      if (host_len)
+      {
+        if (host_len > sizeof(hostname) - 1) // Did truncation occur?
+          host_len = strlen(hostname);
+
+        if (hostname[host_len - 1] == '.')
+          hostname[host_len - 1] = '\0';
+      }
     }
 
     return (http_sspi_client(http, hostname));


### PR DESCRIPTION
Rather than call strlen when we do not need to, we should only call it if truncation has been detected.