### PR TITLE
scheduler/job.c: unload job before freeing job history in cupsdDeletejob()

### DIFF
--- a/scheduler/job.c
+++ b/scheduler/job.c
@@ -1405,10 +1405,10 @@ cupsdDeleteJob(cupsd_job_t       *job,	/* I - Job */
     job->num_files = 0;
   }
 
+  unload_job(job);
+
   if (job->history)
     free_job_history(job);
-
-  unload_job(job);
 
   cupsArrayRemove(Jobs, job);
   cupsArrayRemove(ActiveJobs, job);


### PR DESCRIPTION
With "PreserveJobHistory Off", LogLevel not set to debug (or debug2), and "LogDebugHistory 200" (the default), cupsdDeleteJob() frees the job history and then unloads the job.  However, unload_job() calls cupsdLogJob() which re-creates the job history and puts "Unloading..." into it because level (debug) is greater than LogLevel (warn) and LogDebugHistory is set to 200 messages by default.  Unused (and unreachable) job history is left behind, resulting in a memory leak.

The solution seems to be to unload the job before freeing the job history.