### PR TITLE
Fix delays printing to lpd when reserved ports are exhausted

### DIFF
--- a/backend/lpd.c
+++ b/backend/lpd.c
@@ -63,7 +63,7 @@ static int	abort_job = 0;		/* Non-zero if we get SIGTERM */
 
 #define RESERVE_NONE		0	/* Don't reserve a privileged port */
 #define RESERVE_RFC1179		1	/* Reserve port 721-731 */
-#define RESERVE_ANY		2	/* Reserve port 1-1023 */
+#define RESERVE_ANY		2	/* Reserve port 512-1023 */
 
 
 /*
@@ -775,7 +775,7 @@ lpd_queue(const char      *hostname,	/* I - Host to connect to */
 
       if (lport < 721 && reserve == RESERVE_RFC1179)
 	lport = 731;
-      else if (lport < 1)
+      else if (lport < 512)
 	lport = 1023;
 
 #ifdef HAVE_GETEUID


### PR DESCRIPTION
cups_rresvport() doesn't reserve ports less than 512; however, lpd_queue() continues decrementing the port number to 0.  This leads to delays of ~511 seconds once all ports between 512-1023 are exhausted.  Even when ports become available, lpd_queue() still tries calling cups_rresvport() with port numbers less than 512, waiting one second between each call.