### PR TITLE
backend/ipp.c: Fix printing jobs with long names on older IPP printers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@ Changes in CUPS v2.5b1 (TBA)
 - Fixed Digest authentication support (Issue #260)
 - Fixed extensive looping in scheduler (Issue #604)
 - Fixed printing multiple files on specific printers (Issue #643)
+- Fixed printing of jobs with job name longer than 255 chars on older printers (Issue #644)
 - Fixed segfault in `cupsGetNamedDest()` when trying to get default printer, but
   the default printer is not set (Issue #719)
 - Fixed ready media support for iOS 17+ (Issue #738)

--- a/backend/ipp.c
+++ b/backend/ipp.c
@@ -216,7 +216,7 @@ main(int  argc,				/* I - Number of command-line args */
   off_t		compatsize = 0;		/* Size of compatibility file */
   int		port;			/* Port number (not used) */
   char		uri[HTTP_MAX_URI];	/* Updated URI without user/pass */
-  char		print_job_name[1024];	/* Update job-name for Print-Job */
+  char		print_job_name[256];	/* Update job-name for Print-Job */
   http_status_t	http_status;		/* Status of HTTP request */
   ipp_status_t	ipp_status;		/* Status of IPP request */
   http_t	*http;			/* HTTP connection */
@@ -1464,6 +1464,10 @@ main(int  argc,				/* I - Number of command-line args */
   }
   else
   {
+   /*
+    * TODO: make this compatible with UTF-8 - possible UTF-8 truncation here..
+    */
+
     snprintf(print_job_name, sizeof(print_job_name), "%s - %s", argv[1],
              argv[3]);
     monitor.job_name = print_job_name;


### PR DESCRIPTION
On older printers (ones which don't support IPP operation Create-Job) we concatenate job number and title into one string, which we use as IPP attribute job-name. If the original title was almost 255 chars, the joining the strings will overflow maximal required length for this attribute, and Validate-Job fails.

We could check whether the string is longer than 255 and cut it, but I chose to shrink the buffer to 256, since we already use `snprintf()` which will cut the string and put null terminator for us.

Fixes #644