### PR TITLE
backend/ipp.c: Fix infinite loop with Kerberos

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,7 @@ Changes in CUPS v2.5b1 (TBA)
 - Fixed memory leak when creating color profiles (Issue #814)
 - Fixed crash in `scan_ps()` if incoming argument is NULL (Issue #831)
 - Fixed setting job state reasons for successful jobs (Issue #832)
+- Fixed infinite loop in IPP backend if hostname is IP address with Kerberos (Issue #838)
 - Fixed crash in `ppdEmitString()` if there is no record for page size `Custom`
   (Issue #849)
 - Fixed reporting `media-source-supported` when sharing printer which has numbers as strings

--- a/backend/ipp.c
+++ b/backend/ipp.c
@@ -409,6 +409,19 @@ main(int  argc,				/* I - Number of command-line args */
   else
     cupsSetEncryption(HTTP_ENCRYPTION_IF_REQUESTED);
 
+  if (!strcmp(auth_info_required, "negotiate") &&
+      (isdigit(hostname[0] & 255) || hostname[0] == '['))
+  {
+   /*
+    * IP addresses are not allowed with Kerberos...
+    */
+
+    _cupsLangPrintFilter(stderr, "ERROR",
+			 _("IP address is not allowed as hostname when using Negotiate - use FQDN."));
+    update_reasons(NULL, "-connecting-to-device");
+    return (CUPS_BACKEND_FAILED);
+  }
+
  /*
   * See if there are any options...
   */


### PR DESCRIPTION
If IP address was used with Kerberos, IPP backend retried connection indefinitely. The fix is to abort when we find out hostname is an IP address and we require Kerberos.

Fixes #838