### PR TITLE
scheduler: Fix potential bug when adding new printers (Issue #934)

### DIFF
--- a/scheduler/client.c
+++ b/scheduler/client.c
@@ -430,6 +430,14 @@ cupsdCloseClient(cupsd_client_t *con)	/* I - Client to close */
     con->file = -1;
   }
 
+  if (con->bg_pending)
+  {
+   /*
+    * Don't close connection when there is a background thread pending
+    */
+    partial = 1;
+  }
+
  /*
   * Close the socket and clear the file from the input set for select()...
   */


### PR DESCRIPTION
When adding a new printer a thread is created to handle PPD generation, and the requesting client connection might close while the thread is running. This commit prevents full connection cleanup until the thread is finished.