### PR TITLE
ppd-cache: fix memory leak in `_cupsConvertOptions()`

### DIFF
--- a/cups/ppd-cache.c
+++ b/cups/ppd-cache.c
@@ -228,6 +228,7 @@ _cupsConvertOptions(
                     "y-dimension", size->length);
 
       ippAddCollection(media_col, IPP_TAG_ZERO, "media-size", media_size);
+      ippDelete(media_size);
     }
 
     for (i = 0; i < media_col_sup->num_values; i ++)
@@ -247,6 +248,7 @@ _cupsConvertOptions(
     }
 
     ippAddCollection(request, IPP_TAG_JOB, "media-col", media_col);
+    ippDelete(media_col);
   }
 
   if ((keyword = cupsGetOption("output-bin", num_options, options)) == NULL)


### PR DESCRIPTION
`ippAddCollection()` is usually used in combination with `ippDelete()`. Otherwise, as I understand it, this object won't be finally deleted when calling `ippDelete(request)`.

Also if a potential memory allocation error occurs, the object won't be added to the `request` due to the `NULL` value returned from `ipp_add_attr() -> calloc()`, so it'll be freed here with `ippDelete()`.