### PR TITLE
scheduler: add a systemd slice

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ Changes in CUPS v2.5b1 (TBA)
 - Added driver filter to web interface (Issue #848)
 - Added support for PAM modules password-auth and system-auth (Issue #892)
 - Added Docker support (Issue #929)
+- Added a systemd slice to the systemd services included with the scheduler
 - Added localizations for deprecated IPP attributes/options (Issue #1020)
 - Updated CUPS to require TLS support - OpenSSL, GNUTLS and LibreSSL are
   supported.

--- a/scheduler/Makefile
+++ b/scheduler/Makefile
@@ -195,6 +195,7 @@ install-data:
 	if test "x$(SYSTEMD_DIR)" != x; then \
 		echo Installing systemd configuration files...; \
 		$(INSTALL_DIR) $(BUILDROOT)$(SYSTEMD_DIR); \
+		$(INSTALL_DATA) system-cups.slice $(BUILDROOT)$(SYSTEMD_DIR); \
 		$(INSTALL_DATA) cups.path $(BUILDROOT)$(SYSTEMD_DIR); \
 		$(INSTALL_DATA) cups.service $(BUILDROOT)$(SYSTEMD_DIR); \
 		$(INSTALL_DATA) cups.socket $(BUILDROOT)$(SYSTEMD_DIR); \

--- a/scheduler/cups-lpdAT.service.in
+++ b/scheduler/cups-lpdAT.service.in
@@ -6,4 +6,5 @@ Documentation=man:cups-lpd(8)
 ExecStart=-@CUPS_SERVERBIN@/daemon/cups-lpd
 StandardInput=socket
 User=@CUPS_USER@
+Slice=system-cups.slice
 

--- a/scheduler/cups.service.in
+++ b/scheduler/cups.service.in
@@ -8,6 +8,7 @@ Requires=cups.socket
 ExecStart=@sbindir@/cupsd -l
 Type=notify
 Restart=on-failure
+Slice=system-cups.slice
 @TIMEOUTSTARTSEC@
 
 [Install]

--- a/scheduler/system-cups.slice
+++ b/scheduler/system-cups.slice
@@ -1,0 +1,3 @@
+[Unit]
+Description=CUPS Slice
+Documentation=man:cups(1)


### PR DESCRIPTION
From the systemd documentation[1]:

> A slice unit is a concept for hierarchically managing resources of a group of processes.

Benefits of collecting our two systemd services into a slice include
* ease of configuring resource limits on the entire CUPS system,
* ``systemctl status`` showing the CUPS units in an indented subtree, making it more organized,
* and the possibility of viewing all interlaced logs from all of the CUPS daemons using ``journalctl -u system-cups.slice``.

[1]:
https://www.freedesktop.org/software/systemd/man/latest/systemd.slice.html or ``man systemd.slice(5)``