### PR TITLE
Trying to display non-existing printer/class in web ui doesn't return 404 : Fixes #423

### DIFF
--- a/templates/class.tmpl
+++ b/templates/class.tmpl
@@ -1,3 +1,4 @@
+{printer_state?<H1></H1>:<H1>ERROR : No class found</H1>}
 <H2 CLASS="title"><A HREF="{printer_uri_supported}">{printer_name}</A>
 ({printer_state=3?Idle:{printer_state=4?Processing:Paused}},
 {printer_is_accepting_jobs=0?Rejecting Jobs:Accepting Jobs},

--- a/templates/printer.tmpl
+++ b/templates/printer.tmpl
@@ -1,3 +1,4 @@
+{printer_state?<H1></H1>:<H1>ERROR : No printer found</H1>}
 <H2 CLASS="title"><A HREF="{printer_uri_supported}">{printer_name}</A>
 ({printer_state=3?Idle:{printer_state=4?Processing:Paused}},
 {printer_is_accepting_jobs=0?Rejecting Jobs:Accepting Jobs},


### PR DESCRIPTION
Fixes Issue #423 :
When user open the api for any unknown classes or printers, then previously it was showing a random UI with that printer/class name.
Now it will throw "ERROR : No class/printer found " error for those cases.
Example for : http://localhost:631/classes/testclass or http://localhost:631/printers/testpriner
@tillkamppeter please review the PR