### PR TITLE
scheduler/conf.c: Print to stderr if we don't open cups-files.conf

### DIFF
--- a/scheduler/conf.c
+++ b/scheduler/conf.c
@@ -811,11 +811,7 @@ cupsdReadConfiguration(void)
     cupsdLogMessage(CUPSD_LOG_INFO, "No %s, using defaults.", CupsFilesFile);
   else
   {
-#ifdef HAVE_SYSTEMD_SD_JOURNAL_H
-    sd_journal_print(LOG_ERR, "Unable to open \"%s\" - %s", CupsFilesFile, strerror(errno));
-#else
-    syslog(LOG_LPR, "Unable to open \"%s\" - %s", CupsFilesFile, strerror(errno));
-#endif /* HAVE_SYSTEMD_SD_JOURNAL_H */
+    fprintf(stderr, "Unable to read \"%s\" - %s\n", CupsFilesFile, strerror(errno));
 
     return (0);
   }


### PR DESCRIPTION
In case cupsd can't open the cups-files.conf, the error message is lost if journal and syslog don't exist or work on system (usually in containers).

Log the error into stderr at this place to get the error message if needed.