### PR TITLE
Fix memory leaks in ppdc.cxx

### DIFF
--- a/ppdc/ppdc.cxx
+++ b/ppdc/ppdc.cxx
@@ -354,7 +354,7 @@ main(int  argc,				// I - Number of command-line arguments
 	                  _("ppdc: Warning - overlapping filename \"%s\"."),
 			  filename);
 	else
-	  cupsArrayAdd(filenames, strdup(filename));
+	  cupsArrayAdd(filenames, filename);
 
 	fp = cupsFileOpen(filename, comp ? "w9" : "w");
 	if (!fp)
@@ -409,6 +409,8 @@ main(int  argc,				// I - Number of command-line arguments
   if (catalog)
     catalog->release();
 
+  cupsArrayDelete(filenames);
+  delete locales;
   // Return with no errors.
   return (0);
 }


### PR DESCRIPTION
Running cups unit tests with ASAN sanitizer
causes memory leaks in ppdc.cxx file, which stops the build Closes #1174
Signed-off by: Kirill Furman <kir.furman@gmail.com>