### PR TITLE
Use "purge-job" instead of "purge-jobs" when canceling a single job

### DIFF
--- a/systemv/cancel.c
+++ b/systemv/cancel.c
@@ -294,7 +294,8 @@ main(int  argc,				/* I - Number of command-line arguments */
 	ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_NAME,
                      "requesting-user-name", NULL, cupsUser());
 
-      if (purge) {
+      if (purge)
+      {
 	if (op == IPP_CANCEL_JOB)
 	  ippAddBoolean(request, IPP_TAG_OPERATION, "purge-job", (char)purge);
 	else

--- a/systemv/cancel.c
+++ b/systemv/cancel.c
@@ -294,11 +294,12 @@ main(int  argc,				/* I - Number of command-line arguments */
 	ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_NAME,
                      "requesting-user-name", NULL, cupsUser());
 
-      if (purge)
+      if (purge) {
 	if (op == IPP_CANCEL_JOB)
 	  ippAddBoolean(request, IPP_TAG_OPERATION, "purge-job", (char)purge);
 	else
 	  ippAddBoolean(request, IPP_TAG_OPERATION, "purge-jobs", (char)purge);
+      }
 
      /*
       * Do the request and get back a response...

--- a/systemv/cancel.c
+++ b/systemv/cancel.c
@@ -260,6 +260,7 @@ main(int  argc,				/* I - Number of command-line arguments */
       *    attributes-natural-language
       *    printer-uri + job-id *or* job-uri
       *    [requesting-user-name]
+      *    [purge-job] or [purge-jobs]
       */
 
       request = ippNewRequest(op);
@@ -294,7 +295,10 @@ main(int  argc,				/* I - Number of command-line arguments */
                      "requesting-user-name", NULL, cupsUser());
 
       if (purge)
-	ippAddBoolean(request, IPP_TAG_OPERATION, "purge-jobs", (char)purge);
+	if (op == IPP_CANCEL_JOB)
+	  ippAddBoolean(request, IPP_TAG_OPERATION, "purge-job", (char)purge);
+	else
+	  ippAddBoolean(request, IPP_TAG_OPERATION, "purge-jobs", (char)purge);
 
      /*
       * Do the request and get back a response...


### PR DESCRIPTION
The command "cancel -x <job>" adds "purge-jobs true" to the Cancel-Job operation; however, the correct attribute to use for Cancel-job is "purge-job" (singular), not "purge-jobs" (plural).  As a result, job files are not removed from /var/spool/cups when "cancel -x <job>" is executed.