### PR TITLE
Update man pages for default printer

### DIFF
--- a/doc/help/man-lp.html
+++ b/doc/help/man-lp.html
@@ -201,6 +201,13 @@ Prints on both sides of the paper for portrait output.
     <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>-o sides=two-sided-short-edge</strong><br>
 Prints on both sides of the paper for landscape output.
 </p>
+    <h2 id="lp-1.environment-variables">Environment Variables</h2>
+    <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>LPDEST</strong><br>
+Specifies the default print queue (System V standard).
+</p>
+    <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>PRINTER</strong><br>
+Specifies the default print queue (Berkeley standard).
+</p>
     <h2 id="lp-1.conforming-to">Conforming To</h2>
 <p>Unlike the System V printing system, CUPS allows printer names to contain any printable character except SPACE, TAB, &quot;/&quot;, or &quot;#&quot;.
 Also, printer and class names are <em>not</em> case-sensitive.

--- a/doc/help/man-lpadmin.html
+++ b/doc/help/man-lpadmin.html
@@ -7,7 +7,7 @@
   <body>
     <h1 id="lpadmin-8">lpadmin(8)</h1>
     <h2 id="lpadmin-8.name">Name</h2>
-<p>lpadmin - configure cups printers and classes
+<p>lpadmin - configure printers and classes on cups scheduler
 </p>
     <h2 id="lpadmin-8.synopsis">Synopsis</h2>
 <p><strong>lpadmin</strong>

--- a/doc/help/man-lpoptions.html
+++ b/doc/help/man-lpoptions.html
@@ -7,7 +7,7 @@
   <body>
     <h1 id="lpoptions-1">lpoptions(1)</h1>
     <h2 id="lpoptions-1.name">Name</h2>
-<p>lpoptions - display or set printer options and defaults
+<p>lpoptions - display or set user printer options and defaults
 </p>
     <h2 id="lpoptions-1.synopsis">Synopsis</h2>
 <p><strong>lpoptions</strong>
@@ -113,6 +113,13 @@ command.
 <p><em>~/.cups/lpoptions</em> - user defaults and instances created by non-root users.
 <br>
 <em>/etc/cups/lpoptions</em> - system-wide defaults and instances created by the root user.
+</p>
+    <h2 id="lpoptions-1.environment-variables">Environment Variables</h2>
+    <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>LPDEST</strong><br>
+Specifies the default print queue (System V standard).
+</p>
+    <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>PRINTER</strong><br>
+Specifies the default print queue (Berkeley standard).
 </p>
     <h2 id="lpoptions-1.conforming-to">Conforming To</h2>
 <p>The <strong>lpoptions</strong> command is unique to CUPS.

--- a/doc/help/man-lpr.html
+++ b/doc/help/man-lpr.html
@@ -156,6 +156,13 @@ Prints on both sides of the paper for portrait output.
     <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>-o sides=two-sided-short-edge</strong><br>
 Prints on both sides of the paper for landscape output.
 </p>
+    <h2 id="lpr-1.environment-variables">Environment Variables</h2>
+    <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>LPDEST</strong><br>
+Specifies the default print queue (System V standard).
+</p>
+    <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>PRINTER</strong><br>
+Specifies the default print queue (Berkeley standard).
+</p>
     <h2 id="lpr-1.notes">Notes</h2>
 <p>The <em>-c</em>, <em>-d</em>, <em>-f</em>, <em>-g</em>, <em>-i</em>, <em>-n</em>, <em>-t</em>, <em>-v</em>, and <em>-w</em> options are not supported by CUPS and produce a warning message if used.
 </p>

--- a/doc/help/man-lpstat.html
+++ b/doc/help/man-lpstat.html
@@ -95,7 +95,7 @@ Shows the printer classes and the printers that belong to them.
 If no classes are specified then all classes are listed.
 </p>
     <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>-d</strong><br>
-Shows the current default destination.
+Shows the current default destination, either the lpoptions default (if set), or the scheduler default (otherwise).
 </p>
     <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>-e</strong><br>
 Shows all available destinations on the local network.
@@ -133,6 +133,13 @@ If no users are specified, lists the jobs queued by the current user.
     <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>-v </strong>[<em>printer(s)</em>]<br>
 Shows the printers and what device they are attached to.
 If no printers are specified then all printers are listed.
+</p>
+    <h2 id="lpstat-1.environment-variables">Environment Variables</h2>
+    <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>LPDEST</strong><br>
+Specifies the default print queue (System V standard).
+</p>
+    <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>PRINTER</strong><br>
+Specifies the default print queue (Berkeley standard).
 </p>
     <h2 id="lpstat-1.conforming-to">Conforming To</h2>
 <p>Unlike the System V printing system, CUPS allows printer names to contain any printable character except SPACE, TAB, &quot;/&quot;, and &quot;#&quot;.

