### PR TITLE
scheduler: Set reasons in cupsdSetJobState only if we call finalize_j…

### DIFF
--- a/scheduler/job.c
+++ b/scheduler/job.c
@@ -2593,8 +2593,16 @@ cupsdSetJobState(
     case IPP_JSTATE_CANCELED :
     case IPP_JSTATE_COMPLETED :
 	set_time(job, "time-at-completed");
-	ippSetString(job->attrs, &job->reasons, 0, "processing-to-stop-point");
-        break;
+
+       /*
+	* Set the reasons here only if we call finalize_job()
+	* at the end of this function, so finished jobs can get proper
+	* reasons message there...
+	*/
+
+	if (action > CUPSD_JOB_DEFAULT || !job || !job->printer)
+	  ippSetString(job->attrs, &job->reasons, 0, "processing-to-stop-point");
+	break;
   }
 
  /*

--- a/scheduler/job.c
+++ b/scheduler/job.c
@@ -2600,7 +2600,7 @@ cupsdSetJobState(
 	* reasons message there...
 	*/
 
-	if (action > CUPSD_JOB_DEFAULT || !job || !job->printer)
+	if (action >= CUPSD_JOB_FORCE && job && job->printer)
 	  ippSetString(job->attrs, &job->reasons, 0, "processing-to-stop-point");
 	break;
   }


### PR DESCRIPTION
…ob later

Before the fix, every successfully printed jobs ended up with 'processing-to-stop-point' as the last reasons message.

Together with #830 fixes #828 .