### PR TITLE
Initialize character arrays in ipptool.c

### DIFF
--- a/tools/ipptool.c
+++ b/tools/ipptool.c
@@ -3007,9 +3007,9 @@ parse_generate_file(
 			*response = NULL;// Get-Printer-Attributes response
   ipp_attribute_t	*attr;		// Current attribute
   const char		*keyword;	// Keyword value
-  char			token[256],	// Token string
-			temp[1024],	// Temporary string
-			value[1024],	// Value string
+  char			token[256] = "",	// Token string
+			temp[1024] = "",	// Temporary string
+			value[1024] = "",	// Value string
 			*ptr;		// Pointer into value
   static const char *autos[][2] =	// Automatic color/monochrome keywords
   {


### PR DESCRIPTION
Initialize token, temp, and value strings to empty.

==693==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x564634708d9e in token_cb /root/BUILD/cups-2.3.3op2/tools/ipptool.c:3330:2
    #1 0x7feb132dac54 in _ippFileParse /root/BUILD/cups-2.3.3op2/cups/ipp-file.c:184:12
    #2 0x564634709456 in do_tests /root/BUILD/cups-2.3.3op2/tools/ipptool.c:1920:3
    #3 0x56463470062e in main /root/BUILD/cups-2.3.3op2/tools/ipptool.c:671:12
    #4 0x7feb12f615cf in __libc_start_call_main (/lib64/libc.so.6+0x295cf) (BuildId: 38347dcfe861b665e08e8b1263215f626f4e003c)
    #5 0x7feb12f6167f in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x2967f) (BuildId: 38347dcfe861b665e08e8b1263215f626f4e003c)
    #6 0x564634664a34 in _start (/root/BUILD/cups-2.3.3op2/tools/ipptool+0x34a34) (BuildId: d57559e910bfffb79c75b95ff66855e9486eee5a)

SUMMARY: MemorySanitizer: use-of-uninitialized-value /root/BUILD/cups-2.3.3op2/tools/ipptool.c:3330:2 in token_cb Exiting