### PR TITLE
Fixed a couple of gcc warnings

### DIFF
--- a/cups/dest.c
+++ b/cups/dest.c
@@ -1730,7 +1730,7 @@ cupsGetNamedDest(http_t     *http,	// I - Connection to server or @code CUPS_HTT
       DEBUG_puts("1cupsGetNamedDest: Asking server for default printer...");
     }
     else
-      DEBUG_printf("1cupsGetNamedDest: Using name=\"%s\"...", name);
+      DEBUG_printf("1cupsGetNamedDest: Using dest_name=\"%s\"...", dest_name);
   }
 
   //


### PR DESCRIPTION
In cups/dest.c:

    dest.c:1830:21: warning: ‘%s’ directive argument is null [-Wformat-overflow=]
     1733 |       DEBUG_printf(("1cupsGetNamedDest: Using name=\"%s\"...", name));
	  |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

This is really true, and gcc was smart enough to deduct it from context. Obviously, we meant to print dest_name here.

In cgi-bin/search.c:

    search.c:191:29: warning: pointer ‘s’ may be used after ‘realloc’ [-Wuse-after-free]
      191 |         sptr = temp + (sptr - s);
	  |                       ~~~~~~^~~~

The code is correct, but too hard for gcc to analyze. So code simplified a bit to make compiler happy.