### PR TITLE
scheduler: Fix cupsd activated on-demand via socket

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,11 @@
-CHANGES - OpenPrinting CUPS 2.4.9 - (2024-06-11)
+CHANGES - OpenPrinting CUPS 2.4.10 - (2024-06-18)
 ================================================
 
-Changes in CUPS v2.4.10 (TBD)
+Changes in CUPS v2.4.10 (2024-06-18)
 -----------------------------
 
 - Fixed error handling when reading a mixed `1setOf` attribute.
+- Fixed scheduler start if there is only domain socket to listen on (Issue #985)
 
 
 Changes in CUPS v2.4.9 (2024-06-11)

--- a/scheduler/conf.c
+++ b/scheduler/conf.c
@@ -558,6 +558,18 @@ cupsdReadConfiguration(void)
 
   cupsdDeleteAllListeners();
 
+ /*
+  * Allocate array Listeners
+  */
+
+  Listeners = cupsArrayNew(NULL, NULL);
+
+  if (!Listeners)
+  {
+    fprintf(stderr, "Unable to allocate memory for array Listeners.");
+    return (0);
+  }
+
   old_remote_port = RemotePort;
   RemotePort      = 0;
 
@@ -1041,32 +1053,6 @@ cupsdReadConfiguration(void)
 	Group = 65534;
       }
     }
-  }
-
- /*
-  * Check that we have at least one listen/port line; if not, report this
-  * as an error and exit!
-  */
-
-#ifdef HAVE_ONDEMAND
-  if (cupsArrayCount(Listeners) == 0 && !OnDemand)
-#else
-  if (cupsArrayCount(Listeners) == 0)
-#endif // HAVE_ONDEMAND
-  {
-   /*
-    * No listeners!
-    */
-
-    cupsdLogMessage(CUPSD_LOG_EMERG,
-                    "No valid Listen or Port lines were found in the "
-		    "configuration file.");
-
-   /*
-    * Commit suicide...
-    */
-
-    cupsdEndProcess(getpid(), 0);
   }
 
  /*
@@ -3154,17 +3140,6 @@ read_cupsd_conf(cups_file_t *fp)	/* I - File to read from */
        /*
         * Allocate another listener...
 	*/
-
-        if (!Listeners)
-	  Listeners = cupsArrayNew(NULL, NULL);
-
-	if (!Listeners)
-	{
-          cupsdLogMessage(CUPSD_LOG_ERROR,
-	                  "Unable to allocate %s at line %d - %s.",
-	                  line, linenum, strerror(errno));
-          break;
-	}
 
         if ((lis = calloc(1, sizeof(cupsd_listener_t))) == NULL)
 	{

--- a/scheduler/main.c
+++ b/scheduler/main.c
@@ -2043,7 +2043,7 @@ service_checkin(void)
     * No listeners!
     */
 
-    cupsdLogMessage(CUPSD_LOG_EMERG, "service_checkin: No listener sockets present.");
+    cupsdLogMessage(CUPSD_LOG_EMERG, "No listener sockets present.");
 
    /*
     * Commit suicide...


### PR DESCRIPTION
If only the expected cups.sock is set as listener in cupsd.conf, the array Listeners was NULL. To prevent copying the code, do the array allocation earlier and have only one check for Listeners, in service_checkin() which is run every time cupsd starts.

Fixes #985