### PR TITLE
scheduler: Fix possible use_after_free in `cupsdReadClient()`

### DIFF
--- a/scheduler/client.c
+++ b/scheduler/client.c
@@ -2761,10 +2761,7 @@ check_start_tls(cupsd_client_t *con)	/* I - Client connection */
     httpSetField(con->http, HTTP_FIELD_CONTENT_LENGTH, "0");
 
     if (!cupsdSendHeader(con, HTTP_STATUS_OK, NULL, CUPSD_AUTH_NONE))
-    {
-      cupsdCloseClient(con);
       return (-1);
-    }
   }
 
   return (1);


### PR DESCRIPTION
If `cupsdSendHeader()` fails, we free the connection and return -1, but in that case we try to free the connection again in `cupsdReadClient()`.