### PR TITLE
snmp.c: Validate input OID string for `_cupsSNMPStringToOID()`

### DIFF
--- a/cups/snmp.c
+++ b/cups/snmp.c
@@ -485,13 +485,18 @@ _cupsSNMPStringToOID(const char *src,	/* I - OID string */
        *src && dstptr < dstend;
        src ++)
   {
-    if (*src == '.')
+    if (*src == '.' && src[1])
     {
       dstptr ++;
       *dstptr = 0;
     }
     else if (isdigit(*src & 255))
+    {
+      if ((*dstptr * 10 + *src - '0') > 0xffff)
+        break;
+
       *dstptr = *dstptr * 10 + *src - '0';
+    }
     else
       break;
   }


### PR DESCRIPTION
We can accept OID string as input in few cases (mainly via side channel) and if the crafted OID string is sent, internal function `asn1_size_oid()` can end up with stack buffer overflow.

The issue happens when one OID node is too large, or OID is invalid (no dots or ending with dots) - we can fix it in `_cupsSNMPStringToOID()` by checking for a dot or if the last source character is a dot (invalid OID), and by limiting integer for OID node to 0xffff.

Fixes #905