### PR TITLE
scheduler/colorman.c: Fix memory leak during creating color profile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ CHANGES - OpenPrinting CUPS 2.4.8 - TBA
 Changes in CUPS v2.4.8 (TBA)
 ----------------------------
 
+- Fixed memory leak when creating color profiles
 - Raised `cups_enum_dests()` timeout for listing available IPP printers (Issue #751)
 - Really backport fix for Issue #742
 

--- a/scheduler/colorman.c
+++ b/scheduler/colorman.c
@@ -1080,7 +1080,7 @@ colord_create_profile(
 
   dbus_message_iter_get_basic(&args, &profile_path);
   cupsdLogMessage(CUPSD_LOG_DEBUG, "Created profile \"%s\".", profile_path);
-  cupsArrayAdd(profiles, strdup(profile_path));
+  cupsArrayAdd(profiles, profile_path);
 
 out:
 


### PR DESCRIPTION
 Since the array `profiles` is set to use `strdup()` as a copy function, we
 don't have to use `strdup()` on the element which is passed as parameter
 of `cupsArrayAdd()` - using the `strdup()` as we used till now causes
 memory leak.

 Reproducer is the same as https://github.com/OpenPrinting/cups/pull/813