### PR TITLE
Fix get-printer-attributes test with media-col-database

### DIFF
--- a/examples/get-printer-attributes-suite.test
+++ b/examples/get-printer-attributes-suite.test
@@ -347,7 +347,7 @@ VERSION 2.0
 	ATTR charset attributes-charset utf-8
 	ATTR language attributes-natural-language en
 	ATTR uri printer-uri $uri
-	ATTR keyword requested-attributes 'all'
+	ATTR keyword requested-attributes 'media-col-database'
 
 	STATUS successful-ok
 


### PR DESCRIPTION
The test that is supposed to explicitly ask for `requested-attributes='media-col-database'` is instead asking for `requested-attributes='all'`