### PR TITLE
cups/dest.c: Raise timeout _CUPS_DNSSD_GET_DESTS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@ Changes in CUPS v2.5b1 (TBA)
 - Fixed use-after-free in `cupsdAcceptClient()` when we log warning during error
   handling (fixes CVE-2023-34241)
 - Fixed a bug in the PPD command interpretation code (Issue #768)
+- Raised `cups_enum_dests()` timeout for listing available IPP printers (Issue #751)
 - Removed `HAVE_LIBZ` and `HAVE_POLL` defines, making CUPS to depend
   on the functionality
 - Removed hash support for SHA2-512-224 and SHA2-512-256

--- a/cups/dest.c
+++ b/cups/dest.c
@@ -40,7 +40,7 @@
 #  define kUseLastPrinter	CFSTR("UseLastPrinter")
 #endif // __APPLE__
 
-#define _CUPS_DNSSD_GET_DESTS	250	// Milliseconds for cupsGetDests
+#define _CUPS_DNSSD_GET_DESTS	1000	// Milliseconds for cupsGetDests
 #define _CUPS_DNSSD_MAXTIME	50	// Milliseconds for maximum quantum of time
 
 


### PR DESCRIPTION
The current timeout is not able to list all network devices if there are many IPP services on mDNS (the tested number is 165 services).

Raising the timeout to 1s does not slow libcups if there are less services (Avahi returns earlier) or if Avahi does not run on the system (libcups cannot create an Avahi client in that case), and provides time frame for getting reasonable amount of IPP services (big enterprise servers will use permanent queues and printer profiles than mDNS).

Fixes #751