### PR TITLE
ipp.c: fix unreachable else-if block in main()

### DIFF
--- a/backend/ipp.c
+++ b/backend/ipp.c
@@ -2116,24 +2116,24 @@ main(int  argc,				/* I - Number of command-line args */
 	password_tries = 0;
       else
       {
-	if (ipp_status != IPP_STATUS_ERROR_SERVICE_UNAVAILABLE &&
-	    ipp_status != IPP_STATUS_ERROR_BUSY)
-	{
-	  ippDelete(response);
+        if (ipp_status == IPP_STATUS_ERROR_INTERNAL)
+        {
+          waitjob_tries ++;
+
+          if (waitjob_tries > 4)
+          {
+            ippDelete(response);
+            ipp_status = IPP_STATUS_OK;
+            break;
+          }
+        }
+        else if (ipp_status != IPP_STATUS_ERROR_SERVICE_UNAVAILABLE &&
+            ipp_status != IPP_STATUS_ERROR_BUSY)
+        {
+          ippDelete(response);
           ipp_status = IPP_STATUS_OK;
           break;
-	}
-	else if (ipp_status == IPP_STATUS_ERROR_INTERNAL)
-	{
-	  waitjob_tries ++;
-
-	  if (waitjob_tries > 4)
-	  {
-	    ippDelete(response);
-	    ipp_status = IPP_STATUS_OK;
-	    break;
-	  }
-	}
+        }
       }
 
       if (response)


### PR DESCRIPTION
Incorrect if-else structure leads to unreachable code.

When the value of `ipp_status` is equal to `IPP_STATUS_ERROR_INTERNAL` the variable `waitjob_tries` is incremented and `ippDelete()` function will be called depending on its value.

In current backend/ipp.c if `ipp_status` is equal to `IPP_STATUS_ERROR_INTERNAL` it falls into `if` block, because it's not equal to `IPP_STATUS_ERROR_SERVICE_UNAVAILABLE` and `IPP_STATUS_ERROR_BUSY`. So `else if` block with `waitjob_tries` is always unreachable and the function is called unconditionally.

Swap the conditions to correct handling of `IPP_STATUS_ERROR_INTERNAL` status.