### PR TITLE
scheduler: Fix cupsd activated on-demand via socket (fixes #985)

### DIFF
--- a/scheduler/conf.c
+++ b/scheduler/conf.c
@@ -551,6 +551,17 @@ cupsdReadConfiguration(void)
 
   cupsdDeleteAllListeners();
 
+ /*
+  * Allocate Listeners array
+  */
+  Listeners = cupsArrayNew(NULL, NULL);
+
+  if (!Listeners)
+  {
+    fprintf(stderr, "Unable to allocate memory for array Listeners.");
+    return (0);
+  }
+
   old_remote_port = RemotePort;
   RemotePort      = 0;
 
@@ -1041,32 +1052,6 @@ cupsdReadConfiguration(void)
 	Group = 65534;
       }
     }
-  }
-
- /*
-  * Check that we have at least one listen/port line; if not, report this
-  * as an error and exit!
-  */
-
-#ifdef HAVE_ONDEMAND
-  if (cupsArrayCount(Listeners) == 0 && !OnDemand)
-#else
-  if (cupsArrayCount(Listeners) == 0)
-#endif // HAVE_ONDEMAND
-  {
-   /*
-    * No listeners!
-    */
-
-    cupsdLogMessage(CUPSD_LOG_EMERG,
-                    "No valid Listen or Port lines were found in the "
-		    "configuration file.");
-
-   /*
-    * Commit suicide...
-    */
-
-    cupsdEndProcess(getpid(), 0);
   }
 
  /*
@@ -3223,17 +3208,6 @@ read_cupsd_conf(cups_file_t *fp)	/* I - File to read from */
        /*
         * Allocate another listener...
 	*/
-
-        if (!Listeners)
-	  Listeners = cupsArrayNew(NULL, NULL);
-
-	if (!Listeners)
-	{
-          cupsdLogMessage(CUPSD_LOG_ERROR,
-	                  "Unable to allocate %s at line %d - %s.",
-	                  line, linenum, strerror(errno));
-          break;
-	}
 
         if ((lis = calloc(1, sizeof(cupsd_listener_t))) == NULL)
 	{


### PR DESCRIPTION
If only the expected cups.sock is set as listener in cupsd.conf, the array Listeners was NULL. To prevent copying the code, do the array allocation earlier and have only one check for Listeners, in `service_checkin()` which is run every time cupsd starts.

Fixes #985