### PR TITLE
Use PAM password-auth or system-auth if present

### DIFF
--- a/conf/pam.password
+++ b/conf/pam.password
@@ -1,0 +1,4 @@
+#%PAM-1.0
+# Use password-auth common PAM configuration for the daemon
+auth     include  password-auth
+account  include  password-auth

--- a/conf/pam.system
+++ b/conf/pam.system
@@ -1,0 +1,3 @@
+#%PAM-1.0
+auth     include  system-auth
+account  include  system-auth

--- a/config-scripts/cups-pam.m4
+++ b/config-scripts/cups-pam.m4
@@ -71,6 +71,10 @@ AS_IF([test x$enable_pam != xno], [
 	    PAMMOD="pam_${with_pam_module}.so"
 	], [test -f /etc/pam.d/common-auth], [
 	    PAMFILE="pam.common"
+	], [test -f /etc/pam.d/password-auth], [
+	    PAMFILE="pam.password"
+	], [test -f /etc/pam.d/system-auth], [
+	    PAMFILE="pam.system"
 	], [
 	    moddir=""
 	    for dir in /lib/security /lib64/security /lib/x86_64-linux-gnu/security /var/lib/pam; do


### PR DESCRIPTION
This PR is actually based on one really old patch we have in Fedora, which enables possibility to use PAM modules password-auth or system-auth if they exist during compilation.

Those PAM modules looks to be used for remote, respective local authentication, in Linux. Would it be possible to add their support into CUPS?