### PR TITLE
Add Kyocera KM-1635 USB quirks

### DIFF
--- a/backend/org.cups.usb-quirks
+++ b/backend/org.cups.usb-quirks
@@ -327,6 +327,9 @@
 # Lexmark C540n (Apple #4778)
 0x043d 0x0139 no-reattach
 
+# Kyocera KM-1635
+0x0482 0x033e soft-reset
+
 # Kyocera Ecosys P6026cdn (Apple #4900)
 0x0482 0x063f no-reattach
 


### PR DESCRIPTION
This device is known to work with all quirks enabled, but exact quirk that helps is unknown. Let's enable all quirks for now.