### PR TITLE
dirsvc.c: Fix DNSSDHostName directive behavior

### DIFF
--- a/scheduler/dirsvc.c
+++ b/scheduler/dirsvc.c
@@ -203,7 +203,7 @@ cupsdUpdateDNSSDName(void)
   * Get the hostname...
   */
 
-  if (cupsDNSSDCopyHostName(DNSSDContext, name, sizeof(name)))
+  if (!DNSSDHostName && cupsDNSSDCopyHostName(DNSSDContext, name, sizeof(name)))
     cupsdSetString(&DNSSDHostName, name);
 
   if (!DNSSDHostName)


### PR DESCRIPTION
DNSSDHostName directive value was replaced by local hostname in the new dnssd implementation.

Fixes #1217