### PR TITLE
scheduler: Clean up failed IPP Everywhere permanent queues

### DIFF
--- a/scheduler/ipp.c
+++ b/scheduler/ipp.c
@@ -5226,6 +5226,7 @@ create_local_bg_thread(
       /* Force printer to timeout and be deleted */
       cupsRWLockWrite(&printer->lock);
       printer->state_time = 0;
+      printer->temporary = 1;
       cupsRWUnlock(&printer->lock);
 
       send_ipp_status(con, IPP_STATUS_ERROR_DEVICE, _("Couldn't resolve mDNS URI \"%s\"."), printer->device_uri);
@@ -5246,6 +5247,7 @@ create_local_bg_thread(
     /* Force printer to timeout and be deleted */
     cupsRWLockWrite(&printer->lock);
     printer->state_time = 0;
+    printer->temporary = 1;
     cupsRWUnlock(&printer->lock);
 
     send_ipp_status(con, IPP_STATUS_ERROR_DEVICE, _("Unable to connect to %s:%d: %s"), host, port, cupsGetErrorString());
@@ -5330,6 +5332,7 @@ create_local_bg_thread(
     /* Force printer to timeout and be deleted */
     cupsRWLockWrite(&printer->lock);
     printer->state_time = 0;
+    printer->temporary = 1;
     cupsRWUnlock(&printer->lock);
 
     send_ipp_status(con, IPP_STATUS_ERROR_DEVICE, _("The printer does not provide attributes required for IPP Everywhere."));
@@ -5339,6 +5342,12 @@ create_local_bg_thread(
   // Validate response from printer...
   if (!ippValidateAttributes(response))
   {
+    /* Force printer to timeout and be deleted */
+    cupsRWLockWrite(&printer->lock);
+    printer->state_time = 0;
+    printer->temporary = 1;
+    cupsRWUnlock(&printer->lock);
+
     send_ipp_status(con, IPP_STATUS_ERROR_DEVICE, _("Printer returned invalid data: %s"), cupsGetErrorString());
     goto finish_response;
   }
@@ -5387,6 +5396,7 @@ create_local_bg_thread(
       /* Force printer to timeout and be deleted */
       cupsRWLockWrite(&printer->lock);
       printer->state_time = 0;
+      printer->temporary = 1;
       cupsRWUnlock(&printer->lock);
 
       send_ipp_status(con, IPP_STATUS_ERROR_DEVICE, _("Unable to create PPD for printer: %s"), strerror(errno));
@@ -5420,6 +5430,7 @@ create_local_bg_thread(
     /* Force printer to timeout and be deleted */
     cupsRWLockWrite(&printer->lock);
     printer->state_time = 0;
+    printer->temporary = 1;
     cupsRWUnlock(&printer->lock);
 
     send_ipp_status(con, IPP_STATUS_ERROR_DEVICE, _("Unable to create PPD: %s"), cupsGetErrorString());


### PR DESCRIPTION
If creating of permanent queue with IPP Everywhere model fails in separate thread, the print queue is created as raw.

It would be great if we remove such queue if creation fails, and marking them as temporary would make them to be removed automatically.