### PR TITLE
Use CFStringCreateWithCStringNoCopy when the CFString doesn't outlast the char *

### DIFF
--- a/backend/usb-darwin.c
+++ b/backend/usb-darwin.c
@@ -1950,7 +1950,7 @@ CFStringRef cfstr_create_trim(const char *cstr)
   CFStringRef		cfstr;
   CFMutableStringRef	cfmutablestr = NULL;
 
-  if ((cfstr = CFStringCreateWithCString(kCFAllocatorDefault, cstr, kCFStringEncodingUTF8)) != NULL)
+  if ((cfstr = CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, cstr, kCFStringEncodingUTF8, NULL)) != NULL)
   {
     if ((cfmutablestr = CFStringCreateMutableCopy(kCFAllocatorDefault, 1024, cfstr)) != NULL)
       CFStringTrimWhitespace(cfmutablestr);
@@ -2071,7 +2071,7 @@ static void setup_cfLanguage(void)
     return;
   }
 
-  lang[0] = CFStringCreateWithCString(kCFAllocatorDefault, requestedLang, kCFStringEncodingUTF8);
+  lang[0] = CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, requestedLang, kCFStringEncodingUTF8, NULL);
   langArray = CFArrayCreate(kCFAllocatorDefault, (const void **)lang, sizeof(lang) / sizeof(lang[0]), &kCFTypeArrayCallBacks);
 
   CFPreferencesSetValue(CFSTR("AppleLanguages"), langArray, kCFPreferencesCurrentApplication, kCFPreferencesAnyUser, kCFPreferencesAnyHost);

--- a/cups/dest.c
+++ b/cups/dest.c
@@ -2149,7 +2149,7 @@ cupsSetDests2(http_t      *http,	// I - Connection to server or @code CUPS_HTTP_
 
   if ((dest = cupsGetDest(NULL, NULL, num_dests, dests)) != NULL)
   {
-    CFStringRef name = CFStringCreateWithCString(kCFAllocatorDefault, dest->name, kCFStringEncodingUTF8);
+    CFStringRef name = CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, dest->name, kCFStringEncodingUTF8, NULL);
 					// Default printer name
 
     if (name)

--- a/scheduler/colorman.c
+++ b/scheduler/colorman.c
@@ -249,8 +249,8 @@ apple_init_profile(
     return;
   }
 
-  cftext = CFStringCreateWithCString(kCFAllocatorDefault, text,
-				     kCFStringEncodingUTF8);
+  cftext = CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, text,
+				     kCFStringEncodingUTF8, NULL);
 
   if (cftext)
   {
@@ -281,10 +281,10 @@ apple_init_profile(
 
       if (attr && attr->text[0])
       {
-	cflang = CFStringCreateWithCString(kCFAllocatorDefault, language,
-					   kCFStringEncodingUTF8);
-	cftext = CFStringCreateWithCString(kCFAllocatorDefault, attr->text,
-					   kCFStringEncodingUTF8);
+	cflang = CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, language,
+					   kCFStringEncodingUTF8, NULL);
+	cftext = CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, attr->text,
+					   kCFStringEncodingUTF8, NULL);
 
         if (cflang && cftext)
 	  CFDictionarySetValue(dict, cflang, cftext);
@@ -766,8 +766,8 @@ apple_register_profiles(
     device_name  = CFDictionaryCreateMutable(kCFAllocatorDefault, 0,
 					     &kCFTypeDictionaryKeyCallBacks,
 					     &kCFTypeDictionaryValueCallBacks);
-    printer_name = CFStringCreateWithCString(kCFAllocatorDefault,
-                                             p->name, kCFStringEncodingUTF8);
+    printer_name = CFStringCreateWithCStringNoCopy(kCFAllocatorDefault,
+                                             p->name, kCFStringEncodingUTF8, NULL);
 
     if (device_name && printer_name)
     {


### PR DESCRIPTION
The object is freed before anything happens to the pointers.