### PR TITLE
http.c: Fix infinite loop in GTK apps

### DIFF
--- a/cups/http.c
+++ b/cups/http.c
@@ -2909,7 +2909,7 @@ _httpUpdate(http_t        *http,	// I - HTTP connection
     // See whether our read buffer is full...
     DEBUG_printf("2_httpUpdate: used=%d", http->used);
 
-    if (http->used > 0 && !memchr(http->buffer, '\n', (size_t)http->used) && (size_t)http->used < sizeof(http->buffer))
+    if ((size_t)http->used < sizeof(http->buffer))
     {
       // No, try filling in more data...
       if ((bytes = http_read(http, http->buffer + http->used, sizeof(http->buffer) - (size_t)http->used, /*timeout*/0)) > 0)


### PR DESCRIPTION
GTK has a specific IPP processing which stopped working after fix for CVE-2025-58436. GTK depended on internal behavior of `_httpUpdate()` which read a line from connection regardless of already buffered data.

To mitigate CVE-2025-58436 `_httpUpdate()` started to read another data from connection only if there is already a line buffered in internal HTTP structure in order to prevent being stuck on slow clients - the function now returns HTTP_STATUS_CONTINUE in such cases.

The fix which fixes GTK behavior here, which caused the GTK print dialogs not being opened at all, is to read from the connection if we have a signal there are data to read, and only if there is no newline after this data read, return error/continue to client.

Fixes #1429