### PR TITLE
Fix memory leaks connected to cgiGetVariable() usage 

### DIFF
--- a/cgi-bin/admin.c
+++ b/cgi-bin/admin.c
@@ -3702,6 +3702,8 @@ get_option_value(
 	    if (number_points < cparam->minimum.custom_points ||
 		number_points > cparam->maximum.custom_points) {
 	      free(val);
+	      if (uval)
+	        free(uval);
 	      return (NULL);
 	    }
 

--- a/cgi-bin/admin.c
+++ b/cgi-bin/admin.c
@@ -327,7 +327,7 @@ do_am_class(http_t *http,		/* I - HTTP connection */
   char		uri[HTTP_MAX_URI];	/* Device or printer URI */
   const char	*name,			/* Pointer to class name */
 		*ptr;			/* Pointer to CGI variable */
-  char *op;		/* Operation name */
+  char *op;		  /* Operation name */
   const char	*title;			/* Title of page */
   static const char * const pattrs[] =	/* Requested printer attributes */
 		{
@@ -1552,7 +1552,7 @@ do_config_server(http_t *http)		/* I - HTTP connection */
     cups_file_t	*temp;			/* Temporary file */
     char	*start,			/* Start of line */
 		*end,			/* End of line */
-    *tmp_start;
+		*tmp_start;
 
    /*
     * Create a temporary file for the new cupsd.conf file...
@@ -2309,7 +2309,7 @@ do_set_allowed_users(http_t *http)	/* I - HTTP connection */
   char		uri[HTTP_MAX_URI];	/* Printer URI */
   const char	*printer,		/* Printer name */
 		*users;			/* List of users or groups */
-	char	*is_class,		/* Is a class? */
+  char	*is_class,		/* Is a class? */
 		*type;			/* Allow/deny type */
   int		num_users;		/* Number of users */
   char		*ptr,			/* Pointer into users string */
@@ -2579,7 +2579,7 @@ do_set_default(http_t *http)		/* I - HTTP connection */
   ipp_t		*request;		/* IPP request */
   char		uri[HTTP_MAX_URI];	/* Printer URI */
   const char	*printer;		/* Printer name */
-	char	*is_class;		/* Is a class? */
+  char	*is_class;			/* Is a class? */
 
 
   is_class = cgiGetVariable("IS_CLASS");
@@ -2669,7 +2669,7 @@ do_set_options(http_t *http,		/* I - HTTP connection */
 		*response;		/* IPP response */
   ipp_attribute_t *attr;		/* IPP attribute */
   char		uri[HTTP_MAX_URI];	/* Job URI */
-  char	*var;			/* Variable value */
+  char	*var;				/* Variable value */
   const char	*printer;		/* Printer printer name */
   const char	*filename;		/* PPD filename */
   char		tempfile[1024];		/* Temporary filename */
@@ -3425,7 +3425,7 @@ get_option_value(
   ppd_cparam_t	*cparam;		/* Current custom parameter */
   char		keyword[256];		/* Parameter name */
   char	*val = NULL,			/* Parameter value */
-		*uval = NULL;			/* Units value */
+	*uval = NULL;			/* Units value */
   long		integer;		/* Integer value */
   double	number,			/* Number value */
 		number_points;		/* Number in points */
@@ -3553,20 +3553,20 @@ get_option_value(
 	      (uval = cgiGetVariable(keyword)) == NULL ||
 	      (strcmp(uval, "pt") && strcmp(uval, "in") && strcmp(uval, "ft") &&
 	       strcmp(uval, "cm") && strcmp(uval, "mm") && strcmp(uval, "m"))) {
-	    if (uval)
-        free(uval);
-      return (NULL);
-    }
+	      if (uval)
+	        free(uval);
+	      return (NULL);
+	  }
 
 	  number_points = get_points(number, uval);
 	  if (number_points < cparam->minimum.custom_points ||
 	      number_points > cparam->maximum.custom_points) {
-      free(uval);
-	    return (NULL);
-    }
+	      free(uval);
+	      return (NULL);
+	  }
 
 	  snprintf(buffer, bufsize, "Custom.%g%s", number, uval);
-    free(uval);
+	  free(uval);
           break;
 
       case PPD_CUSTOM_PASSCODE :
@@ -3642,10 +3642,10 @@ get_option_value(
 		(strcmp(uval, "pt") && strcmp(uval, "in") &&
 		 strcmp(uval, "ft") && strcmp(uval, "cm") &&
 		 strcmp(uval, "mm") && strcmp(uval, "m"))) {
-        if (uval)
-          free(uval);
+	      if (uval)
+	        free(uval);
 	      return (NULL);
-     }
+	    }
 	    number_points = get_points(number, uval);
 	    if (number_points < cparam->minimum.custom_points ||
 		number_points > cparam->maximum.custom_points)
@@ -3653,7 +3653,7 @@ get_option_value(
 
 	    snprintf(bufptr, (size_t)(bufend - bufptr), "%g%s", number, uval);
 	    free(uval);
-      break;
+	    break;
 
 	case PPD_CUSTOM_PASSCODE :
 	    for (uval = val; *uval; uval ++)

--- a/cgi-bin/admin.c
+++ b/cgi-bin/admin.c
@@ -326,8 +326,8 @@ do_am_class(http_t *http,		/* I - HTTP connection */
   ipp_attribute_t *attr;		/* member-uris attribute */
   char		uri[HTTP_MAX_URI];	/* Device or printer URI */
   const char	*name,			/* Pointer to class name */
-		*op,			/* Operation name */
 		*ptr;			/* Pointer to CGI variable */
+  char *op;		/* Operation name */
   const char	*title;			/* Title of page */
   static const char * const pattrs[] =	/* Requested printer attributes */
 		{
@@ -496,9 +496,13 @@ do_am_class(http_t *http,		/* I - HTTP connection */
     }
 
     cgiEndHTML();
-
+    if (op)
+      free(op);
     return;
   }
+
+  if (op)
+    free(op);
 
   if (!name)
   {

--- a/cgi-bin/admin.c
+++ b/cgi-bin/admin.c
@@ -3342,19 +3342,19 @@ do_set_options(http_t *http,		/* I - HTTP connection */
     if ((var = cgiGetVariable("printer_error_policy")) != NULL) {
       ippAddString(request, IPP_TAG_PRINTER, IPP_TAG_NAME,
 		   "printer-error-policy", NULL, var);
-       free(var);
+      free(var);
     }
 
     if ((var = cgiGetVariable("printer_op_policy")) != NULL) {
       ippAddString(request, IPP_TAG_PRINTER, IPP_TAG_NAME,
 		   "printer-op-policy", NULL, var);
-       free(var);
+      free(var);
     }
 
     if ((var = cgiGetVariable("port_monitor")) != NULL) {
       ippAddString(request, IPP_TAG_PRINTER, IPP_TAG_NAME,
 		   "port-monitor", NULL, var);
-       free(var);
+      free(var);
     }
 
    /*

--- a/cgi-bin/admin.c
+++ b/cgi-bin/admin.c
@@ -1878,19 +1878,21 @@ do_delete_printer(http_t *http)		/* I - HTTP connection */
   ipp_t		*request;		/* IPP request */
   char		uri[HTTP_MAX_URI];	/* Job URI */
   const char	*printer;		/* Printer printer name */
+  char *tmp;
 
 
  /*
   * Get form variables...
   */
 
-  if (cgiGetVariable("CONFIRM") == NULL)
+  if ((tmp = cgiGetVariable("CONFIRM")) == NULL)
   {
     cgiStartHTML(cgiText(_("Delete Printer")));
     cgiCopyTemplateLang("printer-confirm.tmpl");
     cgiEndHTML();
     return;
   }
+  free(tmp);
 
   if ((printer = cgiGetTextfield("PRINTER_NAME")) != NULL)
     httpAssembleURIf(HTTP_URI_CODING_ALL, uri, sizeof(uri), "ipp", NULL,

--- a/cgi-bin/admin.c
+++ b/cgi-bin/admin.c
@@ -56,7 +56,8 @@ int					/* O - Exit status */
 main(void)
 {
   http_t	*http;			/* Connection to the server */
-  const char	*op;			/* Operation name */
+  char	*op;			/* Operation name */
+  char	*tmp = NULL;
 
 
  /*
@@ -90,7 +91,7 @@ main(void)
   * See if we have form data...
   */
 
-  if (!cgiInitialize() || !cgiGetVariable("OP"))
+  if (!cgiInitialize() || !(tmp = cgiGetVariable("OP")))
   {
    /*
     * Nope, send the administration menu...
@@ -118,12 +119,14 @@ main(void)
       					/* Port number */
       char	uri[1024];		/* URL */
 
-      if (printer)
+      if (printer) {
+        free(tmp);
         httpAssembleURIf(HTTP_URI_CODING_ALL, uri, sizeof(uri),
 	                 getenv("HTTPS") ? "https" : "http", NULL,
 			 getenv("SERVER_NAME"), port, "/%s/%s",
-			 cgiGetVariable("IS_CLASS") ? "classes" : "printers",
+			 (tmp = cgiGetVariable("IS_CLASS")) ? "classes" : "printers",
 			 printer);
+      }
       else
         httpAssembleURI(HTTP_URI_CODING_ALL, uri, sizeof(uri),
 	                getenv("HTTPS") ? "https" : "http", NULL,
@@ -166,10 +169,12 @@ main(void)
       cgiCopyTemplateLang("error-op.tmpl");
       cgiEndHTML();
     }
+    free(op);
   }
   else if (op && !strcmp(op, "redirect"))
   {
-    const char	*url;			/* Redirection URL... */
+    free(op);
+    char	*url;			/* Redirection URL... */
     char	prefix[1024];		/* URL prefix */
 
 
@@ -229,6 +234,8 @@ main(void)
     }
     else
       printf("Location: %s/admin\n\n", prefix);
+    if (url)
+      free(url);
   }
   else
   {
@@ -239,6 +246,8 @@ main(void)
     cgiStartHTML(cgiText(_("Administration")));
     cgiCopyTemplateLang("error-op.tmpl");
     cgiEndHTML();
+    if (op)
+      free(op);
   }
 
  /*
@@ -250,6 +259,8 @@ main(void)
  /*
   * Return with no errors...
   */
+  if (tmp)
+    free(tmp);
 
   return (0);
 }

--- a/cgi-bin/admin.c
+++ b/cgi-bin/admin.c
@@ -633,8 +633,8 @@ do_am_printer(http_t *http,		/* I - HTTP connection */
 		evefile[1024] = "";	/* IPP Everywhere PPD file */
   int		maxrate;		/* Maximum baud rate */
   char		baudrate[255];		/* Baud rate string */
-  const char	*name,			/* Pointer to class name */
-		*ptr;			/* Pointer to CGI variable */
+  const char	*name;			/* Pointer to class name */
+	char	*ptr;			/* Pointer to CGI variable */
   const char	*title;			/* Title of page */
   static int	baudrates[] =		/* Baud rates */
 		{
@@ -654,6 +654,7 @@ do_am_printer(http_t *http,		/* I - HTTP connection */
   ptr = cgiGetVariable("DEVICE_URI");
   fprintf(stderr, "DEBUG: do_am_printer: DEVICE_URI=\"%s\"\n",
           ptr ? ptr : "(null)");
+  free(ptr);
 
   title = cgiText(modify ? _("Modify Printer") : _("Add Printer"));
 

--- a/cgi-bin/admin.c
+++ b/cgi-bin/admin.c
@@ -2560,8 +2560,8 @@ do_set_default(http_t *http)		/* I - HTTP connection */
   const char	*title;			/* Page title */
   ipp_t		*request;		/* IPP request */
   char		uri[HTTP_MAX_URI];	/* Printer URI */
-  const char	*printer,		/* Printer name */
-		*is_class;		/* Is a class? */
+  const char	*printer;		/* Printer name */
+	char	*is_class;		/* Is a class? */
 
 
   is_class = cgiGetVariable("IS_CLASS");
@@ -2574,6 +2574,8 @@ do_set_default(http_t *http)		/* I - HTTP connection */
     cgiStartHTML(title);
     cgiCopyTemplateLang("error.tmpl");
     cgiEndHTML();
+    if (is_class)
+      free(is_class);
     return;
   }
 
@@ -2630,6 +2632,8 @@ do_set_default(http_t *http)		/* I - HTTP connection */
   }
 
   cgiEndHTML();
+  if (is_class)
+    free(is_class);
 }
 
 

--- a/cgi-bin/admin.c
+++ b/cgi-bin/admin.c
@@ -1262,8 +1262,10 @@ do_am_printer(http_t *http,		/* I - HTTP connection */
 static void
 do_config_server(http_t *http)		/* I - HTTP connection */
 {
-  if (cgiGetVariable("CHANGESETTINGS"))
+  char *tmp, *tmp2 = NULL, *tmp3;
+  if ((tmp = cgiGetVariable("CHANGESETTINGS")))
   {
+    free(tmp);
    /*
     * Save basic setting changes...
     */
@@ -1536,8 +1538,10 @@ do_config_server(http_t *http)		/* I - HTTP connection */
 
     cgiEndHTML();
   }
-  else if (cgiGetVariable("SAVECHANGES") && cgiGetVariable("CUPSDCONF"))
+  else if ((tmp2 = cgiGetVariable("SAVECHANGES")) && (tmp3 = cgiGetVariable("CUPSDCONF")))
   {
+    free(tmp2);
+    free(tmp3);
    /*
     * Save hand-edited config file...
     */
@@ -1546,9 +1550,9 @@ do_config_server(http_t *http)		/* I - HTTP connection */
     char	tempfile[1024];		/* Temporary new cupsd.conf */
     int		tempfd;			/* Temporary file descriptor */
     cups_file_t	*temp;			/* Temporary file */
-    const char	*start,			/* Start of line */
-		*end;			/* End of line */
-
+    char	*start,			/* Start of line */
+		*end,			/* End of line */
+    *tmp_start;
 
    /*
     * Create a temporary file for the new cupsd.conf file...
@@ -1585,6 +1589,7 @@ do_config_server(http_t *http)		/* I - HTTP connection */
     */
 
     start = cgiGetVariable("CUPSDCONF");
+    tmp_start = start;
     while (start)
     {
       if ((end = strstr(start, "\r\n")) == NULL)
@@ -1598,8 +1603,10 @@ do_config_server(http_t *http)		/* I - HTTP connection */
         start = end + 2;
       else if (*end == '\n')
         start = end + 1;
-      else
+      else {
+        free(tmp_start);
         start = NULL;
+      }
     }
 
     cupsFileClose(temp);
@@ -1648,6 +1655,8 @@ do_config_server(http_t *http)		/* I - HTTP connection */
     char	filename[1024];		/* Filename */
     const char	*server_root;		/* Location of config files */
 
+    if (tmp2)
+      free(tmp2);
 
    /*
     * Locate the cupsd.conf file...

--- a/cgi-bin/admin.c
+++ b/cgi-bin/admin.c
@@ -2296,8 +2296,8 @@ do_set_allowed_users(http_t *http)	/* I - HTTP connection */
 		*response;		/* IPP response */
   char		uri[HTTP_MAX_URI];	/* Printer URI */
   const char	*printer,		/* Printer name */
-		*is_class,		/* Is a class? */
-		*users,			/* List of users or groups */
+		*users;			/* List of users or groups */
+	char	*is_class,		/* Is a class? */
 		*type;			/* Allow/deny type */
   int		num_users;		/* Number of users */
   char		*ptr,			/* Pointer into users string */
@@ -2320,6 +2320,8 @@ do_set_allowed_users(http_t *http)	/* I - HTTP connection */
     cgiStartHTML(cgiText(_("Set Allowed Users")));
     cgiCopyTemplateLang("error.tmpl");
     cgiEndHTML();
+    if (is_class)
+      free(is_class);
     return;
   }
 
@@ -2547,6 +2549,10 @@ do_set_allowed_users(http_t *http)	/* I - HTTP connection */
 
     cgiEndHTML();
   }
+  if (is_class)
+    free(is_class);
+  if (type)
+    free(type);
 }
 
 

--- a/cgi-bin/admin.c
+++ b/cgi-bin/admin.c
@@ -1793,19 +1793,20 @@ do_delete_class(http_t *http)		/* I - HTTP connection */
   ipp_t		*request;		/* IPP request */
   char		uri[HTTP_MAX_URI];	/* Job URI */
   const char	*pclass;		/* Printer class name */
-
+  char *tmp;
 
  /*
   * Get form variables...
   */
 
-  if (cgiGetVariable("CONFIRM") == NULL)
+  if ((tmp = cgiGetVariable("CONFIRM")) == NULL)
   {
     cgiStartHTML(cgiText(_("Delete Class")));
     cgiCopyTemplateLang("class-confirm.tmpl");
     cgiEndHTML();
     return;
   }
+  free(tmp);
 
   if ((pclass = cgiGetTextfield("PRINTER_NAME")) != NULL)
     httpAssembleURIf(HTTP_URI_CODING_ALL, uri, sizeof(uri), "ipp", NULL,


### PR DESCRIPTION
cgiGetVariable() returns the result of strdup - pointer to allocated dynamic memory which must be freed. Fix memory leaks.