### PR TITLE
raster-interpreter.c: Fix crash in 'scan_ps()' found by fuzzer

### DIFF
--- a/cups/raster-interpret.c
+++ b/cups/raster-interpret.c
@@ -1047,6 +1047,8 @@ scan_ps(_cups_ps_stack_t *st,		/* I  - Stack */
   int			parens;		/* Parenthesis nesting level */
 
 
+  if (!*ptr)
+    return (NULL);
  /*
   * Skip leading whitespace...
   */


### PR DESCRIPTION
Fuzzer using `_cupsRasterExecPS()` found a way how to pass NULL into `scan_ps()`, causing crash - we have to sanitize the argument for NULL to fix it.

Fixes #831