### PR TITLE
Fixed unreliable DNS-SD discovery with ippfind -T 0

### DIFF
--- a/tools/ippfind.c
+++ b/tools/ippfind.c
@@ -233,6 +233,7 @@ main(int  argc,				/* I - Number of command-line args */
   struct timeval	stimeout;	/* Timeout for select() */
 #endif /* HAVE_MDNSRESPONDER */
   double		endtime;	/* End time */
+  double		mintime;	/* Minimal end time */
   static const char * const ops[] =	/* Node operation names */
   {
     "NONE",
@@ -1308,9 +1309,16 @@ main(int  argc,				/* I - Number of command-line args */
   */
 
   if (bonjour_timeout > 1.0)
+  {
     endtime = get_time() + bonjour_timeout;
+    mintime = endtime; /* Actually ignored in this mode */
+  }
   else
-    endtime = get_time() + 300.0;
+  {
+    double now = get_time();
+    endtime = now + 300.0;
+    mintime = now + 2.5; /* To ensure reliable browsing with -T 0 option */
+  }
 
   while (get_time() < endtime)
   {
@@ -1458,8 +1466,11 @@ main(int  argc,				/* I - Number of command-line args */
       * If we have processed all services we have discovered, then we are done.
       */
 
-      if (processed == cupsArrayCount(services) && bonjour_timeout <= 1.0)
-        break;
+      if (get_time() >= mintime)
+      {
+        if (processed == cupsArrayCount(services) && bonjour_timeout <= 1.0)
+          break;
+      }
     }
   }
 


### PR DESCRIPTION
The driverless backend uses the ippfind tool for DNS-SD discovery. When invoking ippfind, it uses the -T 0 option to maximize speed.

In this mode, ippfind follows a heuristic: if no new events are received from Avahi for 500 milliseconds and all discovered services have already been resolved, it assumes discovery is complete and exits.

However, Avahi sometimes responds too slowly, meaning a 500 ms silence does not necessarily indicate that no more services will be discovered shortly. As a result, ippfind may exit prematurely, increasing the likelihood of missing devices.

This issue occurs particularly often when only the loopback interface is active, and the only available devices are those published by the ipp-usb daemon.

To address this, the fix increases the minimum search time to 2500 milliseconds. This change has minimal impact on normal operations, since discovery typically takes 2000–2500 ms when devices are found, while eliminating unreliability caused by early termination.