### PR TITLE
http: return from httpGets2() on unhandled errors

### DIFF
--- a/cups/http.c
+++ b/cups/http.c
@@ -1091,6 +1091,7 @@ httpGets2(http_t *http,			// I - HTTP connection
 	    continue;
 
 	  http->error = WSAGetLastError();
+          return (NULL);
 	}
 	else if (WSAGetLastError() != http->error)
 	{
@@ -1113,6 +1114,7 @@ httpGets2(http_t *http,			// I - HTTP connection
 	    continue;
 
 	  http->error = errno;
+          return (NULL);
 	}
 	else if (errno != http->error)
 	{


### PR DESCRIPTION
Closes: #879

In case of some errors httpGets2 waits for the next packet. In all other cases of errors it should return NULL to avoid negative values of http->used leading to ending up in an endless loop.