### PR TITLE
Fix heap overflow in array.c

### DIFF
--- a/cups/array.c
+++ b/cups/array.c
@@ -109,7 +109,7 @@ cupsArrayAddStrings(cups_array_t *a,	// I - Array
 
   DEBUG_printf("_cupsArrayAddStrings(a=%p, s=\"%s\", delim='%c')", (void *)a, s, delim);
 
-  if (!a || !s || !*s)
+  if (!a || !s || !*s || delim == '\0')
   {
     DEBUG_puts("1_cupsArrayAddStrings: Returning 0");
     return (false);


### PR DESCRIPTION
When delim variable has \0 value,
strchr() func switch end var to the end of string, set it to \0 and shift to next byte, which causes
heap overflow when new cycle runs
Fixes #1176
Signed-off by Kirill Furman <kir.furman@gmail.com>