### PR TITLE
ppd-mark: try to map PageSize to PPD if media is missing. Fixes #1375

### DIFF
--- a/cups/ppd-mark.c
+++ b/cups/ppd-mark.c
@@ -55,6 +55,7 @@ cupsMarkOptions(
 		s[255];			/* Temporary string */
   const char	*val,			/* Pointer into value */
 		*media,			/* media option */
+		*page_size,		/* PageSize option */
 		*output_bin,		/* output-bin option */
 		*ppd_keyword,		/* PPD keyword */
 		*print_color_mode,	/* print-color-mode option */
@@ -80,6 +81,7 @@ cupsMarkOptions(
   */
 
   media         = cupsGetOption("media", num_options, options);
+  page_size     = cupsGetOption("PageSize", num_options, options);
   output_bin    = cupsGetOption("output-bin", num_options, options);
   print_quality = cupsGetOption("print-quality", num_options, options);
   sides         = cupsGetOption("sides", num_options, options);
@@ -88,7 +90,7 @@ cupsMarkOptions(
                                         options)) == NULL)
     print_color_mode = cupsGetOption("output-mode", num_options, options);
 
-  if ((media || output_bin || print_color_mode || print_quality || sides) &&
+  if ((media || page_size || output_bin || print_color_mode || print_quality || sides) &&
       !ppd->cache)
   {
    /*
@@ -99,6 +101,19 @@ cupsMarkOptions(
   }
 
   cache = ppd->cache;
+
+  if (page_size && *page_size && !ppdPageSize(ppd, page_size))
+  {
+   /*
+    * If PageSize value is missing from the PPD, assume PPD uses non-Adobe
+    * names and try to load the mapping from cache.
+    *
+    * Media has higher priority and may redefine PageSize later.
+    */
+
+    if ((ppd_keyword = _ppdCacheGetPageSize(cache, NULL, page_size, NULL)) != NULL)
+      ppd_mark_option(ppd, "PageSize", ppd_keyword);
+  }
 
   if (media)
   {


### PR DESCRIPTION
When CUPS prints to another CUPS over IPP, it uses PageSize instead of media or media-col, as it is assumed that PPD files (or at least the attribute values) are synced on both sides.

However this is not the case with ippeve or drvless auto-generated PPDs, where only Adobe names are used for page sizes instead of the values on the remote side, which makes page selection inconsistent.

Try to map Adobe names to PPD names on the server side, if only PageSize is provided in IPP request.