### PR TITLE
Initialization of new option array elements

### DIFF
--- a/cups/options.c
+++ b/cups/options.c
@@ -103,11 +103,19 @@ cupsAddOption(const char    *name,	/* I  - Name of option */
 
     DEBUG_printf("4cupsAddOption: New option inserted at index %d...", insert);
 
-    if (num_options == 0)
-      temp = (cups_option_t *)malloc(sizeof(cups_option_t));
+	if (num_options == 0)
+    {
+      temp = (cups_option_t *)calloc(1, sizeof(cups_option_t));
+    }
     else
+    {
       temp = (cups_option_t *)realloc(*options, sizeof(cups_option_t) * (size_t)(num_options + 1));
-
+      if (temp)
+      {
+        memset(&temp[num_options], 0, sizeof(cups_option_t));
+      }
+    }
+    
     if (!temp)
     {
       DEBUG_puts("3cupsAddOption: Unable to expand option array, returning 0");


### PR DESCRIPTION
When a new element of the options array is created, all fields of the cups_option_t structure (including value) are now initialized to zero. This ensures that when cups_compare_options is called to compare options, the structure contains no uninitialized bytes. MemorySanitizer will no longer report use-of-uninitialized-memory from this code path.


==661962==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x7f43488185f5 in cups_compare_options /home/tsudik/cups/test/cups/cups/cups/options.c:602:11
    #1 0x7f43488185f5 in cups_find_option /home/tsudik/cups/test/cups/cups/cups/options.c:642:17
    #2 0x7f4348818063 in cupsAddOption /home/tsudik/cups/test/cups/cups/cups/options.c:91:14
    #3 0x7f4348817de4 in cupsAddIntegerOption /home/tsudik/cups/test/cups/cups/cups/options.c:45:11
    #4 0x7f43487fc551 in ippFileSetVar /home/tsudik/cups/test/cups/cups/cups/ipp-file.c:1136:24
    #5 0x55fc5d3541ce in main /home/tsudik/cups/test/cups/cups/tools/ipptool.c:722:12
    #6 0x7f43484295cf in __libc_start_call_main (/lib64/libc.so.6+0x295cf) (BuildId: 38347dcfe861b665e08e8b1263215f626f4e003c)
    #7 0x7f434842967f in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x2967f) (BuildId: 38347dcfe861b665e08e8b1263215f626f4e003c)
    #8 0x55fc5d2b8bf4 in _start (/home/tsudik/cups/test/cups/cups/tools/ipptool+0x35bf4) (BuildId: 26bc6973ea67a83c8bb92151510715af79bc7b29)

SUMMARY: MemorySanitizer: use-of-uninitialized-value /home/tsudik/cups/test/cups/cups/cups/options.c:602:11 in cups_compare_options Exiting