### PR TITLE
ppd-cache.c: Fix generating cupsUrfSupported (fixes #952)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ CHANGES - OpenPrinting CUPS 2.4.9 - (TBA)
 Changes in CUPS v2.4.9 (TBA)
 ----------------------------
 
+- Fixed creating of `cupsUrfSupported` PPD keyword (Issue #952)
 - Fixed searching for destinations in web ui (Issue #954)
 - Fixed TLS negotiation using OpenSSL with servers that require the TLS SNI
   extension.

--- a/cups/ppd-cache.c
+++ b/cups/ppd-cache.c
@@ -3511,7 +3511,7 @@ _ppdCreateFromIPP2(
     for (i = 0, count = ippGetCount(attr); i < count; i ++)
     {
       keyword = ippGetString(attr, i, NULL);
-      cupsFilePrintf(fp, "%s%s", keyword, i ? "" : ",");
+      cupsFilePrintf(fp, "%s%s", keyword, i != count - 1 ? "," : "");
     }
     cupsFilePuts(fp, "\"\n");
   }


### PR DESCRIPTION
The PPD keyword got the option values concatenated together without commas, which broke filter processing in libcupsfilters

Sometimes more commas better commas :)