### PR TITLE
scheduler: Sanitize values for FilterNice directive

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -161,9 +161,10 @@ v2.5b1 - YYYY-MM-DD
   (Issue #1201)
 - Fixed job cleanup after daemon restart (Issue #1315)
 - Fixed unreachable block in IPP backend (Issue #1351)
-- Fixed memory leak in _cupsConvertOptions (Issue #1354)
+- Fixed memory leak in `_cupsConvertOptions()` (Issue #1354)
 - Fixed missing write check in `cupsFileOpen/Fd` (Issue #1360)
 - Fixed error recovery when scanning for PPDs in `cups-driverd` (Issue #1416)
+- Fixed allowed values for directive `FilterNice`
 - Removed hash support for SHA2-512-224 and SHA2-512-256.
 - Removed `mantohtml` script for generating html pages (use
   `https://www.msweet.org/mantohtml/`)

--- a/scheduler/conf.c
+++ b/scheduler/conf.c
@@ -81,7 +81,6 @@ static const cupsd_var_t	cupsd_vars[] =
   { "DNSSDHostName",		&DNSSDHostName,		CUPSD_VARTYPE_STRING },
   { "ErrorPolicy",		&ErrorPolicy,		CUPSD_VARTYPE_STRING },
   { "FilterLimit",		&FilterLimit,		CUPSD_VARTYPE_INTEGER },
-  { "FilterNice",		&FilterNice,		CUPSD_VARTYPE_INTEGER },
 #ifdef HAVE_GSSAPI
   { "GSSServiceName",		&GSSServiceName,	CUPSD_VARTYPE_STRING },
 #endif /* HAVE_GSSAPI */
@@ -3488,6 +3487,28 @@ read_cupsd_conf(cups_file_t *fp)	/* I - File to read from */
 	  if (!_cups_isspace(*value) || *value != ',')
 	    break;
       }
+    }
+    else if (!_cups_strcasecmp(line, "FilterNice") && value)
+    {
+      /*
+       * FilterNice [0-19]
+       */
+
+      char *end; /* Remaining string if any*/
+
+      long n = strtol(value, &end, 10);
+
+      if ((end && *end) || n < 0 || n > 19)
+      {
+        cupsdLogMessage(CUPSD_LOG_WARN, "The directive FilterNice accepts values 0 to 19.");
+
+	if (FatalErrors & CUPSD_FATAL_CONFIG)
+	  return (0);
+        else
+          continue;
+      }
+
+      FilterNice = n;
     }
     else if (!_cups_strcasecmp(line, "AccessLog") ||
              !_cups_strcasecmp(line, "CacheDir") ||


### PR DESCRIPTION
We allow only values 0-19 for `nice()` in cupsd, but when reading the configuration this fact was not applied.