### PR TITLE
Fix NULL pointer dereference if ErrorLog uses '%s' (Issue 1277)

### DIFF
--- a/scheduler/conf.c
+++ b/scheduler/conf.c
@@ -984,6 +984,19 @@ cupsdReadConfiguration(void)
     }
   }
 
+  /*
+   * ServerName was updated.
+   * It is used to substitute '%s' in ErrorLog - see cups-files.conf(5)
+   * It is possible that ErrorFile points to e.g.
+   * /var/log/cups/localhost-error_log instead of /var/log/cups/<ServerName>-error_log
+   * We need to close and later re-open ErrorFile.
+   */
+  if (ErrorFile != NULL) {
+    if (ErrorFile != LogStderr)
+      cupsFileClose(ErrorFile);
+    ErrorFile = NULL;
+  }
+
   for (slash = ServerName; isdigit(*slash & 255) || *slash == '.'; slash ++);
 
   ServerNameIsIP = !*slash;

--- a/scheduler/log.c
+++ b/scheduler/log.c
@@ -165,9 +165,10 @@ cupsdCheckLogFile(cups_file_t **lf,	/* IO - Log file */
 	{
 	 /*
 	  * Insert the server name...
+	  * If it is NULL use "localhost" to avoid core dump.
 	  */
 
-	  cupsCopyString(ptr, ServerName, sizeof(filename) - (size_t)(ptr - filename));
+	  cupsCopyString(ptr, ServerName == 0 ? "localhost" : ServerName, sizeof(filename) - (size_t)(ptr - filename));
 	  ptr += strlen(ptr);
 	}
         else


### PR DESCRIPTION
Bug: https://github.com/OpenPrinting/cups/issues/1277