### PR TITLE
ppd-cache.c: Check for `urf-supported` if `image/urf` is found

### DIFF
--- a/cups/ppd-cache.c
+++ b/cups/ppd-cache.c
@@ -3435,7 +3435,7 @@ _ppdCreateFromIPP2(
 
   if ((attr = ippFindAttribute(supported, "document-format-supported", IPP_TAG_MIMETYPE)) != NULL)
   {
-    is_apple = ippContainsString(attr, "image/urf");
+    is_apple = ippContainsString(attr, "image/urf") && (ippFindAttribute(supported, "urf-supported", IPP_TAG_KEYWORD) != NULL);
     is_pdf   = ippContainsString(attr, "application/pdf");
     is_pwg   = ippContainsString(attr, "image/pwg-raster") && !is_apple;
 

--- a/cups/ppd-cache.c
+++ b/cups/ppd-cache.c
@@ -3437,7 +3437,9 @@ _ppdCreateFromIPP2(
   {
     is_apple = ippContainsString(attr, "image/urf") && (ippFindAttribute(supported, "urf-supported", IPP_TAG_KEYWORD) != NULL);
     is_pdf   = ippContainsString(attr, "application/pdf");
-    is_pwg   = ippContainsString(attr, "image/pwg-raster") && !is_apple;
+    is_pwg   = ippContainsString(attr, "image/pwg-raster") && !is_apple &&
+	       (ippFindAttribute(supported, "pwg-raster-document-resolution-supported", IPP_TAG_KEYWORD) != NULL) &&
+	       (ippFindAttribute(supported, "pwg-raster-document-type-supported", IPP_TAG_KEYWORD) != NULL);
 
     if (ippContainsString(attr, "image/jpeg"))
       cupsFilePuts(fp, "*cupsFilter2: \"image/jpeg image/jpeg 0 -\"\n");


### PR DESCRIPTION
Some devices have `image/urf` in `document-format-supported`, but is missing `urf-supported` if AirPrint support is turned off, which breaks PPD generation.

Check for attribute `urf-supported` when we are about to decide whether the printer uses AirPrint, so in case the device supports another driverless standard, we can use it for PPD generation.

Fixes [Fedora issue](https://bugzilla.redhat.com/show_bug.cgi?id=2263053)