### PR TITLE
cgi: Fix showing query string in Help

### DIFF
--- a/cgi-bin/help.c
+++ b/cgi-bin/help.c
@@ -28,7 +28,7 @@ main(int  argc,				/* I - Number of command-line arguments */
 		*si;			/* Search index */
   help_node_t	*n;			/* Current help node */
   int		i;			/* Looping var */
-  const char	*query;			/* Search query */
+  const char	*query = NULL;		/* Search query */
   const char	*cache_dir;		/* CUPS_CACHEDIR environment variable */
   const char	*docroot;		/* CUPS_DOCROOT environment variable */
   const char	*helpfile,		/* Current help file */
@@ -172,8 +172,9 @@ main(int  argc,				/* I - Number of command-line arguments */
 
   if (cgiGetVariable("CLEAR"))
     cgiSetVariable("QUERY", "");
+  else if ((query = cgiGetTextfield("QUERY")) != NULL)
+    query = strdup(query);
 
-  query = cgiGetTextfield("QUERY");
   si    = helpSearchIndex(hi, query, topic, helpfile);
 
   cgiClearVariables();


### PR DESCRIPTION
If a string was searched on CUPS Web UI help page, garbage was printed out in search box. It was because text field pointer was freed before and contained garbage - previously it was variable value which was allocated, so the string survived `cgCleanVariables(()`, but the text field is a pointer into form variables which gets cleaned up.

Fix is to use `strdup()` if `cgiGetTextfield()` returns non-NULL pointer. The binary exits shortly after either way, so memory is taken care of by OS.