### PR TITLE
scheduler: Fix build failure on Linux with '-Werror -Wall'

### DIFF
--- a/scheduler/colorman.c
+++ b/scheduler/colorman.c
@@ -1014,7 +1014,7 @@ colord_create_profile(
   DBusError	error;			/* D-Bus error */
   char		*idstr;			/* Profile ID string */
   size_t	idstrlen;		/* Profile ID allocated length */
-  const char	*profile_path;		/* Device object path */
+  char		*profile_path;		/* Device object path */
   char		format_str[1024];	/* Qualifier format as a string */
 
 


### PR DESCRIPTION
The string which we add into array stays `const` after fixing #814 (because `strdup()`, which caused memory leak returned `char *`) and compiler fails because of it if it runs with '-Werror -Wall'.