### PR TITLE
scheduler/job.c: Fix extensive logging in scheduler

### DIFF
--- a/scheduler/job.c
+++ b/scheduler/job.c
@@ -443,12 +443,12 @@ cupsdCleanJobs(void)
        job;
        job = (cupsd_job_t *)cupsArrayNext(Jobs))
   {
-    cupsdLogMessage(CUPSD_LOG_DEBUG2, "cupsdCleanJobs: Job %d, state=%d, printer=%p, history_time=%d, file_time=%d", job->id, (int)job->state_value, (void *)job->printer, (int)job->history_time, (int)job->file_time);
+    cupsdLogMessage(CUPSD_LOG_DEBUG2, "cupsdCleanJobs: Job %d, state=%d, printer=%p, history_time=%d, file_time=%d, num_files=%d", job->id, (int)job->state_value, (void *)job->printer, (int)job->history_time, (int)job->file_time, (int)job->num_files);
 
     if ((job->history_time && job->history_time < JobHistoryUpdate) || !JobHistoryUpdate)
       JobHistoryUpdate = job->history_time;
 
-    if ((job->file_time && job->file_time < JobHistoryUpdate) || !JobHistoryUpdate)
+    if (job->num_files > 0 && ((job->file_time && job->file_time < JobHistoryUpdate) || !JobHistoryUpdate))
       JobHistoryUpdate = job->file_time;
 
     if (job->state_value >= IPP_JOB_CANCELED && !job->printer)


### PR DESCRIPTION
Based on currently unknown trigger scheduler sometimes sets JobHistoryUpdate into past, which causes `select()` to timeout after one second.

It happens when `job->file_time` of a job without files to remove gets assigned to `JobHistoryUpdate`. If we check for `job->num_files` and assign the `job->file_time` only if there are any, we will fix extensive logging (and unneeded cupsd execution) in various places, e.g. cleaning jobs, expiring subscriptions, deleting temporary queues...

Fixes #604