### PR TITLE
Regression: Certificate data is corrupted during base64 conversion

### DIFF
--- a/cups/http-support.c
+++ b/cups/http-support.c
@@ -746,7 +746,7 @@ httpEncode64_2(char       *out,		/* I - String to write to */
     if (outptr < outend)
     {
       if (inlen > 1)
-        *outptr ++ = base64[((in[0] << 2) | (in[1] >> 6)) & 63];
+        *outptr ++ = base64[(((in[0] & 255) << 2) | ((in[1] & 255) >> 6)) & 63];
       else
         *outptr ++ = base64[(in[0] << 2) & 63];
     }


### PR DESCRIPTION
The bug during which certificates become corrupt was introduced in a521b235a1abc008cb0b2f490a765bb31e2ec14b. It turns out some data was not being truncated after being promoted to an integer, causing 1s to be ORed into the index number when they should not have been.

I only intended to remove the & 255 from the other side, where the & 63 would have rendered that operation redundant.

I apologize for this error. I made the appropriate changes I intended to make in this new PR.

Please merge and make a new release if possible.

Thank you so much!