### PR TITLE
usb-quirks: disable soft-reset for Samsung M337x 387x 407x Series

### DIFF
--- a/backend/org.cups.usb-quirks
+++ b/backend/org.cups.usb-quirks
@@ -197,6 +197,9 @@
 # Samsung SCX-3405W works without quirks (https://github.com/OpenPrinting/cups/issues/270)
 0x04e8 0x344f whitelist
 
+# Samsung M337x 387x 407x Series works without quirks
+0x04e8 0x3460 whitelist
+
 # Samsung ML-2160 Series (https://bugzilla.redhat.com/show_bug.cgi?id=873123)
 0x04e8 0x330f unidir
 


### PR DESCRIPTION
04e8:3460 Samsung Electronics Co., Ltd M337x 387x 407x Series

I noticed that after first page is printed in CUPS scanner stops responding