### PR TITLE
tls-gnutls.c: Pass gnutls pointer to `gnutls_credentials_set()`

### DIFF
--- a/cups/tls-gnutls.c
+++ b/cups/tls-gnutls.c
@@ -1717,7 +1717,7 @@ _httpTLSStart(http_t *http)		// I - Connection to server
   }
 
   if (!status && credentials)
-    status = gnutls_credentials_set(http->tls, GNUTLS_CRD_CERTIFICATE, credentials);
+    status = gnutls_credentials_set(http->tls, GNUTLS_CRD_CERTIFICATE, credentials->creds);
 
   if (status)
   {


### PR DESCRIPTION
`credentials` changed type in 2.5, now gnutls pointer, which is needed for the mentioned function, is a member of new structure which is `credentials` now, so pass `credential->creds` to the function, otherwise it crashes.

Found out during running the test suite with gnutls enabled.