### PR TITLE
Pre-allocate form variables before resizing

### DIFF
--- a/cgi-bin/var.c
+++ b/cgi-bin/var.c
@@ -616,45 +616,41 @@ cgi_add_variable(const char *name,	/* I - Variable name */
                  const char *value)	/* I - Variable value */
 {
   _cgi_var_t	*var;			/* New variable */
-
+  
+  char **pre_alloc;
 
   if (name == NULL || value == NULL || element < 0 || element > 100000)
+    return;
+  
+  pre_alloc = calloc((size_t)element + 1, sizeof(char *));
+  
+  if (pre_alloc == NULL)
     return;
 
   if (form_count >= form_alloc)
   {
     _cgi_var_t	*temp_vars;		/* Temporary form pointer */
-
-
+    
     if (form_alloc == 0)
       temp_vars = malloc(sizeof(_cgi_var_t) * 16);
     else
       temp_vars = realloc(form_vars, (size_t)(form_alloc + 16) * sizeof(_cgi_var_t));
 
     if (!temp_vars)
-      return;
-
-    var = temp_vars + form_count;
-
-    if ((var->values = calloc((size_t)element + 1, sizeof(char *))) == NULL)
     {
-      /*
-       * Rollback changes
-       */
-
-      if (form_alloc == 0)
-        free(temp_vars);
+      free(pre_alloc);
       return;
     }
+
     form_vars = temp_vars;
     form_alloc += 16;
+    
+    var = temp_vars + form_count;
   }
   else
-  {
     var = form_vars + form_count;
-    if ((var->values = calloc((size_t)element + 1, sizeof(char *))) == NULL)
-      return;
-  }
+  
+  var->values = pre_alloc;
 
   var->name            = strdup(name);
   var->nvalues         = element + 1;


### PR DESCRIPTION
If the calloc fails, this is catastrophic. We cannot trust form_vars as the memory block could have changed entirely. Who knows what issues this can cause. This is undefined behavior.