### PR TITLE
ipp.c: Add workaround for bad IPP Everywhere attribute on Canon printers (OpenPrinting/cups-filters#635)

### DIFF
--- a/cups/ipp.c
+++ b/cups/ipp.c
@@ -4066,8 +4066,8 @@ ippValidateAttribute(
 			 "x(-[a-z0-9]{1,8})+"			// privateuse
 			 "|"
 			 "[a-z]{1,3}(-[a-z][0-9]{2,8}){1,2}"	// grandfathered
-             "|"
-             "(en-  )" // Special case for "en-  " (hack for Canon printers)
+			 "|"
+			 "([a-z]{2,3}-  )" // Special case for "en-  " (hack for Canon printers)
 			 ")$",
 			 REG_NOSUB | REG_EXTENDED)) != 0)
         {


### PR DESCRIPTION
Some Canon printers have a firmware bug that sets the IPP Everywhere `naturalLanguage` attribute to `en-  ` (language code like "en", a dash, and two spaces) with certain locales.

This change loosens the RFC5646 regex check a little bit. As far as I can tell, the `naturalLanguage` attribute isn't actually used for anything within CUPS anyway (just forwarded back with responses).

With the change, `ipptool -Itv ipp://192.168.1.2:631/ipp/print get-printer-attributes.test` works, and I'm able to add my Canon printer as an IPP Everywhere device and print with it.

This isn't a CUPS issue, but Canon has so far not responded to my communications about the bug. Setting the printer locale to certain regions with valid language tags _can_ fix the problem. Patching CUPS could save some time and Googling for affected people in the future, but I completely understand if the maintainers would rather not hack around Canon's problem :)