### PR TITLE
backend/ipp: Fix report_attr() to handle localized and octetString IPP tags

### DIFF
--- a/backend/ipp.c
+++ b/backend/ipp.c
@@ -3149,7 +3149,6 @@ report_attr(ipp_attribute_t *attr)	/* I - Attribute */
       case IPP_TAG_NAME :
       case IPP_TAG_NAMELANG :
       case IPP_TAG_KEYWORD :
-      case IPP_TAG_STRING :
           quote_string(attr->values[i].string.text, valptr, (size_t)(value + sizeof(value) - valptr));
           valptr += strlen(valptr);
           break;


### PR DESCRIPTION
I've started using the the IPP Everywhere driver with my Brother MFC-L3750CDW, as I had problems using the proprietary driver on Nixos. And while IPP Everywhere resolves that problem and works great for printing, I found that it doesn't provide the toner status.

`lpstat` showed no toner levels even though `ipptool` showed the data was there. I have programming experience, but I am not a versed C guy, so I used the help of an LLM to trace the code path and identify the problem. Not sure if this is accepted.

The error description and fix according to the LLM:
### What's happening
`ippFindAttribute()` correctly matches localized types to their base
types (e.g., `NAMELANG` → `NAME`) in `cups/ipp.c`. But `report_attr()`
switches on `attr->value_tag` (the actual tag, e.g., `NAMELANG`), and
its switch only covers `INTEGER`, `TEXT`, `NAME`, and `KEYWORD`. The
unhandled tag falls through to `default: return;`, silently dropping
the data.

### Fix
Add `IPP_TAG_TEXTLANG`, `IPP_TAG_NAMELANG`, and `IPP_TAG_STRING` as
fall-through cases. They use the same `string.text` union member, so
no additional logic is needed.


I've tested the patch locally with my Brother MCF-L3750CDW with IPP Everywhere.
After applying the patch the toner levels are correctly reported in `lpstat` and (in my case) the KDE printer settings. 
