### PR TITLE
Fix src shift in ipp-file.c

### DIFF
--- a/cups/ipp-file.c
+++ b/cups/ipp-file.c
@@ -199,10 +199,11 @@ ippFileExpandVars(ipp_file_t *file,	// I - IPP data file
 
 	  if (*tempptr)
 	    *tempptr = '\0';
+
+	  src   += tempptr - temp + 1;
         }
 
         value = ippFileGetVar(file, temp);
-        src   += tempptr - temp + 1;
       }
 
       if (value)


### PR DESCRIPTION
Each case (`$$`, `$ENV[`, `${`, and plain `$`) is supposed to shift `src` after parsing. But the block responsible for the `$` case lacks this shift--it is located out of that block. So for the `${` case `src` is shifted twice: by `src += 2` and by `src += tempptr - temp + 1`, which results in `while (*src)` reading beyond the NUL-terminator.

run command:

```
LD_LIBRARY_PATH=./cups ./tools/ipptool -t ipp://localhost:631/printers/TestPrinter test_file
```

test_file:

```
{
 ATTR charset attcharset 
" 
${
```


MSAN:
```
==181511==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x7f28ca786892 in ippFileExpandVars /home/tsudik/cups/test/cups/cups/cups/ipp-file.c:150:3
    #1 0x7f28ca78969b in parse_value /home/tsudik/cups/test/cups/cups/cups/ipp-file.c:1632:3
    #2 0x7f28ca787b9f in ippFileRead /home/tsudik/cups/test/cups/cups/cups/ipp-file.c:548:14
    #3 0x56169af31892 in do_tests /home/tsudik/cups/test/cups/cups/tools/ipptool.c:2522:3
    #4 0x56169af2f644 in main /home/tsudik/cups/test/cups/cups/tools/ipptool.c:765:17
    #5 0x7f28ca2295cf in __libc_start_call_main (/lib64/libc.so.6+0x295cf) (BuildId: 38347dcfe861b665e08e8b1263215f626f4e003c)
    #6 0x7f28ca22967f in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x2967f) (BuildId: 38347dcfe861b665e08e8b1263215f626f4e003c)
    #7 0x56169ae93bf4 in _start (/home/tsudik/cups/test/cups/cups/tools/ipptool+0x35bf4) (BuildId: 84b1db2e275d63ce60e3bfc8c2b9b5c762ca0b14)

  Uninitialized value was created by an allocation of 'temp' in the stack frame
    #0 0x7f28ca7895a2 in parse_value /home/tsudik/cups/test/cups/cups/cups/ipp-file.c:1617:3

SUMMARY: MemorySanitizer: use-of-uninitialized-value /home/tsudik/cups/test/cups/cups/cups/ipp-file.c:150:3 in ippFileExpandVars
Exiting
```
