### PR TITLE
 cups/ppd-cache.c: Put cupsSingleFile into generated PPD

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ CHANGES - OpenPrinting CUPS 2.4.6 - TBA
 Changes in CUPS v2.4.6 - TBA
 ----------------------------
 
+- Fix printing multiple files on specific printers (Issue #643)
+
 
 Changes in CUPS v2.4.5 - 2023-06-13
 -----------------------------------

--- a/cups/ppd-cache.c
+++ b/cups/ppd-cache.c
@@ -5056,6 +5056,16 @@ _ppdCreateFromIPP2(
   }
 
  /*
+  * Add cupsSingleFile to support multiple files printing on printers
+  * which don't support multiple files in its firmware...
+  *
+  * Adding the keyword degrades printing performance (there is 1-2 seconds
+  * pause between files).
+  */
+
+  cupsFilePuts(fp, "*cupsSingleFile: true\n");
+
+ /*
   * Close up and return...
   */
 


### PR DESCRIPTION
Some printers are not able to print multiple files in one job via IPP Everywhere. Adding the PPD keyword enables the feature on all printers in exchange for performance degradation (there is a 1-2s pause between printed files).

Fixes #643