### PR TITLE
Fix allowable UTC timezone offsets as per RFC 2579

### DIFF
--- a/cups/ipp.c
+++ b/cups/ipp.c
@@ -3736,7 +3736,7 @@ ippValidateAttribute(
 	    return (0);
 	  }
 
-          if (date[9] > 11)
+          if (date[9] > 13)
 	  {
 	    ipp_set_error(IPP_STATUS_ERROR_BAD_REQUEST, _("\"%s\": Bad dateTime UTC hours %u (RFC 8011 section 5.1.15)."), attr->name, date[9]);
 	    return (0);


### PR DESCRIPTION
This fixes Issue #1201, by extending the allowable UTC timezone offsets to '13' from the current '11'.

For confirmation, please see [RFC2579](https://www.rfc-editor.org/rfc/rfc2579) page 18, where the range listed for the 'hours from UTC' should extend from `0..13`.