### PR TITLE
[Add] Dockerfile and Docker Compose for CUPS setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,35 @@
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/go/build-context-dockerignore/
+
+**/.DS_Store
+**/__pycache__
+**/.venv
+**/.classpath
+**/.dockerignore
+**/.env
+**/.git
+**/.gitignore
+**/.project
+**/.settings
+**/.toolstarget
+**/.vs
+**/.vscode
+**/*.*proj.user
+**/*.dbmdl
+**/*.jfm
+**/bin
+**/charts
+**/docker-compose*
+**/compose*
+**/Dockerfile*
+**/node_modules
+**/npm-debug.log
+**/obj
+**/secrets.dev.yaml
+**/values.dev.yaml
+LICENSE
+README.md
+container-config

--- a/.gitignore
+++ b/.gitignore
@@ -162,4 +162,5 @@
 /vcnet/x64
 /xcode/CUPS.xcodeproj/project.xcworkspace/
 /xcode/CUPS.xcodeproj/xcuserdata/
-
+.DS_store
+container-config

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1
+
+# Use the latest Ubuntu base image
+FROM ubuntu:latest
+
+# Set the working directory inside the container
+WORKDIR /workspaces/cups
+
+# Update package list and upgrade existing packages
+RUN apt-get update -y && apt-get upgrade -y
+
+# Install required dependencies for CUPS
+RUN apt-get install -y \
+    autoconf \
+    build-essential \
+    libavahi-client-dev \
+    libgnutls28-dev \
+    libkrb5-dev \
+    libnss-mdns \
+    libpam-dev \
+    libsystemd-dev \
+    libusb-1.0-0-dev \
+    zlib1g-dev \
+    openssl \
+    sudo
+
+# Copy the current directory contents into the container's working directory
+COPY . .
+
+# Expose port 631 for CUPS web interface
+EXPOSE 631

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -211,3 +211,9 @@ To build and run CUPS using Docker, follow these steps:
     ```bash
     docker exec -it cups /bin/bash
     ```
+### Additional Information
+1. Use 'admin' as CUPS username and 'admin' as password.
+
+2. You can find the CUPS configuration files and log files in the docker-config directory of the repository on your local machine. Any changes made to these files will be reflected in the CUPS service running inside the Docker container.
+
+3. The CUPS web interface is accessible at http://localhost:631 from your web browser.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -185,3 +185,29 @@ logging:
   the messages to stderr.  Prefix a filename with "+" to append to an existing
   file.  You can include a single "%d" in the filename to embed the current
   process ID.
+
+Build Using Docker
+------------------
+
+### Prerequisites
+
+- Docker installed on your system
+
+### Build and Run
+
+To build and run CUPS using Docker, follow these steps:
+
+1. Clone this repository to your local machine.
+
+2. Navigate to the root directory of the cloned repository.
+
+3. Run the following command to start the Docker containers in the background:
+
+   ```bash
+   docker-compose up -d
+   ```
+
+4. To start interactive terminal in container
+    ```bash
+    docker exec -it cups /bin/bash
+    ```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,48 @@
+version: "3.8"
+
+services:
+  cups:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: cups
+    # Command to be executed when the container starts
+    command:
+      - /bin/bash
+      - -c
+      - |
+        # Add a new user 'admin' with password 'admin'
+        useradd -m --create-home --password $(echo 'admin' | openssl passwd -1 -stdin) -f 0 admin
+
+        # Create a new group 'lpadmin'
+        groupadd lpadmin
+
+        # Add the user 'admin' to the 'lpadmin' group
+        usermod -aG lpadmin admin
+
+        # Grant sudo privileges to the user 'admin'
+        echo 'admin ALL=(ALL:ALL) ALL' >> /etc/sudoers
+
+        # build CUPS
+        ./configure
+        make
+        make install
+
+        # Start the CUPS daemon for remote access
+        /usr/sbin/cupsd \
+        && while [ ! -f /var/run/cups/cupsd.pid ]; do sleep 1; done \
+        && cupsctl --remote-admin --remote-any --share-printers \
+        && kill $(cat /var/run/cups/cupsd.pid) \
+        && echo "ServerAlias *" >> /etc/cups/cupsd.conf \
+        && service cups start \
+        && /usr/sbin/cupsd -f
+
+    # Expose port 631 for CUPS web interface
+    ports:
+      - "631:631"
+
+    # Bind mount for cups config files and logs
+    volumes:
+      - .:/workspaces/cups
+      - ./container-config:/etc/cups
+      - ./container-config/logs:/var/log/cups


### PR DESCRIPTION
This PR adds Dockerfile and Docker Compose configuration to streamline the process of setting up CUPS (Common Unix Printing System) in a Docker environment, making it easier for development purposes.

### Changes Made
- Added a Dockerfile to define the environment and dependencies required for running CUPS.
- Included a Docker Compose configuration for orchestrating the build and execution of CUPS in a Docker container.
- Provided instructions in the INSTALL.md file on how to build, run, and access CUPS using Docker.