### PR TITLE
cups/ppd-cache.c: Add cupsUrfSupported to generated PPD (see #804)

### DIFF
--- a/cups/ppd-cache.c
+++ b/cups/ppd-cache.c
@@ -3479,6 +3479,20 @@ _ppdCreateFromIPP2(
     goto bad_ppd;
 
  /*
+  * cupsUrfSupported
+  */
+  if ((attr = ippFindAttribute(supported, "urf-supported", IPP_TAG_KEYWORD)) != NULL)
+  {
+    cupsFilePuts(fp, "*cupsUrfSupported: \"");
+    for (i = 0, count = ippGetCount(attr); i < count; i ++)
+    {
+      keyword = ippGetString(attr, i, NULL);
+      cupsFilePrintf(fp, "%s%s", keyword, i ? "" : ",");
+    }
+    cupsFilePuts(fp, "\"\n");
+  }
+
+ /*
   * PageSize/PageRegion/ImageableArea/PaperDimension
   */
 


### PR DESCRIPTION
It fixes driverless printing on Pantum BM5100ADW Series and, probably, on many other devices.

- Without this parameter, /usr/lib/cups/filter/universal generates RGB image/urf even for monochrome printer
- Pantum BM5100ADW Series rejects to print these RGB images with the "Print job canceled at printer" status.
- Probably, this issue affects many other devices

See #804 for details.