### PR TITLE
Fix HTTP PeerCred authentication for domain users (fixes #1001)

### DIFF
--- a/conf/cups-files.conf.in
+++ b/conf/cups-files.conf.in
@@ -6,6 +6,9 @@
 # List of events that are considered fatal errors for the scheduler...
 #FatalErrors @CUPS_FATAL_ERRORS@
 
+# Strip domain in local username?
+#StripUserDomain No
+
 # Do we call fsync() after writing configuration or status files?
 #SyncOnClose @CUPS_SYNC_ON_CLOSE@
 

--- a/man/cups-files.conf.5
+++ b/man/cups-files.conf.5
@@ -214,6 +214,17 @@ Note: the standard CUPS filter and backend environment variables cannot be overr
 \fBStateDir \fIdirectory\fR
 Specifies the directory to use for PID and local certificate files.
 The default is "/var/run/cups" or "/etc/cups" depending on the platform.
+.\"#StripUserDomain
+.TP 5
+\StripUserDomain Yes\fR
+.TP 5
+\StripUserDomain No\fR
+Specifies whether to remove domain from user name during local user authentication (e.g., "user@example.com" –> "user").
+This practice can be beneficial for maintaining compatibility with older versions of Kerberos.
+However, enabling this option can have negative consequences.
+It may result in confusion between domain and local users with identical names, potentially leading
+to incorrect assignment of user permissions and unintentional permission escalation,
+thus creating a security risk. Therefore, it is advisable to avoid using this option in most cases.
 .\"#SyncOnClose
 .TP 5
 \fBSyncOnClose Yes\fR

--- a/scheduler/auth.c
+++ b/scheduler/auth.c
@@ -1639,14 +1639,14 @@ cupsdIsAuthorized(cupsd_client_t *con,	/* I - Connection */
   * Strip any @domain or @KDC from the username and owner...
   */
 
-  if ((ptr = strchr(username, '@')) != NULL)
+  if (StripUserDomain && (ptr = strchr(username, '@')) != NULL)
     *ptr = '\0';
 
   if (owner)
   {
     cupsCopyString(ownername, owner, sizeof(ownername));
 
-    if ((ptr = strchr(ownername, '@')) != NULL)
+    if (StripUserDomain && (ptr = strchr(ownername, '@')) != NULL)
       *ptr = '\0';
   }
   else

--- a/scheduler/conf.c
+++ b/scheduler/conf.c
@@ -146,6 +146,7 @@ static const cupsd_var_t	cupsfiles_vars[] =
   { "ServerKeychain",		&ServerKeychain,	CUPSD_VARTYPE_PATHNAME },
   { "ServerRoot",		&ServerRoot,		CUPSD_VARTYPE_PATHNAME },
   { "StateDir",			&StateDir,		CUPSD_VARTYPE_STRING },
+  { "StripUserDomain",		&StripUserDomain,	CUPSD_VARTYPE_BOOLEAN },
   { "SyncOnClose",		&SyncOnClose,		CUPSD_VARTYPE_BOOLEAN },
 #ifdef HAVE_AUTHORIZATION_H
   { "SystemGroupAuthKey",	&SystemGroupAuthKey,	CUPSD_VARTYPE_STRING },
@@ -731,6 +732,7 @@ cupsdReadConfiguration(void)
   LogFilePerm              = CUPS_DEFAULT_LOG_FILE_PERM;
   LogFileGroup             = Group;
   LogLevel                 = CUPSD_LOG_WARN;
+  StripUserDomain          = FALSE;
   LogTimeFormat            = CUPSD_TIME_STANDARD;
   MaxClients               = 100;
   MaxClientsPerHost        = 0;

--- a/scheduler/conf.h
+++ b/scheduler/conf.h
@@ -178,6 +178,8 @@ VAR gid_t		LogFileGroup		VALUE(0);
 					/* Group ID for log files */
 VAR cupsd_loglevel_t	LogLevel		VALUE(CUPSD_LOG_WARN);
 					/* Error log level */
+VAR int			StripUserDomain		VALUE(FALSE);
+					/* Strip domain in local username? */
 VAR cupsd_time_t	LogTimeFormat		VALUE(CUPSD_TIME_STANDARD);
 					/* Log file time format */
 VAR cups_file_t		*LogStderr		VALUE(NULL);


### PR DESCRIPTION
- Remove domain from user name during local user authentication (e.g., "user@example.com" –> "user"). This practice can be beneficial for maintaining compatibility with older versions of Kerberos. However, enabling this option can have negative consequences. It may result in confusion between domain and local users with identical names, potentially leading to incorrect assignment of user permissions and unintentional permission escalation, thus creating a security risk. Therefore, it is advisable to avoid using this option in most cases.
- Add "StripUserDomain" parameter to cupsd.conf