### PR TITLE
lpstat.c: Implement successful filter for jobs

### DIFF
--- a/doc/help/man-lpstat.html
+++ b/doc/help/man-lpstat.html
@@ -83,7 +83,7 @@ Shows the ranking of print jobs.
 Specifies an alternate username.
 </p>
     <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>-W </strong><em>which-jobs</em><br>
-Specifies which jobs to show, &quot;completed&quot; or &quot;not-completed&quot; (the default).
+Specifies which jobs to show, &quot;all&quot;, &quot;successful&quot;, &quot;completed&quot; or &quot;not-completed&quot; (the default).
 This option <em>must</em> appear before the <em>-o</em> option and/or any printer names, otherwise the default (&quot;not-completed&quot;) value will be used in the request to the scheduler.
 </p>
     <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>-a </strong>[<em>printer(s)</em>]<br>

--- a/man/lpstat.1
+++ b/man/lpstat.1
@@ -82,7 +82,7 @@ Shows the ranking of print jobs.
 Specifies an alternate username.
 .TP 5
 \fB\-W \fIwhich-jobs\fR
-Specifies which jobs to show, "completed" or "not-completed" (the default).
+Specifies which jobs to show, "all, "successful", "completed" or "not-completed" (the default).
 This option \fImust\fR appear before the \fI-o\fR option and/or any printer names, otherwise the default ("not-completed") value will be used in the request to the scheduler.
 .TP 5
 \fB\-a \fR[\fIprinter(s)\fR]

--- a/systemv/lpstat.c
+++ b/systemv/lpstat.c
@@ -141,16 +141,16 @@ main(int  argc,				/* I - Number of command-line arguments */
 
 		if (i >= argc)
 		{
-		  _cupsLangPrintf(stderr, _("%s: Error - need \"completed\", \"not-completed\", or \"all\" after \"-W\" option."), argv[0]);
+		  _cupsLangPrintf(stderr, _("%s: Error - need \"completed\", \"not-completed\", \"successful\", or \"all\" after \"-W\" option."), argv[0]);
 		  usage();
 		}
 
 		which = argv[i];
 	      }
 
-	      if (strcmp(which, "completed") && strcmp(which, "not-completed") && strcmp(which, "all"))
+	      if (strcmp(which, "completed") && strcmp(which, "not-completed") && strcmp(which, "all") && strcmp(which, "successful"))
 	      {
-		_cupsLangPrintf(stderr, _("%s: Error - need \"completed\", \"not-completed\", or \"all\" after \"-W\" option."), argv[0]);
+		_cupsLangPrintf(stderr, _("%s: Error - need \"completed\", \"not-completed\", \"successful\", or \"all\" after \"-W\" option."), argv[0]);
 		usage();
 	      }
 	      break;
@@ -1358,7 +1358,7 @@ show_jobs(const char *dests,		/* I - Destinations */
                NULL, cupsGetUser());
 
   ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_KEYWORD, "which-jobs",
-               NULL, which);
+               NULL, !strcmp(which, "successful") ? "completed" : which);
 
  /*
   * Do the request and get back a response...
@@ -1396,6 +1396,7 @@ show_jobs(const char *dests,		/* I - Destinations */
 
     if (!strcmp(which, "aborted") ||
         !strcmp(which, "canceled") ||
+        !strcmp(which, "successful") ||
         !strcmp(which, "completed"))
       time_at = "time-at-completed";
     else
@@ -1476,7 +1477,11 @@ show_jobs(const char *dests,		/* I - Destinations */
 
       if (match_list(dests, dest) && match_list(users, username))
       {
-        snprintf(temp, sizeof(temp), "%s-%d", dest, jobid);
+	if (!strcmp(which, "successful") && (!reasons || (reasons &&
+	    strcmp(reasons->name, "job-completed-successfully"))))
+	  continue;
+
+	snprintf(temp, sizeof(temp), "%s-%d", dest, jobid);
 
 	_cupsStrDate(date, sizeof(date), jobtime);
 
@@ -1557,7 +1562,7 @@ show_printers(const char  *printers,	/* I - Destinations */
   int		jobid;			/* Job ID of current job */
   char		printer_uri[HTTP_MAX_URI],
 					/* Printer URI */
-		printer_state_time[255];/* Printer state time */
+	printer_state_time[255];/* Printer state time */
   _cups_globals_t *cg = _cupsGlobals();	/* Global data */
   static const char *pattrs[] =		/* Attributes we need for printers... */
 		{

--- a/systemv/lpstat.c
+++ b/systemv/lpstat.c
@@ -1478,7 +1478,7 @@ show_jobs(const char *dests,		/* I - Destinations */
       if (match_list(dests, dest) && match_list(users, username))
       {
 	if (!strcmp(which, "successful") && (!reasons || (reasons &&
-	    strcmp(reasons->name, "job-completed-successfully"))))
+	    strcmp(reasons->values[0].string.text, "job-completed-successfully"))))
 	  continue;
 
 	snprintf(temp, sizeof(temp), "%s-%d", dest, jobid);


### PR DESCRIPTION
`lpstat` does not have a way how to show successful jobs. One possible solution would be to rewrite the behavior of 'completed' type, but this can cause discrepancies in behavior which some users can expect.

Fixes #828

EDIT:
Now lpstat does filtering after receiving response, so no need for new support in cupsd - however lpstat still shows a new argument value.