### PR TITLE
scheduler: Fix sending response headers to client

### DIFF
--- a/scheduler/client.c
+++ b/scheduler/client.c
@@ -2400,23 +2400,12 @@ cupsdWriteClient(cupsd_client_t *con)	/* I - Client connection */
 	      httpSetField(con->http, field, value);
 
 	      if (field == HTTP_FIELD_LOCATION)
-	      {
 		con->pipe_status = HTTP_STATUS_SEE_OTHER;
-		con->sent_header = 2;
-	      }
-	      else
-	        con->sent_header = 1;
 	    }
 	    else if (!_cups_strcasecmp(con->header, "Status") && value)
-	    {
   	      con->pipe_status = (http_status_t)atoi(value);
-	      con->sent_header = 2;
-	    }
 	    else if (!_cups_strcasecmp(con->header, "Set-Cookie") && value)
-	    {
 	      httpSetCookie(con->http, value);
-	      con->sent_header = 1;
-	    }
 	  }
 
          /*
@@ -2451,6 +2440,8 @@ cupsdWriteClient(cupsd_client_t *con)	/* I - Client connection */
 		cupsdCloseClient(con);
 		return;
 	      }
+
+	      con->sent_header = 1;
 	    }
 	    else
 	    {
@@ -2459,6 +2450,8 @@ cupsdWriteClient(cupsd_client_t *con)	/* I - Client connection */
 		cupsdCloseClient(con);
 		return;
 	      }
+
+	      con->sent_header = 1;
 	    }
           }
 	  else


### PR DESCRIPTION
Sometimes headers are not correctly copied into response to the client (some are missing). It happens because `sent_header` is set prematurely before the actual send happens. The present code in affected `cupsdWriteClient()` scope looks like code remains from CUPS 1.6.3, where `cupsdSendHeader()` is called earlier and generates the required headers by itself - the current `cupsdSendHeader()` sends only the headers which are saved in array `fields`, so the premature setting of `sent_header` sometimes causes not having all headers in the response.

With the change, testing via curl gives reliable results all time.