### PR TITLE
scheduler: Fix reasons for previously printed jobs

### DIFF
--- a/scheduler/job.c
+++ b/scheduler/job.c
@@ -1832,6 +1832,14 @@ cupsdLoadJob(cupsd_job_t *job)		/* I - Job */
     else
       ippSetString(job->attrs, &job->reasons, 0, "none");
   }
+  else if (job->state_value == IPP_JSTATE_COMPLETED && !strcmp(job->reasons, "processing-to-stop-point"))
+  {
+   /*
+    * Try to fix job reasons for older jobs finished before openprinting/cups #832 was applied...
+    */
+
+    ippSetString(job->attrs, &job->reasons, 0, "job-completed-successfully");
+  }
 
   job->impressions = ippFindAttribute(job->attrs, "job-impressions-completed", IPP_TAG_INTEGER);
   job->sheets      = ippFindAttribute(job->attrs, "job-media-sheets-completed", IPP_TAG_INTEGER);

--- a/scheduler/job.c
+++ b/scheduler/job.c
@@ -1832,7 +1832,7 @@ cupsdLoadJob(cupsd_job_t *job)		/* I - Job */
     else
       ippSetString(job->attrs, &job->reasons, 0, "none");
   }
-  else if (job->state_value == IPP_JSTATE_COMPLETED && !strcmp(job->reasons, "processing-to-stop-point"))
+  else if (job->state_value == IPP_JSTATE_COMPLETED && !strcmp(ippGetString(job->reasons, 0, NULL), "processing-to-stop-point"))
   {
    /*
     * Try to fix job reasons for older jobs finished before openprinting/cups #832 was applied...


### PR DESCRIPTION
Before #832 most successfully finished jobs had incorrect job state reasons - try to fix them during loading the jobs.