### PR TITLE
Add `NoSystem` SSLOptions value

### DIFF
--- a/cups/http-private.h
+++ b/cups/http-private.h
@@ -89,7 +89,8 @@ extern "C" {
 #  define _HTTP_TLS_ALLOW_RC4	1	/* Allow RC4 cipher suites */
 #  define _HTTP_TLS_ALLOW_DH	2	/* Allow DH/DHE key negotiation */
 #  define _HTTP_TLS_DENY_CBC	4	/* Deny CBC cipher suites */
-#  define _HTTP_TLS_SET_DEFAULT 128     /* Setting the default TLS options */
+#  define _HTTP_TLS_NO_SYSTEM	8	/* No system crypto policy */
+#  define _HTTP_TLS_SET_DEFAULT 128	/* Setting the default TLS options */
 
 #  define _HTTP_TLS_SSL3	0	/* Min/max version is SSL/3.0 */
 #  define _HTTP_TLS_1_0		1	/* Min/max version is TLS/1.0 */

--- a/cups/tls-gnutls.c
+++ b/cups/tls-gnutls.c
@@ -1616,6 +1616,8 @@ _httpTLSStart(http_t *http)		// I - Connection to server
 
   DEBUG_printf("3_httpTLSStart(http=%p)", http);
 
+  priority_string[0] = '\0';
+
   if (tls_options < 0)
   {
     DEBUG_puts("4_httpTLSStart: Setting defaults.");
@@ -1813,7 +1815,10 @@ _httpTLSStart(http_t *http)		// I - Connection to server
     return (false);
   }
 
-  cupsCopyString(priority_string, "@SYSTEM,NORMAL", sizeof(priority_string));
+  if (!(tls_options & _HTTP_TLS_NO_SYSTEM))
+    cupsCopyString(priority_string, "@SYSTEM,", sizeof(priority_string));
+
+  cupsConcatString(priority_string, "NORMAL", sizeof(priority_string));
 
   if (tls_max_version < _HTTP_TLS_MAX)
   {

--- a/cups/usersys.c
+++ b/cups/usersys.c
@@ -1672,6 +1672,8 @@ cups_set_ssl_options(
       min_version = _HTTP_TLS_1_3;
     else if (!_cups_strcasecmp(start, "None"))
       options = _HTTP_TLS_NONE;
+    else if (!_cups_strcasecmp(start, "NoSystem"))
+      options |= _HTTP_TLS_NO_SYSTEM;
   }
 
   cc->ssl_options     = options;

--- a/doc/help/man-client.conf.html
+++ b/doc/help/man-client.conf.html
@@ -59,7 +59,7 @@ Specifies the address and optionally the port to use when connecting to the serv
     <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>ServerName </strong><em>hostname-or-ip-address</em>[<em>:port</em>]<strong>/version=1.1</strong><br>
 Specifies the address and optionally the port to use when connecting to a server running CUPS 1.3.12 and earlier.
 </p>
-    <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>SSLOptions </strong>[<em>AllowDH</em>] [<em>AllowRC4</em>] [<em>AllowSSL3</em>] [<em>DenyCBC</em>] [<em>DenyTLS1.0</em>] [<em>MaxTLS1.0</em>] [<em>MaxTLS1.1</em>] [<em>MaxTLS1.2</em>] [<em>MaxTLS1.3</em>] [<em>MinTLS1.0</em>] [<em>MinTLS1.1</em>] [<em>MinTLS1.2</em>] [<em>MinTLS1.3</em>]<br>
+    <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>SSLOptions </strong>[<em>AllowDH</em>] [<em>AllowRC4</em>] [<em>AllowSSL3</em>] [<em>DenyCBC</em>] [<em>DenyTLS1.0</em>] [<em>MaxTLS1.0</em>] [<em>MaxTLS1.1</em>] [<em>MaxTLS1.2</em>] [<em>MaxTLS1.3</em>] [<em>MinTLS1.0</em>] [<em>MinTLS1.1</em>] [<em>MinTLS1.2</em>] [<em>MinTLS1.3</em>] [<em>NoSystem</em>]<br>
 </p>
     <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>SSLOptions None</strong><br>
 Sets encryption options (only in /etc/cups/client.conf).
@@ -73,6 +73,7 @@ The <em>DenyCBC</em> option disables all CBC cipher suites.
 The <em>DenyTLS1.0</em> option disables TLS v1.0 support - this sets the minimum protocol version to TLS v1.1.
 The <em>MinTLS</em> options set the minimum TLS version to support.
 The <em>MaxTLS</em> options set the maximum TLS version to support.
+The <em>NoSystem</em> option disables applying system cryptographic policy.
 Not all operating systems support TLS 1.3 at this time.
 </p>
     <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>TrustOnFirstUse Yes</strong><br>

--- a/doc/help/man-cupsd.conf.html
+++ b/doc/help/man-cupsd.conf.html
@@ -396,7 +396,7 @@ The default is &quot;Minimal&quot;.
 Listens on the specified address and port for encrypted connections.
 </p>
     <p style="margin-left: 2.5em; text-indent: -2.5em;"></p>
-    <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>SSLOptions </strong>[<em>AllowDH</em>] [<em>AllowRC4</em>] [<em>AllowSSL3</em>] [<em>DenyCBC</em>] [<em>DenyTLS1.0</em>] [<em>MaxTLS1.0</em>] [<em>MaxTLS1.1</em>] [<em>MaxTLS1.2</em>] [<em>MaxTLS1.3</em>] [<em>MinTLS1.0</em>] [<em>MinTLS1.1</em>] [<em>MinTLS1.2</em>] [<em>MinTLS1.3</em>]<br>
+    <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>SSLOptions </strong>[<em>AllowDH</em>] [<em>AllowRC4</em>] [<em>AllowSSL3</em>] [<em>DenyCBC</em>] [<em>DenyTLS1.0</em>] [<em>MaxTLS1.0</em>] [<em>MaxTLS1.1</em>] [<em>MaxTLS1.2</em>] [<em>MaxTLS1.3</em>] [<em>MinTLS1.0</em>] [<em>MinTLS1.1</em>] [<em>MinTLS1.2</em>] [<em>MinTLS1.3</em>] [<em>NoSystem</em>]<br>
 </p>
     <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>SSLOptions None</strong><br>
 Sets encryption options (only in /etc/cups/client.conf).
@@ -410,6 +410,7 @@ The <em>DenyCBC</em> option disables all CBC cipher suites.
 The <em>DenyTLS1.0</em> option disables TLS v1.0 support - this sets the minimum protocol version to TLS v1.1.
 The <em>MinTLS</em> options set the minimum TLS version to support.
 The <em>MaxTLS</em> options set the maximum TLS version to support.
+The <em>NoSystem</em> option disables applying system cryptographic policy.
 Not all operating systems support TLS 1.3 at this time.
 </p>
     <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>SSLPort </strong><em>port</em><br>

--- a/man/client.conf.5
+++ b/man/client.conf.5
@@ -67,7 +67,7 @@ Specifies the address and optionally the port to use when connecting to the serv
 Specifies the address and optionally the port to use when connecting to a server running CUPS 1.3.12 and earlier.
 .\"#SSLOptions
 .TP 5
-\fBSSLOptions \fR[\fIAllowDH\fR] [\fIAllowRC4\fR] [\fIAllowSSL3\fR] [\fIDenyCBC\fR] [\fIDenyTLS1.0\fR] [\fIMaxTLS1.0\fR] [\fIMaxTLS1.1\fR] [\fIMaxTLS1.2\fR] [\fIMaxTLS1.3\fR] [\fIMinTLS1.0\fR] [\fIMinTLS1.1\fR] [\fIMinTLS1.2\fR] [\fIMinTLS1.3\fR]
+\fBSSLOptions \fR[\fIAllowDH\fR] [\fIAllowRC4\fR] [\fIAllowSSL3\fR] [\fIDenyCBC\fR] [\fIDenyTLS1.0\fR] [\fIMaxTLS1.0\fR] [\fIMaxTLS1.1\fR] [\fIMaxTLS1.2\fR] [\fIMaxTLS1.3\fR] [\fIMinTLS1.0\fR] [\fIMinTLS1.1\fR] [\fIMinTLS1.2\fR] [\fIMinTLS1.3\fR] [\fINoSystem\fR]
 .TP 5
 \fBSSLOptions None\fR
 Sets encryption options (only in /etc/cups/client.conf).
@@ -81,6 +81,7 @@ The \fIDenyCBC\fR option disables all CBC cipher suites.
 The \fIDenyTLS1.0\fR option disables TLS v1.0 support - this sets the minimum protocol version to TLS v1.1.
 The \fIMinTLS\fR options set the minimum TLS version to support.
 The \fIMaxTLS\fR options set the maximum TLS version to support.
+The \fINoSystem\fR option disables applying system cryptographic policy.
 Not all operating systems support TLS 1.3 at this time.
 .\"#TrustOnFirstUse
 .TP 5

--- a/man/cupsd.conf.5
+++ b/man/cupsd.conf.5
@@ -447,7 +447,7 @@ Listens on the specified address and port for encrypted connections.
 .\"#SSLOptions
 .TP 5
 .TP 5
-\fBSSLOptions \fR[\fIAllowDH\fR] [\fIAllowRC4\fR] [\fIAllowSSL3\fR] [\fIDenyCBC\fR] [\fIDenyTLS1.0\fR] [\fIMaxTLS1.0\fR] [\fIMaxTLS1.1\fR] [\fIMaxTLS1.2\fR] [\fIMaxTLS1.3\fR] [\fIMinTLS1.0\fR] [\fIMinTLS1.1\fR] [\fIMinTLS1.2\fR] [\fIMinTLS1.3\fR]
+\fBSSLOptions \fR[\fIAllowDH\fR] [\fIAllowRC4\fR] [\fIAllowSSL3\fR] [\fIDenyCBC\fR] [\fIDenyTLS1.0\fR] [\fIMaxTLS1.0\fR] [\fIMaxTLS1.1\fR] [\fIMaxTLS1.2\fR] [\fIMaxTLS1.3\fR] [\fIMinTLS1.0\fR] [\fIMinTLS1.1\fR] [\fIMinTLS1.2\fR] [\fIMinTLS1.3\fR] [\fINoSystem\fR]
 .TP 5
 \fBSSLOptions None\fR
 Sets encryption options (only in /etc/cups/client.conf).
@@ -461,6 +461,7 @@ The \fIDenyCBC\fR option disables all CBC cipher suites.
 The \fIDenyTLS1.0\fR option disables TLS v1.0 support - this sets the minimum protocol version to TLS v1.1.
 The \fIMinTLS\fR options set the minimum TLS version to support.
 The \fIMaxTLS\fR options set the maximum TLS version to support.
+The \fINoSystem\fR option disables applying system cryptographic policy.
 Not all operating systems support TLS 1.3 at this time.
 .\"#SSLPort
 .TP 5

--- a/scheduler/conf.c
+++ b/scheduler/conf.c
@@ -3128,6 +3128,8 @@ read_cupsd_conf(cups_file_t *fp)	/* I - File to read from */
 	    min_version = _HTTP_TLS_1_3;
 	  else if (!_cups_strcasecmp(start, "None"))
 	    options = _HTTP_TLS_NONE;
+	  else if (!_cups_strcasecmp(start, "NoSystem"))
+	    options |= _HTTP_TLS_NO_SYSTEM;
 	  else if (_cups_strcasecmp(start, "NoEmptyFragments"))
 	    cupsdLogMessage(CUPSD_LOG_WARN, "Unknown SSL option %s at line %d.", start, linenum);
         }


### PR DESCRIPTION
In case using system crypto policy breaks communication with device irreversibly (f.e. if device does not support better key exchange algorithm), the new option value gives a way how to opt-out from crypto policy if user do not want to change default system crypto policy for the whole machine.