### PR TITLE
Prevent malloc when newlength is 0

### DIFF
--- a/scheduler/job.c
+++ b/scheduler/job.c
@@ -3939,7 +3939,9 @@ get_options(cupsd_job_t *job,		/* I - Job */
 
   if (newlength > optlength || !options)
   {
-    if (!options)
+    if (newlength == 0)
+      optptr = NULL;
+    else if (!options)
       optptr = malloc(newlength);
     else
       optptr = realloc(options, newlength);


### PR DESCRIPTION
I do not know if this is even impossible but given how I think we should be aware, because options can be null. We should handle this case just in case.