### PR TITLE
Feature: Add debug message for ServerAlias directive

### DIFF
--- a/scheduler/conf.c
+++ b/scheduler/conf.c
@@ -3525,6 +3525,7 @@ read_cupsd_conf(cups_file_t *fp)	/* I - File to read from */
     }
 
 	cupsdAddAlias(ServerAlias, value);
+  cupsdLogMessage(CUPSD_LOG_DEBUG, "Added ServerAlias %s", value);
 
         for (value += valuelen; *value; value ++)
 	  if (!_cups_isspace(*value) || *value != ',')


### PR DESCRIPTION
Fixes #1390 

This PR adds a debug log message to the scheduler to confirm when a `ServerAlias` directive is successfully loaded from the `cupsd.conf` file.