### PR TITLE
adminutil.c: Recognize other policy scopes than default

### DIFF
--- a/cups/adminutil.c
+++ b/cups/adminutil.c
@@ -270,7 +270,7 @@ cupsAdminGetServerSettings(
       {
 	debug_logging = !_cups_strncasecmp(value, "debug", 5);
       }
-      else if (!_cups_strcasecmp(line, "<Policy") && value && !_cups_strcasecmp(value, "default"))
+      else if (!_cups_strcasecmp(line, "<Policy") && value)
       {
 	in_policy = 1;
       }


### PR DESCRIPTION
The function `cupsAdminGetServerSettings()` did not take different policies as policy, which resulted into adding their contents into output array `settings`.

If the caller uses the same array for `cupsAdminSetServerSettings()`, there is possibility to add such directives at the end of configuration file if a different tool removes those directives from the original file.

Possibly reason for dangling JobPrivate*, SubscriptionPrivate* directives outside of policy scope...