### PR TITLE
fix: delete the strings file when removing the local printer

### DIFF
--- a/scheduler/ipp.c
+++ b/scheduler/ipp.c
@@ -6192,6 +6192,9 @@ delete_printer(cupsd_client_t  *con,	/* I - Client connection */
   snprintf(filename, sizeof(filename), "%s/%s.data", CacheDir, printer->name);
   unlink(filename);
 
+  snprintf(filename, sizeof(filename), "%s/%s.strings", CacheDir, printer->name);
+  unlink(filename);
+
  /*
   * Unregister color profiles...
   */


### PR DESCRIPTION
The string file does not seem necessary to keep, so I think it is better to delete it along with the local printer.