### PR TITLE
Add jobs' original hostname indication in the Jobs table

### DIFF
--- a/templates/da/jobs.tmpl
+++ b/templates/da/jobs.tmpl
@@ -8,7 +8,7 @@
 <TR VALIGN="TOP">
 <TD><A HREF="{job_printer_uri}">{job_printer_name}</A>-{job_id}{?phone? ({phone}):}&nbsp;</TD>
 <TD>{?job_name=?Ukendt:{job_name}}&nbsp;</TD>
-<TD>{?job_originating_user_name=?Tilbageholdt:{job_originating_user_name}}&nbsp;</TD>
+<TD>{?job_originating_user_name=?Tilbageholdt:{job_originating_user_name}} @ {job_originating_host_name}&nbsp;</TD>
 <TD>{job_k_octets}k&nbsp;</TD>
 <TD>{job_impressions_completed=0?Ukendt:{?job_impressions_completed}}&nbsp;</TD>
 <TD>{job_state=3?afventer siden<BR>{?time_at_creation=?Ukendt:{time_at_creation}}:{job_state=4?tilbageholdt siden<BR>{?time_at_creation=?Ukendt:{time_at_creation}}:

--- a/templates/da/jobs.tmpl
+++ b/templates/da/jobs.tmpl
@@ -8,7 +8,7 @@
 <TR VALIGN="TOP">
 <TD><A HREF="{job_printer_uri}">{job_printer_name}</A>-{job_id}{?phone? ({phone}):}&nbsp;</TD>
 <TD>{?job_name=?Ukendt:{job_name}}&nbsp;</TD>
-<TD>{?job_originating_user_name=?Tilbageholdt:{job_originating_user_name}} @ {job_originating_host_name}&nbsp;</TD>
+<TD>{?job_originating_user_name=?Tilbageholdt:{job_originating_user_name}}{?job_originating_user_name=?:{?job_originating_host_name=localhost?: @ {job_originating_host_name}}}&nbsp;</TD>
 <TD>{job_k_octets}k&nbsp;</TD>
 <TD>{job_impressions_completed=0?Ukendt:{?job_impressions_completed}}&nbsp;</TD>
 <TD>{job_state=3?afventer siden<BR>{?time_at_creation=?Ukendt:{time_at_creation}}:{job_state=4?tilbageholdt siden<BR>{?time_at_creation=?Ukendt:{time_at_creation}}:

--- a/templates/de/jobs.tmpl
+++ b/templates/de/jobs.tmpl
@@ -8,7 +8,7 @@
 <TR VALIGN="TOP">
 <TD><A HREF="{job_printer_uri}">{job_printer_name}</A>-{job_id}{?phone? ({phone}):}&nbsp;</TD>
 <TD>{?job_name=?Unbekannt:{job_name}}&nbsp;</TD>
-<TD>{?job_originating_user_name=?Zurückbehalten:{job_originating_user_name}}&nbsp;</TD>
+<TD>{?job_originating_user_name=?Zurückbehalten:{job_originating_user_name}} @ {job_originating_host_name}&nbsp;</TD>
 <TD>{job_k_octets}k&nbsp;</TD>
 <TD>{job_impressions_completed=0?Unbekannt:{?job_impressions_completed}}&nbsp;</TD>
 <TD>{job_state=3?unerledigt seit<BR>{?time_at_creation=?Unknown:{time_at_creation}}:{job_state=4?angehalten seit<BR>{?time_at_creation=?Unknown:{time_at_creation}}:

--- a/templates/de/jobs.tmpl
+++ b/templates/de/jobs.tmpl
@@ -8,7 +8,7 @@
 <TR VALIGN="TOP">
 <TD><A HREF="{job_printer_uri}">{job_printer_name}</A>-{job_id}{?phone? ({phone}):}&nbsp;</TD>
 <TD>{?job_name=?Unbekannt:{job_name}}&nbsp;</TD>
-<TD>{?job_originating_user_name=?Zurückbehalten:{job_originating_user_name}} @ {job_originating_host_name}&nbsp;</TD>
+<TD>{?job_originating_user_name=?Zurückbehalten:{job_originating_user_name}}{?job_originating_user_name=?:{?job_originating_host_name=localhost?: @ {job_originating_host_name}}}&nbsp;</TD>
 <TD>{job_k_octets}k&nbsp;</TD>
 <TD>{job_impressions_completed=0?Unbekannt:{?job_impressions_completed}}&nbsp;</TD>
 <TD>{job_state=3?unerledigt seit<BR>{?time_at_creation=?Unknown:{time_at_creation}}:{job_state=4?angehalten seit<BR>{?time_at_creation=?Unknown:{time_at_creation}}:

--- a/templates/es/jobs.tmpl
+++ b/templates/es/jobs.tmpl
@@ -8,7 +8,7 @@
 <TR VALIGN="TOP">
 <TD><A HREF="{job_printer_uri}">{job_printer_name}</A>-{job_id}{?phone? ({phone}):}&nbsp;</TD>
 <TD>{?job_name=?Desconocido:{job_name}}&nbsp;</TD>
-<TD>{?job_originating_user_name=?Retenido:{job_originating_user_name}}&nbsp;</TD>
+<TD>{?job_originating_user_name=?Retenido:{job_originating_user_name}} @ {job_originating_host_name}&nbsp;</TD>
 <TD>{job_k_octets}k&nbsp;</TD>
 <TD>{job_impressions_completed=0?Desconocido:{?job_impressions_completed}}&nbsp;</TD>
 <TD>{job_state=3?pendiente desde<BR>{?time_at_creation=?Unknown:{time_at_creation}}:{job_state=4?retenido desde<BR>{?time_at_creation=?Unknown:{time_at_creation}}:

--- a/templates/es/jobs.tmpl
+++ b/templates/es/jobs.tmpl
@@ -8,7 +8,7 @@
 <TR VALIGN="TOP">
 <TD><A HREF="{job_printer_uri}">{job_printer_name}</A>-{job_id}{?phone? ({phone}):}&nbsp;</TD>
 <TD>{?job_name=?Desconocido:{job_name}}&nbsp;</TD>
-<TD>{?job_originating_user_name=?Retenido:{job_originating_user_name}} @ {job_originating_host_name}&nbsp;</TD>
+<TD>{?job_originating_user_name=?Retenido:{job_originating_user_name}}{?job_originating_user_name=?:{?job_originating_host_name=localhost?: @ {job_originating_host_name}}}&nbsp;</TD>
 <TD>{job_k_octets}k&nbsp;</TD>
 <TD>{job_impressions_completed=0?Desconocido:{?job_impressions_completed}}&nbsp;</TD>
 <TD>{job_state=3?pendiente desde<BR>{?time_at_creation=?Unknown:{time_at_creation}}:{job_state=4?retenido desde<BR>{?time_at_creation=?Unknown:{time_at_creation}}:

--- a/templates/fr/jobs.tmpl
+++ b/templates/fr/jobs.tmpl
@@ -8,7 +8,7 @@
 <TR VALIGN="TOP">
 <TD><A HREF="{job_printer_uri}">{job_printer_name}</A>-{job_id}{?phone? ({phone}):}&nbsp;</TD>
 <TD>{?job_name=?Inconnu:{job_name}}&nbsp;</TD>
-<TD>{?job_originating_user_name=?Caché:{job_originating_user_name}} @ {job_originating_host_name}&nbsp;</TD>
+<TD>{?job_originating_user_name=?Caché:{job_originating_user_name}}{?job_originating_user_name=?:{?job_originating_host_name=localhost?: @ {job_originating_host_name}}}&nbsp;</TD>
 <TD>{job_k_octets}k&nbsp;</TD>
 <TD>{job_impressions_completed=0?Inconnu:{?job_impressions_completed}}&nbsp;</TD>
 <TD>{job_state=3?en attente depuis<BR>{?time_at_creation=?Inconnu:{time_at_creation}}:{job_state=4?retenu depuis le<BR>{?time_at_creation=?Inconnu:{time_at_creation}}:

--- a/templates/fr/jobs.tmpl
+++ b/templates/fr/jobs.tmpl
@@ -8,7 +8,7 @@
 <TR VALIGN="TOP">
 <TD><A HREF="{job_printer_uri}">{job_printer_name}</A>-{job_id}{?phone? ({phone}):}&nbsp;</TD>
 <TD>{?job_name=?Inconnu:{job_name}}&nbsp;</TD>
-<TD>{?job_originating_user_name=?Caché:{job_originating_user_name}}&nbsp;</TD>
+<TD>{?job_originating_user_name=?Caché:{job_originating_user_name}} @ {job_originating_host_name}&nbsp;</TD>
 <TD>{job_k_octets}k&nbsp;</TD>
 <TD>{job_impressions_completed=0?Inconnu:{?job_impressions_completed}}&nbsp;</TD>
 <TD>{job_state=3?en attente depuis<BR>{?time_at_creation=?Inconnu:{time_at_creation}}:{job_state=4?retenu depuis le<BR>{?time_at_creation=?Inconnu:{time_at_creation}}:

--- a/templates/ja/jobs.tmpl
+++ b/templates/ja/jobs.tmpl
@@ -8,7 +8,7 @@
 <TR VALIGN="TOP">
 <TD><A HREF="{job_printer_uri}">{job_printer_name}</A>-{job_id}{?phone? ({phone}):}&nbsp;</TD>
 <TD>{?job_name=?未知:{job_name}}&nbsp;</TD>
-<TD>{?job_originating_user_name=?隠匿:{job_originating_user_name}} @ {job_originating_host_name}&nbsp;</TD>
+<TD>{?job_originating_user_name=?隠匿:{job_originating_user_name}}{?job_originating_user_name=?:{?job_originating_host_name=localhost?: @ {job_originating_host_name}}}&nbsp;</TD>
 <TD>{job_k_octets}k&nbsp;</TD>
 <TD>{job_impressions_completed=0?不明:{?job_impressions_completed}}&nbsp;</TD>
 <TD>{job_state=3?{?time_at_creation=?Unknown:{time_at_creation}}<BR>から保留中:{job_state=4?{?time_at_creation=?Unknown:{time_at_creation}}<BR>から保留中:

--- a/templates/ja/jobs.tmpl
+++ b/templates/ja/jobs.tmpl
@@ -8,7 +8,7 @@
 <TR VALIGN="TOP">
 <TD><A HREF="{job_printer_uri}">{job_printer_name}</A>-{job_id}{?phone? ({phone}):}&nbsp;</TD>
 <TD>{?job_name=?未知:{job_name}}&nbsp;</TD>
-<TD>{?job_originating_user_name=?隠匿:{job_originating_user_name}}&nbsp;</TD>
+<TD>{?job_originating_user_name=?隠匿:{job_originating_user_name}} @ {job_originating_host_name}&nbsp;</TD>
 <TD>{job_k_octets}k&nbsp;</TD>
 <TD>{job_impressions_completed=0?不明:{?job_impressions_completed}}&nbsp;</TD>
 <TD>{job_state=3?{?time_at_creation=?Unknown:{time_at_creation}}<BR>から保留中:{job_state=4?{?time_at_creation=?Unknown:{time_at_creation}}<BR>から保留中:

--- a/templates/jobs.tmpl
+++ b/templates/jobs.tmpl
@@ -8,7 +8,7 @@
 <TR VALIGN="TOP">
 <TD><A HREF="{job_printer_uri}">{job_printer_name}</A>-{job_id}{?phone? ({phone}):}&nbsp;</TD>
 <TD>{?job_name=?Unknown:{job_name}}&nbsp;</TD>
-<TD>{?job_originating_user_name=?Withheld:{job_originating_user_name}}&nbsp;</TD>
+<TD>{?job_originating_user_name=?Withheld:{job_originating_user_name}} @ {job_originating_host_name}&nbsp;</TD>
 <TD>{job_k_octets}k&nbsp;</TD>
 <TD>{job_impressions_completed=0?Unknown:{?job_impressions_completed}}&nbsp;</TD>
 <TD>{job_state=3?pending since<BR>{?time_at_creation=?Unknown:{time_at_creation}}:{job_state=4?held since<BR>{?time_at_creation=?Unknown:{time_at_creation}}:

--- a/templates/jobs.tmpl
+++ b/templates/jobs.tmpl
@@ -8,7 +8,7 @@
 <TR VALIGN="TOP">
 <TD><A HREF="{job_printer_uri}">{job_printer_name}</A>-{job_id}{?phone? ({phone}):}&nbsp;</TD>
 <TD>{?job_name=?Unknown:{job_name}}&nbsp;</TD>
-<TD>{?job_originating_user_name=?Withheld:{job_originating_user_name}} @ {job_originating_host_name}&nbsp;</TD>
+<TD>{?job_originating_user_name=?Withheld:{job_originating_user_name}}{?job_originating_user_name=?:{?job_originating_host_name=localhost?: @ {job_originating_host_name}}}&nbsp;</TD>
 <TD>{job_k_octets}k&nbsp;</TD>
 <TD>{job_impressions_completed=0?Unknown:{?job_impressions_completed}}&nbsp;</TD>
 <TD>{job_state=3?pending since<BR>{?time_at_creation=?Unknown:{time_at_creation}}:{job_state=4?held since<BR>{?time_at_creation=?Unknown:{time_at_creation}}:

--- a/templates/pt_BR/jobs.tmpl
+++ b/templates/pt_BR/jobs.tmpl
@@ -8,7 +8,7 @@
 <TR VALIGN="TOP">
 <TD><A HREF="{job_printer_uri}">{job_printer_name}</A>-{job_id}{?phone? ({phone}):}&nbsp;</TD>
 <TD>{?job_name=?Desconhecido:{job_name}}&nbsp;</TD>
-<TD>{?job_originating_user_name=?Retido:{job_originating_user_name}} @ {job_originating_host_name}&nbsp;</TD>
+<TD>{?job_originating_user_name=?Retido:{job_originating_user_name}}{?job_originating_user_name=?:{?job_originating_host_name=localhost?: @ {job_originating_host_name}}}&nbsp;</TD>
 <TD>{job_k_octets}k&nbsp;</TD>
 <TD>{job_impressions_completed=0?Desconhecido:{?job_impressions_completed}}&nbsp;</TD>
 <TD>{job_state=3?Pendente desde<BR>{?time_at_creation=?Unknown:{time_at_creation}}:{job_state=4?Retido desde<BR>{?time_at_creation=?Unknown:{time_at_creation}}:

--- a/templates/pt_BR/jobs.tmpl
+++ b/templates/pt_BR/jobs.tmpl
@@ -8,7 +8,7 @@
 <TR VALIGN="TOP">
 <TD><A HREF="{job_printer_uri}">{job_printer_name}</A>-{job_id}{?phone? ({phone}):}&nbsp;</TD>
 <TD>{?job_name=?Desconhecido:{job_name}}&nbsp;</TD>
-<TD>{?job_originating_user_name=?Retido:{job_originating_user_name}}&nbsp;</TD>
+<TD>{?job_originating_user_name=?Retido:{job_originating_user_name}} @ {job_originating_host_name}&nbsp;</TD>
 <TD>{job_k_octets}k&nbsp;</TD>
 <TD>{job_impressions_completed=0?Desconhecido:{?job_impressions_completed}}&nbsp;</TD>
 <TD>{job_state=3?Pendente desde<BR>{?time_at_creation=?Unknown:{time_at_creation}}:{job_state=4?Retido desde<BR>{?time_at_creation=?Unknown:{time_at_creation}}:

--- a/templates/ru/jobs.tmpl
+++ b/templates/ru/jobs.tmpl
@@ -7,8 +7,8 @@
 {[job_id]
 <TR VALIGN="TOP">
 <TD><A HREF="{job_printer_uri}">{job_printer_name}</A>-{job_id}{?phone? ({phone}):}&nbsp;</TD>
-<TD>{?job_name=?Неизвестное:{job_name}}&nbsp;</TD>
-<TD>{?job_originating_user_name=?Приостановлено пользователем:{job_originating_user_name}}&nbsp;</TD>
+<TD>{?job_name=?Неизвестный документ:{job_name}}&nbsp;</TD>
+<TD>{?job_originating_user_name=?Неизвестный пользователь:{job_originating_user_name}} @ {job_originating_host_name}&nbsp;</TD>
 <TD>{job_k_octets}k&nbsp;</TD>
 <TD>{job_impressions_completed=0?Неизвестно:{?job_impressions_completed}}&nbsp;</TD>
 <TD>{job_state=3?В очереди<BR>{?time_at_creation=?Unknown:{time_at_creation}}:{job_state=4?Приостановлено с<BR>{?time_at_creation=?Unknown:{time_at_creation}}:

--- a/templates/ru/jobs.tmpl
+++ b/templates/ru/jobs.tmpl
@@ -8,7 +8,7 @@
 <TR VALIGN="TOP">
 <TD><A HREF="{job_printer_uri}">{job_printer_name}</A>-{job_id}{?phone? ({phone}):}&nbsp;</TD>
 <TD>{?job_name=?Неизвестный документ:{job_name}}&nbsp;</TD>
-<TD>{?job_originating_user_name=?Неизвестный пользователь:{job_originating_user_name}} @ {job_originating_host_name}&nbsp;</TD>
+<TD>{?job_originating_user_name=?Неизвестный пользователь:{job_originating_user_name}}{?job_originating_user_name=?:{?job_originating_host_name=localhost?: @ {job_originating_host_name}}}&nbsp;</TD>
 <TD>{job_k_octets}k&nbsp;</TD>
 <TD>{job_impressions_completed=0?Неизвестно:{?job_impressions_completed}}&nbsp;</TD>
 <TD>{job_state=3?В очереди<BR>{?time_at_creation=?Unknown:{time_at_creation}}:{job_state=4?Приостановлено с<BR>{?time_at_creation=?Unknown:{time_at_creation}}:


### PR DESCRIPTION

I am using a Canon MF4550d MFU. Upon installation on Windows, there are two different drivers I can use: Microsoft IPP Class Driver and Canon MF4550D URFII LT Driver.

The first one, should it be called Microsoft driver for short, reports usernames in `HOSTNAME\USERNAME` format. But as the standard driver, it only has basic functionality and so I prefer to use the Canon driver.

The other driver (Canon MF4550d URFII LT) reports just the user name. It can be a problem if an user uses the same username on different computers, which often happens on Windows PCs.

This is the reasoning behind the changes I made. It would be great to also add an option to choose whether the hostname should be displayed or not. But my knowledge in C++ doesn't allow me to do that.

