### PR TITLE
Revert "Fix trivial deprecations"

### DIFF
--- a/cups/usersys.c
+++ b/cups/usersys.c
@@ -593,22 +593,8 @@ cupsSetUserAgent(const char *user_agent)/* I - User-Agent string or @code NULL@ 
   * Gather Windows version information for the User-Agent string...
   */
 
-  typedef NTSTATUS(WINAPI * RtlGetVersionPtr)(PRTL_OSVERSIONINFOW);
-
-  memset(&version, 0, sizeof(version));
-  version.dwOSVersionInfoSize = sizeof(version);
-
-  /* RtlGetVersion gets the current native version of Windows, even when running in compatibility mode */
-  RtlGetVersionPtr RtlGetVersionInternal = (RtlGetVersionPtr)GetProcAddress(GetModuleHandleW(L"ntdll.dll"), "RtlGetVersion");
-  if (RtlGetVersionInternal)
-  {
-    RtlGetVersionInternal((PRTL_OSVERSIONINFOW)&version);
-  }
-  else
-  {
-    /* Should not happen, but just in case, fallback to deprecated GetVersionExW */
-    GetVersionExW(&version);
-  }
+  version.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
+  GetVersionExA(&version);
   GetNativeSystemInfo(&sysinfo);
 
   switch (sysinfo.wProcessorArchitecture)

--- a/scheduler/sysman.c
+++ b/scheduler/sysman.c
@@ -538,7 +538,7 @@ sysEventThreadEntry(void)
   * this later.
   */
 
-  memset(&timerContext, 0, sizeof(timerContext));
+  bzero(&timerContext, sizeof(timerContext));
   timerContext.info = &threadData;
 
   threadData.timerRef =


### PR DESCRIPTION
This reverts commit 9f04d166bd440a4685a55dda681d6d5d297c49d4.

Never ever remove deprecated code in bug fix releases - it might break compilation on some distros, which is not expected between bug fix releases (always move it to minor release).

2.0.0 - major release
2.1.0 - minor release
2.1.1 - bug fix release

Fixes #715 