### PR TITLE
cups.service.in: Order after time-set.target

### DIFF
--- a/scheduler/cups.service.in
+++ b/scheduler/cups.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=CUPS Scheduler
 Documentation=man:cupsd(8)
-After=network.target nss-user-lookup.target nslcd.service
+After=network.target nss-user-lookup.target time-set.target nslcd.service
 Requires=cups.socket
 
 [Service]


### PR DESCRIPTION
Multiple functions that are called either implicitly or explicitly require a "roughly correct" CLOCK_REALTIME to behave.