### PR TITLE
ppd-cache: fix memory leak

### DIFF
--- a/cups/ppd-cache.c
+++ b/cups/ppd-cache.c
@@ -2152,6 +2152,11 @@ _ppdCacheDestroy(_ppd_cache_t *pc)	/* I - PPD cache and mapping data */
   free(pc->charge_info_uri);
   free(pc->password);
 
+  free(pc->sides_option);
+  free(pc->sides_1sided);
+  free(pc->sides_2sided_long);
+  free(pc->sides_2sided_short);
+
   cupsArrayDelete(pc->mandatory);
 
   cupsArrayDelete(pc->support_files);


### PR DESCRIPTION
These fields were being allocated by _ppdCacheCreateWith*() but never freed by anything. Free them in _ppdCacheDestroy() to fix the leak.

Based on commit 7e4b961850b66baf895fc0 in libppd.