### PR TITLE
libusb backend: attempt to fix DRAIN_OUTPUT race condition. Fixes #1461

### DIFF
--- a/backend/usb-libusb.c
+++ b/backend/usb-libusb.c
@@ -447,8 +447,8 @@ print_device(const char *uri,		/* I - Device URI */
       if (g.drain_output && !nfds && !g.print_bytes)
       {
 	/* Send a response... */
-	cupsSideChannelWrite(CUPS_SC_CMD_DRAIN_OUTPUT, CUPS_SC_STATUS_OK, NULL, 0, 1.0);
 	g.drain_output = 0;
+	cupsSideChannelWrite(CUPS_SC_CMD_DRAIN_OUTPUT, CUPS_SC_STATUS_OK, NULL, 0, 1.0);
       }
 
      /*


### PR DESCRIPTION
CUPS_SC_CMD_DRAIN_OUTPUT sidechannel command is supposed to ensure that all the data sent by the filter would be consumed by the backend and sent to the printer via USB before it returns.

However, if backend's main thread read and processed filter's data before filter managed to send CUPS_SC_CMD_DRAIN_OUTPUT, the filter will be blocked for 1 second, as backend will be blocked in select() waiting for new data (while filter is waiting for DRAIN_OUTPUT response and does not send anything).

~~This is a hacky attempt to fix this issue. However, it's not without flaw:~~
~~* If backend's main thread is slow and sidechannel thread is fast, the response to CUPS_SC_CMD_DRAIN_OUTPUT may be sent without actually draining (and even reading) the data.~~
~~* This means that's a tradeoff towards potentially breaking framing of some USB protocols to prevent 1-second locking (and breaking printing for timing-sensitive protocols).~~

A pipe is used to wake up main thread from select().