### PR TITLE
tls-gnutls.c: Do not check for errno after I/O operations

### DIFF
--- a/cups/tls-gnutls.c
+++ b/cups/tls-gnutls.c
@@ -1613,7 +1613,7 @@ _httpTLSRead(http_t *http,		// I - Connection to server
 
   result = gnutls_record_recv(http->tls, buf, (size_t)len);
 
-  if (result < 0 && !errno)
+  if (result < 0)
   {
     // Convert GNU TLS error to errno value...
     switch (result)
@@ -2022,7 +2022,7 @@ _httpTLSWrite(http_t     *http,		// I - Connection to server
 
   result = gnutls_record_send(http->tls, buf, (size_t)len);
 
-  if (result < 0 && !errno)
+  if (result < 0)
   {
     // Convert GNU TLS error to errno value...
     switch (result)


### PR DESCRIPTION
Based on gnutls_record_send/recv man pages, we should use the return value of the functions as indicator what happened in the function and do not look into errno at all.

Checking the errno value caused infinity loop in cupsd on busy servers if there were enough connection errors when cupsd wrote the response.

The patch is provided by Paul Zirnik from SUSE - thank you for the patch!

Fixes #827