### PR TITLE
ppd-conflicts.c: Fix SEGV in 'cupsResolveConflicts()'

### DIFF
--- a/cups/ppd-conflicts.c
+++ b/cups/ppd-conflicts.c
@@ -207,8 +207,12 @@ cupsResolveConflicts(
   newopts     = NULL;
 
   for (i = 0; i < *num_options; i ++)
+  {
+    if (!*options)
+      return (0);
     num_newopts = cupsAddOption((*options)[i].name, (*options)[i].value,
                                 num_newopts, &newopts);
+  }
   if (option && _cups_strcasecmp(option, "Collate"))
     num_newopts = cupsAddOption(option, choice, num_newopts, &newopts);
 


### PR DESCRIPTION
A fuzzer found a way to call `cupsResolveConflicts()` with NULL options structure and not-null num_options.
This caused a segmentation fault because non-existent elements of the options structure are accessed in cupsResolveConflicts() function.
To avoid this, we need to add a NULL values check for the elements of the structure.

Fixes #896