### PR TITLE
Support bare staple and bind finishings values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -89,6 +89,8 @@ Changes in CUPS v2.5b1 (TBA)
 - Fixed memory leak when unloading a job (Issue #813)
 - Fixed memory leak when creating color profiles (Issue #814)
 - Fixed punch finisher support for IPP Everywhere printers (Issue #821)
+- Fixed staple and bind finisher support for IPP Everywhere printers
+  (Issue #1073)
 - Fixed crash in `scan_ps()` if incoming argument is NULL (Issue #831)
 - Fixed setting job state reasons for successful jobs (Issue #832)
 - Fixed infinite loop in IPP backend if hostname is IP address with Kerberos

--- a/cups/ppd-cache.c
+++ b/cups/ppd-cache.c
@@ -4550,7 +4550,7 @@ _ppdCreateFromIPP(char   *buffer,	/* I - Filename buffer */
       value   = ippGetInteger(attr, i);
       keyword = ippEnumString("finishings", value);
 
-      if (!strncmp(keyword, "staple-", 7) || !strncmp(keyword, "bind-", 5) || !strncmp(keyword, "edge-stitch-", 12) || !strcmp(keyword, "saddle-stitch"))
+      if (!strncmp(keyword, "staple-", 7) || !strncmp(keyword, "bind-", 5) || !strncmp(keyword, "edge-stitch-", 12) || !strcmp(keyword, "saddle-stitch") || !strcmp(keyword, "staple") || !strcmp(keyword, "bind"))
         break;
     }
 
@@ -4597,7 +4597,7 @@ _ppdCreateFromIPP(char   *buffer,	/* I - Filename buffer */
         value   = ippGetInteger(attr, i);
         keyword = ippEnumString("finishings", value);
 
-        if (strncmp(keyword, "staple-", 7) && strncmp(keyword, "bind-", 5) && strncmp(keyword, "edge-stitch-", 12) && strcmp(keyword, "saddle-stitch"))
+        if (strncmp(keyword, "staple-", 7) && strncmp(keyword, "bind-", 5) && strncmp(keyword, "edge-stitch-", 12) && strcmp(keyword, "saddle-stitch") && strcmp(keyword, "staple") && strcmp(keyword, "bind"))
           continue;
 
         if (cupsArrayFind(names, (char *)keyword))
@@ -4988,7 +4988,7 @@ _ppdCreateFromIPP(char   *buffer,	/* I - Filename buffer */
 	      option = "FoldType";
 	    else if (!strncmp(keyword, "punch-", 6))
 	      option = "PunchMedia";
-	    else if (!strncmp(keyword, "bind-", 5) || !strncmp(keyword, "edge-stitch-", 12) || !strcmp(keyword, "saddle-stitch") || !strncmp(keyword, "staple-", 7))
+	    else if (!strncmp(keyword, "bind-", 5) || !strncmp(keyword, "edge-stitch-", 12) || !strcmp(keyword, "saddle-stitch") || !strncmp(keyword, "staple-", 7) || !strcmp(keyword, "staple") || !strcmp(keyword, "bind"))
 	      option = "StapleLocation";
 
 	    if (option && keyword)


### PR DESCRIPTION
In the generated PPD, IPP finishings "bind" is supposed to map to "StapleLocation: BindAuto".  Similarly, "staple" is supposed to map to "StapleLocation: SingleAuto".  The code already handles this, except the lookup is blocked by a check that only accepts "staple-*" and "bind-*" prefixed versions.  Fix this by adding the bare versions to the existing checks.

Fixes issue #1073.