### PR TITLE
tls-gnutls.c: Use system crypto policy if available

### DIFF
--- a/cups/tls-gnutls.c
+++ b/cups/tls-gnutls.c
@@ -1813,7 +1813,7 @@ _httpTLSStart(http_t *http)		// I - Connection to server
     return (false);
   }
 
-  cupsCopyString(priority_string, "NORMAL", sizeof(priority_string));
+  cupsCopyString(priority_string, "@SYSTEM,NORMAL", sizeof(priority_string));
 
   if (tls_max_version < _HTTP_TLS_MAX)
   {


### PR DESCRIPTION
Some Linux systems provide a way how to control cryptography on system or service level via cryptographic policies. OpenSSL implementation reflects system changes to some degree, however GnuTLS implementation does not take system policy into account.

GnuTLS supports fallback mechanism, so we can fallback to NORMAL if @SYSTEM is not defined on the system.

Fortunately, the current GnuTLS implementation allows overrides via priority strings (so no "this cipher/hash is disabled" if we enabled them in our application by priority string), so allowing to honor system policy can save us work if someone wants to disable a specific cipher, so we don't have to implement it in libcups.