### PR TITLE
Move declaration of looping variable inside for loop header

### DIFF
--- a/cups/dest-job.c
+++ b/cups/dest-job.c
@@ -68,7 +68,6 @@ cupsCloseDestJob(
     cups_dinfo_t *info, 		/* I - Destination information */
     int          job_id)		/* I - Job ID */
 {
-  int			i;		/* Looping var */
   ipp_t			*request = NULL;/* Close-Job/Send-Document request */
   ipp_attribute_t	*attr;		/* operations-supported attribute */
 
@@ -100,7 +99,7 @@ cupsCloseDestJob(
   if ((attr = ippFindAttribute(info->attrs, "operations-supported",
                                IPP_TAG_ENUM)) != NULL)
   {
-    for (i = 0; i < attr->num_values; i ++)
+    for (int i = 0; i < attr->num_values; i ++)
       if (attr->values[i].integer == IPP_OP_CLOSE_JOB)
       {
         request = ippNewRequest(IPP_OP_CLOSE_JOB);

--- a/cups/dest.c
+++ b/cups/dest.c
@@ -169,11 +169,8 @@ cupsAddDest(const char  *name,		// I  - Destination name
             int         num_dests,	// I  - Number of destinations
             cups_dest_t **dests)	// IO - Destinations
 {
-  int		i;			// Looping var
   cups_dest_t	*dest;			// Destination pointer
   cups_dest_t	*parent = NULL;		// Parent destination
-  cups_option_t	*doption,		// Current destination option
-		*poption;		// Current parent option
 
 
   if (!name || !dests)
@@ -208,11 +205,10 @@ cupsAddDest(const char  *name,		// I  - Destination name
       if (dest->options)
       {
         dest->num_options = parent->num_options;
+        cups_option_t *doption = dest->options;
+        cups_option_t	*poption = parent->options;
 
-	for (i = dest->num_options, doption = dest->options,
-	         poption = parent->options;
-	     i > 0;
-	     i --, doption ++, poption ++)
+        for (int i = dest->num_options; i > 0; i --, doption ++, poption ++)
 	{
 	  doption->name  = _cupsStrRetain(poption->name);
 	  doption->value = _cupsStrRetain(poption->value);
@@ -716,10 +712,7 @@ cupsCopyDest(cups_dest_t *dest,         // I  - Destination to copy
              int         num_dests,     // I  - Number of destinations
              cups_dest_t **dests)       // IO - Destination array
 {
-  int		i;			// Looping var
   cups_dest_t	*new_dest;		// New destination pointer
-  cups_option_t	*new_option,		// Current destination option
-		*option;		// Current parent option
 
 
   //
@@ -763,11 +756,10 @@ cupsCopyDest(cups_dest_t *dest,         // I  - Destination to copy
       return (cupsRemoveDest(dest->name, dest->instance, num_dests, dests));
 
     new_dest->num_options = dest->num_options;
+    cups_option_t *option = dest->options;
+    cups_option_t *new_option = new_dest->options;
 
-    for (i = dest->num_options, option = dest->options,
-	     new_option = new_dest->options;
-	 i > 0;
-	 i --, option ++, new_option ++)
+    for (int i = dest->num_options; i > 0; i --, option ++, new_option ++)
     {
       new_option->name  = _cupsStrRetain(option->name);
       new_option->value = _cupsStrRetain(option->value);

--- a/cups/http-addrlist.c
+++ b/cups/http-addrlist.c
@@ -53,7 +53,7 @@ httpAddrConnect2(
 {
   int			val;		/* Socket option value */
 #ifndef _WIN32
-  int			i, j,		/* Looping vars */
+  int			i,		/* Looping var */
 			flags,		/* Socket flags */
 			result;		/* Result from select() or poll() */
 #endif /* !_WIN32 */
@@ -281,7 +281,7 @@ httpAddrConnect2(
     {
       http_addrlist_t *connaddr = NULL;	/* Connected address, if any */
 
-      for (i = 0; i < nfds; i ++)
+      for (int i = 0; i < nfds; i ++)
       {
 	DEBUG_printf("pfds[%d].revents=%x\n", i, pfds[i].revents);
 
@@ -354,10 +354,10 @@ httpAddrConnect2(
         * far and return...
         */
 
-        for (j = 0; j < i; j ++)
+        for (int j = 0; j < i; j ++)
           httpAddrClose(NULL, fds[j]);
 
-        for (j ++; j < nfds; j ++)
+        for (int j = i + 1; j < nfds; j ++)
           httpAddrClose(NULL, fds[j]);
 
         return (connaddr);

--- a/cups/ipp.c
+++ b/cups/ipp.c
@@ -139,9 +139,7 @@ ippAddBooleans(ipp_t      *ipp,		// I - IPP message
 	       int        num_values,	// I - Number of values
 	       const char *values)	// I - Values
 {
-  int			i;		// Looping var
   ipp_attribute_t	*attr;		// New attribute
-  _ipp_value_t		*value;		// Current value
 
 
   DEBUG_printf("ippAddBooleans(ipp=%p, group=%02x(%s), name=\"%s\", num_values=%d, values=%p)", (void *)ipp, group, ippTagString(group), name, num_values, (void *)values);
@@ -156,7 +154,9 @@ ippAddBooleans(ipp_t      *ipp,		// I - IPP message
 
   if (values)
   {
-    for (i = num_values, value = attr->values; i > 0; i --, value ++)
+    _ipp_value_t *value = attr->values;
+
+    for (int i = num_values; i > 0; i --, value ++)
       value->boolean = *values++;
   }
 
@@ -230,9 +230,7 @@ ippAddCollections(
     int         num_values,		// I - Number of values
     const ipp_t **values)		// I - Values
 {
-  int			i;		// Looping var
   ipp_attribute_t	*attr;		// New attribute
-  _ipp_value_t		*value;		// Current value
 
 
   DEBUG_printf("ippAddCollections(ipp=%p, group=%02x(%s), name=\"%s\", num_values=%d, values=%p)", (void *)ipp, group, ippTagString(group), name, num_values, (void *)values);
@@ -247,7 +245,9 @@ ippAddCollections(
 
   if (values)
   {
-    for (i = num_values, value = attr->values; i > 0; i --, value ++)
+    _ipp_value_t *value = attr->values;
+
+    for (int i = num_values; i > 0; i --, value ++)
     {
       value->collection = (ipp_t *)*values++;
       value->collection->use ++;
@@ -287,8 +287,7 @@ ippAddCredentialsString(
   char			*cvalue,	// Copied value
 			*cstart,	// Start of value
 			*cptr;		// Pointer into copied value
-  size_t		i,		// Looping var
-			num_values;	// Number of values
+  size_t			num_values;	// Number of values
 
 
   // Range check input...
@@ -324,7 +323,9 @@ ippAddCredentialsString(
   // Create the empty attribute and copy the values...
   if ((attr = ippAddStrings(ipp, group, IPP_TAG_TEXT, name, num_values, NULL, NULL)) != NULL)
   {
-    for (i = 0, cptr = cvalue; cptr && i < num_values;)
+    cptr = cvalue;
+
+    for (size_t i = 0; cptr && i < num_values;)
     {
       cstart = cptr;
       if ((cptr = strchr(cptr, '\r')) != NULL)
@@ -466,7 +467,6 @@ ippAddIntegers(ipp_t      *ipp,		// I - IPP message
 {
   int			i;		// Looping var
   ipp_attribute_t	*attr;		// New attribute
-  _ipp_value_t		*value;		// Current value
 
 
   DEBUG_printf("ippAddIntegers(ipp=%p, group=%02x(%s), type=%02x(%s), name=\"%s\", num_values=%d, values=%p)", (void *)ipp, group, ippTagString(group), value_tag, ippTagString(value_tag), name, num_values, (void *)values);
@@ -483,7 +483,9 @@ ippAddIntegers(ipp_t      *ipp,		// I - IPP message
 
   if (values)
   {
-    for (i = num_values, value = attr->values; i > 0; i --, value ++)
+    _ipp_value_t *value = attr->values;
+
+    for (i = num_values; i > 0; i --, value ++)
       value->integer = *values++;
   }
 
@@ -645,9 +647,7 @@ ippAddRanges(ipp_t      *ipp,		// I - IPP message
 	     const int  *lower,		// I - Lower values
 	     const int  *upper)		// I - Upper values
 {
-  int			i;		// Looping var
   ipp_attribute_t	*attr;		// New attribute
-  _ipp_value_t		*value;		// Current value
 
 
   DEBUG_printf("ippAddRanges(ipp=%p, group=%02x(%s), name=\"%s\", num_values=%d, lower=%p, upper=%p)", (void *)ipp, group, ippTagString(group), name, num_values, (void *)lower, (void *)upper);
@@ -662,7 +662,9 @@ ippAddRanges(ipp_t      *ipp,		// I - IPP message
 
   if (lower && upper)
   {
-    for (i = num_values, value = attr->values; i > 0; i --, value ++)
+    _ipp_value_t *value = attr->values;
+
+    for (int i = num_values; i > 0; i --, value ++)
     {
       value->range.lower = *lower++;
       value->range.upper = *upper++;
@@ -737,9 +739,7 @@ ippAddResolutions(ipp_t      *ipp,	// I - IPP message
 		  const int  *xres,	// I - X resolutions
 		  const int  *yres)	// I - Y resolutions
 {
-  int			i;		// Looping var
   ipp_attribute_t	*attr;		// New attribute
-  _ipp_value_t		*value;		// Current value
 
 
   DEBUG_printf("ippAddResolutions(ipp=%p, group=%02x(%s), name=\"%s\", num_value=%d, units=%d, xres=%p, yres=%p)", (void *)ipp, group, ippTagString(group), name, num_values, units, (void *)xres, (void *)yres);
@@ -754,7 +754,9 @@ ippAddResolutions(ipp_t      *ipp,	// I - IPP message
 
   if (xres && yres)
   {
-    for (i = num_values, value = attr->values; i > 0; i --, value ++)
+    _ipp_value_t *value = attr->values;
+
+    for (int i = num_values; i > 0; i --, value ++)
     {
       value->resolution.xres  = *xres++;
       value->resolution.yres  = *yres++;
@@ -1559,14 +1561,14 @@ ippCopyCredentialsString(
 {
   char		*s = NULL,		// Combined string
 		*ptr;			// Pointer into string
-  int		i;			// Looping var
   size_t	slen;			// Length of combined string
 
 
   if (attr && ippGetValueTag(attr) == IPP_TAG_TEXT)
   {
     // Loop through string values and add up the total length...
-    for (i = 0, slen = 0; i < attr->num_values; i ++)
+    slen = 0;
+    for (int i = 0; i < attr->num_values; i ++)
     {
       if (attr->values[i].string.text)
         slen += strlen(attr->values[i].string.text) + 1;
@@ -1577,7 +1579,8 @@ ippCopyCredentialsString(
       // Allocate memory...
       if ((s = malloc(slen + 1)) != NULL)
       {
-	for (i = 0, ptr = s; i < attr->num_values; i ++)
+        ptr = s;
+        for (int i = 0; i < attr->num_values; i ++)
 	{
 	  if (attr->values[i].string.text)
 	  {
@@ -4986,7 +4989,6 @@ ipp_free_values(ipp_attribute_t *attr,	// I - Attribute to free values from
                 int             element,// I - First value to free
                 int             count)	// I - Number of values to free
 {
-  int		i;			// Looping var
   _ipp_value_t	*value;			// Current value
 
 
@@ -5015,7 +5017,8 @@ ipp_free_values(ipp_attribute_t *attr,	// I - Attribute to free values from
       case IPP_TAG_CHARSET :
       case IPP_TAG_LANGUAGE :
       case IPP_TAG_MIMETYPE :
-	  for (i = count, value = attr->values + element; i > 0; i --, value ++)
+        value = attr->values + element;
+        for (int i = count; i > 0; i --, value ++)
 	  {
 	    _cupsStrFree(value->string.text);
 	    value->string.text = NULL;
@@ -5038,7 +5041,8 @@ ipp_free_values(ipp_attribute_t *attr,	// I - Attribute to free values from
 	  break;
 
       case IPP_TAG_BEGIN_COLLECTION :
-	  for (i = count, value = attr->values + element; i > 0; i --, value ++)
+        value = attr->values + element;
+        for (int i = count; i > 0; i --, value ++)
 	  {
 	    ippDelete(value->collection);
 	    value->collection = NULL;
@@ -5047,7 +5051,8 @@ ipp_free_values(ipp_attribute_t *attr,	// I - Attribute to free values from
 
       case IPP_TAG_STRING :
       default :
-	  for (i = count, value = attr->values + element; i > 0; i --, value ++)
+        value = attr->values + element;
+        for (int i = count; i > 0; i --, value ++)
 	  {
 	    if (value->unknown.data)
 	    {

--- a/cups/jwt.c
+++ b/cups/jwt.c
@@ -1,7 +1,7 @@
 //
 // JSON Web Token API implementation for CUPS.
 //
-// Copyright © 2023-2024 by OpenPrinting.
+// Copyright © 2023-2025 by OpenPrinting.
 //
 // Licensed under Apache License v2.0.  See the file "LICENSE" for more
 // information.
@@ -1537,14 +1537,14 @@ cupsJWTSign(cups_jwt_t  *jwt,		// I - JWT object
 static cups_json_t *			// O - JSON array
 copy_x5c(cups_json_t *x5c)		// I - X.509 certificate chain
 {
-  size_t	i,			// Looping var
-		count;			// Count
   cups_json_t	*new_x5c;		// New JSON array
 
 
   if ((new_x5c = cupsJSONNew(/*parent*/NULL, /*after*/NULL, CUPS_JTYPE_ARRAY)) != NULL)
   {
-    for (i = 0, count = cupsJSONGetCount(x5c); i < count; i ++)
+    const size_t count = cupsJSONGetCount(x5c);
+
+    for (size_t i = 0; i < count; i ++)
       cupsJSONNewString(new_x5c, /*after*/NULL, cupsJSONGetString(cupsJSONGetChild(x5c, i)));
   }
 
@@ -1567,8 +1567,7 @@ find_key(cups_json_t *jwk,		// I - Key set
   if ((keys = cupsJSONFind(jwk, "keys")) != NULL)
   {
     // Full key set, find the key we need to use...
-    size_t	i,			// Looping var
-		count;			// Number of keys
+    size_t	count;			// Number of keys
     cups_json_t	*current;		// Current key
     const char	*curkid,		// Current key ID
 		*curkty;		// Current key type
@@ -1578,7 +1577,7 @@ find_key(cups_json_t *jwk,		// I - Key set
     if (kid)
     {
       // Find the matching key ID
-      for (i = 0; i < count; i ++)
+      for (size_t i = 0; i < count; i ++)
       {
         current = cupsJSONGetChild(keys, i);
         curkid  = cupsJSONGetString(cupsJSONFind(current, "kid"));
@@ -1594,7 +1593,7 @@ find_key(cups_json_t *jwk,		// I - Key set
     else
     {
       // Find a key that can be used for the specified algorithm
-      for (i = 0; i < count; i ++)
+      for (size_t i = 0; i < count; i ++)
       {
         current = cupsJSONGetChild(keys, i);
         curkty  = cupsJSONGetString(cupsJSONFind(current, "kty"));

--- a/cups/ppd-cache.c
+++ b/cups/ppd-cache.c
@@ -2170,9 +2170,6 @@ _ppdCacheGetBin(
     _ppd_cache_t *pc,			/* I - PPD cache and mapping data */
     const char   *output_bin)		/* I - PPD OutputBin string */
 {
-  int	i;				/* Looping var */
-
-
  /*
   * Range check input...
   */
@@ -2185,7 +2182,7 @@ _ppdCacheGetBin(
   */
 
 
-  for (i = 0; i < pc->num_bins; i ++)
+  for (int i = 0; i < pc->num_bins; i ++)
     if (!_cups_strcasecmp(output_bin, pc->bins[i].ppd) || !_cups_strcasecmp(output_bin, pc->bins[i].pwg))
       return (pc->bins[i].pwg);
 
@@ -2206,7 +2203,6 @@ _ppdCacheGetFinishingOptions(
     int              num_options,	/* I  - Number of options */
     cups_option_t    **options)		/* IO - Options */
 {
-  int			i;		/* Looping var */
   _pwg_finishings_t	*f,		/* PWG finishings options */
 			key;		/* Search key */
   ipp_attribute_t	*attr;		/* Finishings attribute */
@@ -2229,7 +2225,7 @@ _ppdCacheGetFinishingOptions(
   {
     int	num_values = ippGetCount(attr);	/* Number of values */
 
-    for (i = 0; i < num_values; i ++)
+    for (int i = 0; i < num_values; i ++)
     {
       key.value = (ipp_finishings_t)ippGetInteger(attr, i);
 

--- a/cups/ppd-util.c
+++ b/cups/ppd-util.c
@@ -544,7 +544,6 @@ cups_get_printer_uri(
     char       *resource,		/* I - Resource buffer */
     int        resourcesize)		/* I - Size of resource buffer */
 {
-  int		i;			/* Looping var */
   ipp_t		*request,		/* IPP request */
 		*response;		/* IPP response */
   ipp_attribute_t *attr;		/* Current attribute */
@@ -608,7 +607,7 @@ cups_get_printer_uri(
 
       DEBUG_printf("5cups_get_printer_uri: Got member-uris with %d values.", ippGetCount(attr));
 
-      for (i = 0; i < attr->num_values; i ++)
+      for (int i = 0; i < attr->num_values; i ++)
       {
         DEBUG_printf("5cups_get_printer_uri: member-uris[%d]=\"%s\"", i, ippGetString(attr, i, NULL));
 

--- a/tools/ippfind.c
+++ b/tools/ippfind.c
@@ -150,8 +150,7 @@ int					// O - Exit status
 main(int  argc,				// I - Number of command-line args
      char *argv[])			// I - Command-line arguments
 {
-  int			i,		// Looping var
-			have_output = 0,// Have output expression
+  int			have_output = 0,// Have output expression
 			status = IPPFIND_EXIT_FALSE;
 					// Exit status
   const char		*opt,		// Option character
@@ -208,11 +207,11 @@ main(int  argc,				// I - Number of command-line args
   // Parse command-line...
   if (getenv("IPPFIND_DEBUG"))
   {
-    for (i = 1; i < argc; i ++)
+    for (int i = 1; i < argc; i ++)
       fprintf(stderr, "argv[%d]=\"%s\"\n", i, argv[i]);
   }
 
-  for (i = 1; i < argc; i ++)
+  for (int i = 1; i < argc; i ++)
   {
     if (argv[i][0] == '-')
     {


### PR DESCRIPTION
Have variables more local.
Prevents accidential use of looping var after for loop.