### PR TITLE
cgi-bin/var.c: Fix return value if the text is invalid

### DIFF
--- a/cgi-bin/var.c
+++ b/cgi-bin/var.c
@@ -284,6 +284,8 @@ cgiGetTextfield(const char *name)	/* I - Name of form field */
 
     if (i < form_count)
       memmove(var, var + 1, (size_t)(form_count - i) * sizeof(_cgi_var_t));
+
+    value = NULL;
   }
 
   return (value);


### PR DESCRIPTION
In ```cgiGetTextfield()```, if the original value contains double quote, which is forbidden for text, we free the variable and move the next variable from array to its place. However, the return value still contains the original value of freed pointer, and shows garbage when used.

Set it NULL, since we don't have any value to return for the requested name.