### PR TITLE
tls-gnutls.c: Handle rehandshake error in `_httpTLSRead`

### DIFF
--- a/cups/tls-gnutls.c
+++ b/cups/tls-gnutls.c
@@ -1623,12 +1623,25 @@ _httpTLSRead(http_t *http,		// I - Connection to server
 	  break;
 
       case GNUTLS_E_AGAIN :
-          errno = EAGAIN;
-          break;
+	  errno = EAGAIN;
+	  break;
+
+      case GNUTLS_E_REHANDSHAKE :
+	  // If used in client, ignore the error and try to read again...
+	  if (http->mode == _HTTP_MODE_CLIENT)
+	  {
+	    errno = EAGAIN;
+	  }
+	  else
+	  {
+	    // Terminate the session as server...
+	    errno = EPIPE;
+	  }
+	  break;
 
       default :
-          errno = EPIPE;
-          break;
+	  errno = EPIPE;
+	  break;
     }
 
     result = -1;
@@ -2032,12 +2045,12 @@ _httpTLSWrite(http_t     *http,		// I - Connection to server
 	  break;
 
       case GNUTLS_E_AGAIN :
-          errno = EAGAIN;
-          break;
+	  errno = EAGAIN;
+	  break;
 
       default :
-          errno = EPIPE;
-          break;
+	  errno = EPIPE;
+	  break;
     }
 
     result = -1;


### PR DESCRIPTION
(follows #1507 )

During the review of #1507 I was told there is gnutls error which would be great to handle it separately - GNUTLS_E_REHANDSHAKE - when receiving data.

There are several ways how to handle this based on which side the HTTP library is used on:

```
In case of a client, this message may be simply ignored, replied with an alert GNUTLS_A_NO_RENEGOTIATION , or replied with a new handshake, depending on the client’s will. A server receiving this error code can only initiate a new handshake or terminate the session. 
```

The MR ignores the error on client side and terminates connection on server side.