### PR TITLE
Fix the media-default is displayed as 'unknown' when using a custom p…

### DIFF
--- a/scheduler/printers.c
+++ b/scheduler/printers.c
@@ -4296,8 +4296,15 @@ load_ppd(cupsd_printer_t *p)		/* I - Printer */
       * media-default
       */
 
-      if ((size = ppdPageSize(ppd, NULL)) != NULL)
-        pwgsize = _ppdCacheGetSize(p->pc, size->name);
+      if ((size = ppdPageSize(ppd, NULL)) != NULL) {
+        if ((pwgsize = _ppdCacheGetSize(p->pc, size->name)) == NULL) {
+         pwg_media_t *pwg_media;
+          if ((pwg_media = pwgMediaForSize(PWG_FROM_POINTS(size->width), PWG_FROM_POINTS(size->length))) != NULL) {
+            pwgsize = malloc(sizeof(pwg_size_t));
+            pwgsize->map.pwg =  pwg_media->pwg;
+          }
+        }
+      }
       else
         pwgsize = NULL;
 


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/302a0928-824a-4e7b-aa09-3ce000ba41c4)

my ppd file: [rolloX1.ppd.txt](https://github.com/user-attachments/files/20343325/rolloX1.ppd.txt)

Fix the media-default is displayed as 'unknown' when using a custom page size as the default value. (Issue OpenPrinting#1238)


