### PR TITLE
cups/globals: use getauxval(AT_SECURE) for SUID check

### DIFF
--- a/config-scripts/cups-common.m4
+++ b/config-scripts/cups-common.m4
@@ -132,6 +132,7 @@ dnl Checks for header files.
 AC_CHECK_HEADER([langinfo.h], AC_DEFINE([HAVE_LANGINFO_H], [1], [Have <langinfo.h> header?]))
 AC_CHECK_HEADER([malloc.h], AC_DEFINE([HAVE_MALLOC_H], [1], [Have <malloc.h> header?]))
 AC_CHECK_HEADER([stdint.h], AC_DEFINE([HAVE_STDINT_H], [1], [Have <stdint.h> header?]))
+AC_CHECK_HEADER([sys/auxv.h], AC_DEFINE([HAVE_SYS_AUXV_H], [1], [Have <sys/auxv.h> header?]))
 AC_CHECK_HEADER([sys/ioctl.h], AC_DEFINE([HAVE_SYS_IOCTL_H], [1], [Have <sys/ioctl.h> header?]))
 AC_CHECK_HEADER([sys/param.h], AC_DEFINE([HAVE_SYS_PARAM_H], [1], [Have <sys/param.h> header?]))
 AC_CHECK_HEADER([sys/ucred.h], AC_DEFINE([HAVE_SYS_UCRED_H], [1], [Have <sys/ucred.h> header?]))

--- a/config.h.in
+++ b/config.h.in
@@ -296,6 +296,13 @@
 
 
 /*
+ * Do we have <sys/auxv.h>?
+ */
+
+#undef HAVE_SYS_AUXV_H
+
+
+/*
  * Do we have <sys/ioctl.h>?
  */
 

--- a/cups/globals.c
+++ b/cups/globals.c
@@ -13,6 +13,9 @@
 #include "debug-internal.h"
 #ifndef _WIN32
 #  include <pwd.h>
+#  ifdef HAVE_SYS_AUXV_H
+#    include <sys/auxv.h> // for getauxval()
+#  endif
 #endif /* !_WIN32 */
 
 
@@ -294,7 +297,9 @@ cups_globals_alloc(void)
 		*xdg_config_home = getenv("XDG_CONFIG_HOME");
 					// Environment variables
 #  endif // !__APPLE__
-#  ifdef HAVE_GETEUID
+#  if defined(HAVE_SYS_AUXV_H) && defined(AT_SECURE)
+  if (getauxval(AT_SECURE))
+#  elif defined(HAVE_GETEUID)
   if ((geteuid() != getuid() && getuid()) || getegid() != getgid())
 #  else
   if (!getuid())


### PR DESCRIPTION
Comparing effective and real uid/gid is not a proper way to check for SUID execution:

1. this does not consider file capabilities

2. this check breaks when NO_NEW_PRIVS is used as the Linux kernel resets effective ids during execve(); this means the check is false, but the process still has raised capabilities

For more details about the NO_NEW_PRIVS problem, check this post and the surrounding thread:

 https://lore.kernel.org/lkml/20250509184105.840928-1-max.kellermann@ionos.com/