### PR TITLE
Add custom DefaultPageSize to the IPP media attributes

### DIFF
--- a/scheduler/printers.c
+++ b/scheduler/printers.c
@@ -4661,6 +4661,21 @@ load_ppd(cupsd_printer_t *p)		/* I - Printer */
 
 	ippDelete(col);
       }
+
+      // Add custom media-default into media-ready
+      if (defaultpagesize_is_custom)
+      {
+	if (media_ready)
+	  ippSetString(p->ppd_attrs, &media_ready, ippGetCount(media_ready), default_pwgsize->map.pwg);
+	if (media_col_ready)
+	{
+	  ipp_t	*col;
+	  col = new_media_col(default_pwgsize);
+	  ippSetCollection(p->ppd_attrs, &media_col_ready, ippGetCount(media_col_ready), col);
+	  ippDelete(col);
+	}
+      }
+
     }
 
     ippAddString(p->ppd_attrs, IPP_TAG_PRINTER, IPP_CONST_TAG(IPP_TAG_TEXT), "mopria-certified", NULL, "1.3");


### PR DESCRIPTION
`CustomPageSize` PPD option allows to define custom page size in the web interface. However, this only sets `DefaultPageSize` to `Custom.XXxXXmm` value, but does not add `PageSize`/`PageRegion`/`ImageableArea` to the PPD.
    
Custom `DefaultPageSize` results in proper `media-default` reporting over IPP, but this custom page is missing in `media-supported`, `media-size-supported`, `media-col-database`.
    
Detect custom `DefaultPageSize` and propagate it into IPP attributes.

The second patch does the same for `media-ready` attribute in addition.

Issue: #1388