### PR TITLE
Fix use-of-uninitialized-value in cups_array_find

### DIFF
--- a/cups/ipp.c
+++ b/cups/ipp.c
@@ -5370,7 +5370,7 @@ ipp_read_io(void        *src,		// I - Data source
 {
   int			n;		// Length of data
   unsigned char		*buffer,	// Data buffer
-			string[IPP_MAX_TEXT],
+			string[IPP_MAX_TEXT] = { 0 },
 					// Small string buffer
 			*bufptr,	// Pointer into buffer
 			*bufend;	// End of buffer


### PR DESCRIPTION
Fixes https://github.com/OpenPrinting/cups/issues/1239. After applying this patch, the error testcase does not trigger the MemorySanitizer crash anymore.

This patch was generated by CodeRover-S, an LLM agent for fixing security vulnerabilities. More details of the agent can be found in this [report](https://arxiv.org/pdf/2411.03346).