### PR TITLE
fixed unreachable if-clause

### DIFF
--- a/scheduler/printers.c
+++ b/scheduler/printers.c
@@ -4597,7 +4597,7 @@ load_ppd(cupsd_printer_t *p)		/* I - Printer */
         ppd_option_t *color_model = ppdFindOption(ppd, "ColorModel");
 					// ColorModel PPD option
 
-        if (color_model && strcmp(color_model->defchoice, "RGB") && strcmp(color_model->defchoice, "CMYK"))
+        if (color_model && (strcmp(color_model->defchoice, "RGB") || strcmp(color_model->defchoice, "CMYK")))
           p->num_options = cupsAddOption("print-color-mode", "monochrome", p->num_options, &p->options);
       }
     }


### PR DESCRIPTION
I think in the old version needed the string 'color_model->defchoice' needed to be "RGB" and "CMYK" at the same time to enter the if-clause.