### PR TITLE
scheduler: Fix regression in background thread (Issue #934)

### DIFF
--- a/scheduler/ipp.c
+++ b/scheduler/ipp.c
@@ -5517,9 +5517,9 @@ create_local_bg_thread(
 
   ippDelete(response);
 
-  con->bg_pending = 0;
-
   send_response(con);
+
+  con->bg_pending = 0;
 
   return (NULL);
 }


### PR DESCRIPTION
The con->bg_pending value is used to indicate that the background thread has finished running and that the connection can be safely closed.

This commit makes the con->bg_pending = 0 only after the connection can be safely closed.