### PR TITLE
Remove the underscore from printer name if it is the last and not the only character

### DIFF
--- a/cgi-bin/admin.c
+++ b/cgi-bin/admin.c
@@ -2080,6 +2080,10 @@ do_list_printers(http_t *http)		/* I - HTTP connection */
 	      else if (*ptr == '?' || *ptr == '(')
 	        break;
 
+            // Remove the underscore if it is the last and not the only character
+            if (option_ptr > (option + 1) && option_ptr[-1] == '_')
+              option_ptr--;
+
             *option_ptr = '\0';
 
             cgiSetArray("TEMPLATE_NAME", i, option);


### PR DESCRIPTION
If the backend reports the device name “Canon LBP3200 (captusb)”, the parentheses and their contents are removed, leaving a space at the end, which is replaced with an underscore, resulting in “Canon_LBP3200_”.
This underscore at the end is extremely annoying.

Similar code in cups/dest.c: https://github.com/OpenPrinting/cups/blob/2f6411e489b58c57036e294c15bae1230843980e/cups/dest.c#L3971-L3977

You can test this patch using a dummy backend:
```sh
#!/bin/sh
echo 'direct test://test1 "Canon LBP3200" "Canon LBP3200 (captusb)" "MFG:Canon;MDL:LBP3200;CMD:CAPT;VER:1.0;CLS:PRINTER;DES:Canon LBP3200" ""'
echo 'direct test://test2 "Canon LBP3200" "_" "MFG:Canon;MDL:LBP3200;CMD:CAPT;VER:1.0;CLS:PRINTER;DES:Canon LBP3200" ""'
```

Ref https://github.com/darkvision77/captppd/pull/4#issuecomment-3694959450