### PR TITLE
request.c: Use errno only if it is non-zero (fixes #893)

### DIFF
--- a/cups/cups-private.h
+++ b/cups/cups-private.h
@@ -268,7 +268,7 @@ extern const char	*_cupsGSSServiceName(void) _CUPS_PRIVATE;
 extern int		_cupsNextDelay(int current, int *previous) _CUPS_PRIVATE;
 extern void		_cupsSetDefaults(void) _CUPS_INTERNAL;
 extern void		_cupsSetError(ipp_status_t status, const char *message, int localize) _CUPS_PRIVATE;
-extern void		_cupsSetHTTPError(http_status_t status) _CUPS_INTERNAL;
+extern void		_cupsSetHTTPError(http_t *http, http_status_t status) _CUPS_INTERNAL;
 #  ifdef HAVE_GSSAPI
 extern int		_cupsSetNegotiateAuthString(http_t *http, const char *method, const char *resource) _CUPS_PRIVATE;
 #  endif // HAVE_GSSAPI

--- a/cups/getdevices.c
+++ b/cups/getdevices.c
@@ -152,7 +152,7 @@ cupsGetDevices(
 
   if (status != HTTP_STATUS_OK)
   {
-    _cupsSetHTTPError(status);
+    _cupsSetHTTPError(http, status);
     return (cupsGetError());
   }
 

--- a/cups/getputfile.c
+++ b/cups/getputfile.c
@@ -193,7 +193,7 @@ cupsGetFd(http_t     *http,		/* I - Connection to server or @code CUPS_HTTP_DEFA
   }
   else
   {
-    _cupsSetHTTPError(status);
+    _cupsSetHTTPError(http, status);
     httpFlush(http);
   }
 
@@ -491,7 +491,7 @@ cupsPutFd(http_t     *http,		/* I - Connection to server or @code CUPS_HTTP_DEFA
 
   if (status != HTTP_STATUS_CREATED)
   {
-    _cupsSetHTTPError(status);
+    _cupsSetHTTPError(http, status);
     httpFlush(http);
   }
 

--- a/cups/http-addr.c
+++ b/cups/http-addr.c
@@ -207,7 +207,7 @@ httpAddrListen(http_addr_t *addr,	// I - Address to bind to
   // Create the socket and set options...
   if ((fd = socket(addr->addr.sa_family, SOCK_STREAM, 0)) < 0)
   {
-    _cupsSetHTTPError(HTTP_STATUS_ERROR);
+    _cupsSetError(IPP_STATUS_ERROR_INTERNAL, strerror(errno), 0);
     return (-1);
   }
 
@@ -260,7 +260,7 @@ httpAddrListen(http_addr_t *addr,	// I - Address to bind to
 
   if (status)
   {
-    _cupsSetHTTPError(HTTP_STATUS_ERROR);
+    _cupsSetError(IPP_STATUS_ERROR_INTERNAL, strerror(errno), 0);
 
     close(fd);
 
@@ -270,7 +270,7 @@ httpAddrListen(http_addr_t *addr,	// I - Address to bind to
   // Listen...
   if (listen(fd, INT_MAX))
   {
-    _cupsSetHTTPError(HTTP_STATUS_ERROR);
+    _cupsSetError(IPP_STATUS_ERROR_INTERNAL, strerror(errno), 0);
 
     close(fd);
 

--- a/cups/http.c
+++ b/cups/http.c
@@ -136,7 +136,7 @@ httpAcceptConnection(int fd,		// I - Listen socket file descriptor
 
   if ((http->fd = accept(fd, (struct sockaddr *)&(http->addrlist->addr), &addrlen)) < 0)
   {
-    _cupsSetHTTPError(HTTP_STATUS_ERROR);
+    _cupsSetError(IPP_STATUS_ERROR_INTERNAL, strerror(errno), 0);
     httpClose(http);
 
     return (NULL);

--- a/cups/ipp.c
+++ b/cups/ipp.c
@@ -2849,7 +2849,7 @@ ippReadIO(void        *src,		// I - Data source
 	    attr = ipp->current = ipp_add_attr(ipp, NULL, ipp->curtag, IPP_TAG_ZERO, 1);
 	    if (!attr)
 	    {
-	      _cupsSetHTTPError(HTTP_STATUS_ERROR);
+	      _cupsSetError(IPP_STATUS_ERROR_INTERNAL, _("Unable to allocate IPP attribute."), 1);
 	      DEBUG_puts("1ippReadIO: unable to allocate attribute.");
 	      goto rollback;
 	    }
@@ -2874,7 +2874,7 @@ ippReadIO(void        *src,		// I - Data source
 
 	    if ((attr = ipp->current = ipp_add_attr(ipp, (char *)buffer, ipp->curtag, tag, 1)) == NULL)
 	    {
-	      _cupsSetHTTPError(HTTP_STATUS_ERROR);
+	      _cupsSetError(IPP_STATUS_ERROR_INTERNAL, _("Unable to allocate IPP attribute."), 1);
 	      DEBUG_puts("1ippReadIO: unable to allocate attribute.");
 	      goto rollback;
 	    }
@@ -3181,7 +3181,7 @@ ippReadIO(void        *src,		// I - Data source
 		{
 		  if ((value->unknown.data = malloc((size_t)n)) == NULL)
 		  {
-		    _cupsSetHTTPError(HTTP_STATUS_ERROR);
+		    _cupsSetError(IPP_STATUS_ERROR_INTERNAL, _("Unable to allocate IPP attribute."), 1);
 		    DEBUG_puts("1ippReadIO: Unable to allocate value");
 		    goto rollback;
 		  }
@@ -5989,7 +5989,7 @@ ipp_set_value(ipp_t           *ipp,	// IO - IPP message
   // Reallocate memory...
   if ((temp = realloc(temp, sizeof(ipp_attribute_t) + (size_t)(alloc_values - 1) * sizeof(_ipp_value_t))) == NULL)
   {
-    _cupsSetHTTPError(HTTP_STATUS_ERROR);
+    _cupsSetError(IPP_STATUS_ERROR_INTERNAL, _("Unable to reallocate IPP attribute value."), 1);
     DEBUG_puts("4ipp_set_value: Unable to resize attribute.");
     return (NULL);
   }

--- a/cups/json.c
+++ b/cups/json.c
@@ -1317,7 +1317,7 @@ cupsJSONImportURL(
   else
   {
     // Save the last HTTP status as a CUPS error...
-    _cupsSetHTTPError(status);
+    _cupsSetHTTPError(http, status);
   }
 
   // Flush any remaining data...

--- a/cups/ppd-util.c
+++ b/cups/ppd-util.c
@@ -433,7 +433,7 @@ cupsGetPPD3(http_t     *http,		/* I  - HTTP connection or @code CUPS_HTTP_DEFAUL
   }
   else if (status != HTTP_STATUS_NOT_MODIFIED)
   {
-    _cupsSetHTTPError(status);
+    _cupsSetHTTPError(http2, status);
 
     if (buffer[0])
       unlink(buffer);

--- a/cups/request.c
+++ b/cups/request.c
@@ -248,7 +248,7 @@ cupsDoIORequest(http_t     *http,	/* I - Connection to server or @code CUPS_HTTP
         (status >= HTTP_STATUS_BAD_REQUEST && status != HTTP_STATUS_UNAUTHORIZED &&
 	 status != HTTP_STATUS_UPGRADE_REQUIRED))
     {
-      _cupsSetHTTPError(status);
+      _cupsSetHTTPError(http, status);
       break;
     }
 
@@ -445,7 +445,7 @@ cupsGetResponse(http_t     *http,	/* I - Connection to server or @code CUPS_HTTP
 
     httpFlush(http);
 
-    _cupsSetHTTPError(status);
+    _cupsSetHTTPError(http, status);
 
    /*
     * Then handle encryption and authentication...
@@ -829,7 +829,7 @@ cupsSendRequest(http_t     *http,	/* I - Connection to server or @code CUPS_HTTP
     {
       int temp_status;			/* Temporary status */
 
-      _cupsSetHTTPError(status);
+      _cupsSetHTTPError(http, status);
 
       do
       {
@@ -985,7 +985,7 @@ cupsWriteRequestData(
       _httpUpdate(http, &status);
       if (status >= HTTP_STATUS_MULTIPLE_CHOICES)
       {
-        _cupsSetHTTPError(status);
+        _cupsSetHTTPError(http, status);
 
 	do
 	{
@@ -1151,7 +1151,8 @@ _cupsSetError(ipp_status_t status,	/* I - IPP status code */
  */
 
 void
-_cupsSetHTTPError(http_status_t status)	/* I - HTTP status code */
+_cupsSetHTTPError(http_t	*http,	/* I - HTTP connection */
+		  http_status_t	status)	/* I - HTTP status code */
 {
   switch (status)
   {
@@ -1196,8 +1197,8 @@ _cupsSetHTTPError(http_status_t status)	/* I - HTTP status code */
         break;
 
     case HTTP_STATUS_ERROR :
-	_cupsSetError(IPP_STATUS_ERROR_INTERNAL, strerror(errno), 0);
-        break;
+	_cupsSetError(IPP_STATUS_ERROR_INTERNAL, http->error != 0 ? strerror(http->error) : "Internal Server Error", 0);
+	break;
 
     default :
 	DEBUG_printf("4_cupsSetHTTPError: HTTP error %d mapped to IPP_STATUS_ERROR_SERVICE_UNAVAILABLE!", status);


### PR DESCRIPTION
In case of internal errors, we use errno for generating error message, but there are cases (like operation timeout for listing drivers or models) when errno is zero.
We should take error from `http->error` if errno is zero, falling back to `Internal Server Error` if even `http->error` is 0 and still we have HTTP_STATUS_ERROR.

Fixes #893