--- a/man/lp.1
+++ b/man/lp.1
@@ -195,6 +195,13 @@ Prints on both sides of the paper for portrait output.
 .TP 5
 \fB\-o sides=two\-sided\-short\-edge\fR
 Prints on both sides of the paper for landscape output.
+.SH ENVIRONMENT VARIABLES
+.TP 5
+.B LPDEST
+Specifies the default print queue (System V standard).
+.TP 5
+.B PRINTER
+Specifies the default print queue (Berkeley standard).
 .SH CONFORMING TO
 Unlike the System V printing system, CUPS allows printer names to contain any printable character except SPACE, TAB, "/", or "#".
 Also, printer and class names are \fInot\fR case-sensitive.

--- a/man/lpadmin.8
+++ b/man/lpadmin.8
@@ -10,7 +10,7 @@
 .\"
 .TH lpadmin 8 "CUPS" "2021-02-28" "OpenPrinting"
 .SH NAME
-lpadmin \- configure cups printers and classes
+lpadmin \- configure printers and classes on cups scheduler
 .SH SYNOPSIS
 .B lpadmin
 [

--- a/man/lpoptions.1
+++ b/man/lpoptions.1
@@ -10,7 +10,7 @@
 .\"
 .TH lpoptions 1 "CUPS" "2022-05-02" "OpenPrinting"
 .SH NAME
-lpoptions \- display or set printer options and defaults
+lpoptions \- display or set user printer options and defaults
 .SH SYNOPSIS
 .B lpoptions
 [
@@ -107,6 +107,13 @@ command.
 \fI~/.cups/lpoptions\fR - user defaults and instances created by non-root users.
 .br
 \fI/etc/cups/lpoptions\fR - system-wide defaults and instances created by the root user.
+.SH ENVIRONMENT VARIABLES
+.TP 5
+.B LPDEST
+Specifies the default print queue (System V standard).
+.TP 5
+.B PRINTER
+Specifies the default print queue (Berkeley standard).
 .SH CONFORMING TO
 The \fBlpoptions\fR command is unique to CUPS.
 .SH SEE ALSO

--- a/man/lpr.1
+++ b/man/lpr.1
@@ -150,6 +150,13 @@ Prints on both sides of the paper for portrait output.
 .TP 5
 \fB\-o sides=two\-sided\-short\-edge\fR
 Prints on both sides of the paper for landscape output.
+.SH ENVIRONMENT VARIABLES
+.TP 5
+.B LPDEST
+Specifies the default print queue (System V standard).
+.TP 5
+.B PRINTER
+Specifies the default print queue (Berkeley standard).
 .SH NOTES
 The \fI\-c\fR, \fI\-d\fR, \fI\-f\fR, \fI\-g\fR, \fI\-i\fR, \fI\-n\fR, \fI\-t\fR, \fI\-v\fR, and \fI\-w\fR options are not supported by CUPS and produce a warning message if used.
 .SH EXAMPLES

--- a/man/lpstat.1
+++ b/man/lpstat.1
@@ -82,7 +82,7 @@ Shows the ranking of print jobs.
 Specifies an alternate username.
 .TP 5
 \fB\-W \fIwhich-jobs\fR
-Specifies which jobs to show, "all, "successful", "completed" or "not-completed" (the default).
+Specifies which jobs to show, "all", "successful", "completed" or "not-completed" (the default).
 This option \fImust\fR appear before the \fI-o\fR option and/or any printer names, otherwise the default ("not-completed") value will be used in the request to the scheduler.
 .TP 5
 \fB\-a \fR[\fIprinter(s)\fR]
@@ -94,7 +94,7 @@ Shows the printer classes and the printers that belong to them.
 If no classes are specified then all classes are listed.
 .TP 5
 .B \-d
-Shows the current default destination.
+Shows the current default destination, either the lpoptions default (if set), or the scheduler default (otherwise).
 .TP 5
 .B \-e
 Shows all available destinations on the local network.
@@ -132,6 +132,13 @@ If no users are specified, lists the jobs queued by the current user.
 \fB\-v \fR[\fIprinter(s)\fR]
 Shows the printers and what device they are attached to.
 If no printers are specified then all printers are listed.
+.SH ENVIRONMENT VARIABLES
+.TP 5
+.B LPDEST
+Specifies the default print queue (System V standard).
+.TP 5
+.B PRINTER
+Specifies the default print queue (Berkeley standard).
 .SH CONFORMING TO
 Unlike the System V printing system, CUPS allows printer names to contain any printable character except SPACE, TAB, "/", and "#".
 Also, printer and class names are \fInot\fR case-sensitive.


### PR DESCRIPTION
Attempt to make explanation where the default printer is taken from clearer:

$HOME/lpoptions (/etc/cups/lpoptions for root) > ENV variables LPDEST/PRINTER > Server Default

Fixes #819