### PR TITLE
cups/http-addrlist.c: Fix hanging on Solaris

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Changes in CUPS v2.5b1 (TBA)
 - Fixed delays in lpd backend (Issue #741)
 - Fixed extensive looping in scheduler (Issue #604)
 - Fixed hanging of `lpstat` on IBM AIX (Issue #773)
+- Fixed hanging of `lpstat` on Solaris (Issue #156)
 - Fixed segfault in `cupsGetNamedDest()` when trying to get default printer, but
   the default printer is not set (Issue #719)
 - Fixed RFC 1179 port reserving behavior in LPD backend (Issue #743)


### PR DESCRIPTION
Solaris behaves differently regarding connecting to a socket, so our current code caused hanging.

The patch is from @l1gi's comment -
https://github.com/OpenPrinting/cups/issues/156#issuecomment-1329212604

Fixes #156