### PR TITLE
Avoid NULL strcmp argument

### DIFF
--- a/backend/ipp.c
+++ b/backend/ipp.c
@@ -2960,7 +2960,7 @@ new_request(
       fputs("DEBUG: Adding all operation/job attributes.\n", stderr);
       num_options = adjust_options(num_options, &options);
 
-      if (!strcmp(format, "image/pwg-raster") || !strcmp(format, "image/urf"))
+      if (format && (!strcmp(format, "image/pwg-raster") || !strcmp(format, "image/urf")))
         num_options = cupsRemoveOption("copies", num_options, &options);
 
       cupsEncodeOptions2(request, num_options, options, IPP_TAG_OPERATION);


### PR DESCRIPTION
It is possible for `format` to be NULL (as described in the function signature) which causes a segmentation fault when it is passed to `strcmp`. This patch changes the conditional to short-circuit if `format` is NULL and only call `strcmp` otherwise.

I discovered this issue while running a minimal setup with cups built and installed from the 2.4.x branch. Printing to an IPP printer server caused the IPP backend to crash before this change. I can provide more details on the environment if that is needed.