### PR TITLE
Fix the media-default is displayed as 'unknown' (Issue OpenPrinting#1238)

### DIFF
--- a/scheduler/printers.c
+++ b/scheduler/printers.c
@@ -4296,15 +4296,23 @@ load_ppd(cupsd_printer_t *p)		/* I - Printer */
       * media-default
       */
 
-      if ((size = ppdPageSize(ppd, NULL)) != NULL)
-        pwgsize = _ppdCacheGetSize(p->pc, size->name);
+      if ((size = ppdPageSize(ppd, NULL)) != NULL) {
+        if ((pwgsize = _ppdCacheGetSize(p->pc, size->name)) == NULL) {
+         pwg_media_t *pwg_media;
+          if ((pwg_media = pwgMediaForSize(PWG_FROM_POINTS(size->width), PWG_FROM_POINTS(size->length))) != NULL) {
+            pwgsize = malloc(sizeof(pwg_size_t));
+            pwgsize->map.pwg =  pwg_media->pwg;
+          }
+        }
+      }
       else
         pwgsize = NULL;
 
       ippAddString(p->ppd_attrs, IPP_TAG_PRINTER, IPP_TAG_KEYWORD,
 		   "media-default", NULL,
 		   pwgsize ? pwgsize->map.pwg : "unknown");
-
+      if (pwgsize)
+        free(pwgsize);
      /*
       * media-col-default
       */


### PR DESCRIPTION
  It is displayed as 'unknown' when using a custom page size as the default value.