### PR TITLE
Add additional parameter validation to _cupsRasterWritePixels

### DIFF
--- a/cups/raster-stream.c
+++ b/cups/raster-stream.c
@@ -1407,7 +1407,7 @@ _cupsRasterWritePixels(
 
   DEBUG_printf("_cupsRasterWritePixels(r=%p, p=%p, len=%u), remaining=%u", (void *)r, (void *)p, len, r->remaining);
 
-  if (r == NULL || r->mode == CUPS_RASTER_READ || r->remaining == 0)
+  if (r == NULL || r->mode == CUPS_RASTER_READ || r->remaining == 0 || len == 0 || r->header.cupsBytesPerLine == 0)
     return (0);
 
   if (!r->compressed)


### PR DESCRIPTION
If len is 0, the function does a lot of calculations that ultimately don't produce any output.  This can be skipped with an early return.

If cupsBytesPerLine is 0, this triggers a divide by zero if the output isn't compressed.  This is an error on the caller's part, but it's nicer to return an error than to crash.