### PR TITLE
scheduler: Raise auth failure log level from DEBUG to WARN for fail2ban compatibility

### DIFF
--- a/scheduler/auth.c
+++ b/scheduler/auth.c
@@ -686,9 +686,7 @@ cupsdAuthorize(cupsd_client_t *con)	/* I - Client connection */
       pamerr = pam_authenticate(pamh, PAM_SILENT);
       if (pamerr != PAM_SUCCESS)
       {
-	cupsdLogClient(con, CUPSD_LOG_ERROR, "pam_authenticate() returned %d (%s)", pamerr, pam_strerror(pamh, pamerr));
-  cupsdLogClient(con, CUPSD_LOG_WARN, "Authentication failed for user \"%s\" from %s", username, con->http->hostname);
-	pam_end(pamh, 0);
+  cupsdLogClient(con, CUPSD_LOG_ERROR, "Authentication failed for user \"%s\" from %s (%s)", username, con->http->hostname, pam_strerror(pamh, pamerr));	
 	return;
       }
 
@@ -2082,7 +2080,7 @@ cupsdIsAuthorized(cupsd_client_t *con,	/* I - Connection */
   * The user isn't part of the specified users or groups, so deny access...
   */
 
-  cupsdLogMessage(CUPSD_LOG_WARN, "cupsdIsAuthorized: User not in group(s).");
+  cupsdLogMessage(CUPSD_LOG_ERROR, "Authentication failed for user \"%s\" from %s (User not in group(s)).", con->username, con->http->hostname);
 
   return (con->username[0] ? HTTP_STATUS_FORBIDDEN : HTTP_STATUS_UNAUTHORIZED);
 }

--- a/scheduler/auth.c
+++ b/scheduler/auth.c
@@ -687,6 +687,7 @@ cupsdAuthorize(cupsd_client_t *con)	/* I - Client connection */
       if (pamerr != PAM_SUCCESS)
       {
 	cupsdLogClient(con, CUPSD_LOG_ERROR, "pam_authenticate() returned %d (%s)", pamerr, pam_strerror(pamh, pamerr));
+  cupsdLogClient(con, CUPSD_LOG_WARN, "Authentication failed for user \"%s\" from %s", username, con->http->hostname);
 	pam_end(pamh, 0);
 	return;
       }

--- a/scheduler/auth.c
+++ b/scheduler/auth.c
@@ -687,6 +687,7 @@ cupsdAuthorize(cupsd_client_t *con)	/* I - Client connection */
       if (pamerr != PAM_SUCCESS)
       {
   cupsdLogClient(con, CUPSD_LOG_ERROR, "Authentication failed for user \"%s\" (%s)", username, con->http->hostname, pam_strerror(pamh, pamerr));	
+  pam_end(pamh, 0);
 	return;
       }
 

--- a/scheduler/auth.c
+++ b/scheduler/auth.c
@@ -686,7 +686,7 @@ cupsdAuthorize(cupsd_client_t *con)	/* I - Client connection */
       pamerr = pam_authenticate(pamh, PAM_SILENT);
       if (pamerr != PAM_SUCCESS)
       {
-  cupsdLogClient(con, CUPSD_LOG_ERROR, "Authentication failed for user \"%s\" from %s (%s)", username, con->http->hostname, pam_strerror(pamh, pamerr));	
+  cupsdLogClient(con, CUPSD_LOG_ERROR, "Authentication failed for user \"%s\" (%s)", username, con->http->hostname, pam_strerror(pamh, pamerr));	
 	return;
       }
 

--- a/scheduler/auth.c
+++ b/scheduler/auth.c
@@ -2081,7 +2081,7 @@ cupsdIsAuthorized(cupsd_client_t *con,	/* I - Connection */
   * The user isn't part of the specified users or groups, so deny access...
   */
 
-  cupsdLogMessage(CUPSD_LOG_DEBUG, "cupsdIsAuthorized: User not in group(s).");
+  cupsdLogMessage(CUPSD_LOG_WARN, "cupsdIsAuthorized: User not in group(s).");
 
   return (con->username[0] ? HTTP_STATUS_FORBIDDEN : HTTP_STATUS_UNAUTHORIZED);
 }

--- a/scheduler/auth.c
+++ b/scheduler/auth.c
@@ -686,7 +686,7 @@ cupsdAuthorize(cupsd_client_t *con)	/* I - Client connection */
       pamerr = pam_authenticate(pamh, PAM_SILENT);
       if (pamerr != PAM_SUCCESS)
       {
-  cupsdLogClient(con, CUPSD_LOG_ERROR, "Authentication failed for user \"%s\" (%s)", username, con->http->hostname, pam_strerror(pamh, pamerr));	
+  cupsdLogClient(con, CUPSD_LOG_ERROR, "Authentication failed for user \"%s\" from %s (%s)", username, con->http->hostname, pam_strerror(pamh, pamerr));
   pam_end(pamh, 0);
 	return;
       }
@@ -2081,7 +2081,7 @@ cupsdIsAuthorized(cupsd_client_t *con,	/* I - Connection */
   * The user isn't part of the specified users or groups, so deny access...
   */
 
-  cupsdLogMessage(CUPSD_LOG_ERROR, "Authentication failed for user \"%s\" from %s (User not in group(s)).", con->username, con->http->hostname);
+  cupsdLogMessage(CUPSD_LOG_WARN, "Authentication failed for user \"%s\" from %s (User not in group(s)).", con->username, con->http->hostname);
 
   return (con->username[0] ? HTTP_STATUS_FORBIDDEN : HTTP_STATUS_UNAUTHORIZED);
 }


### PR DESCRIPTION
Fixes #1553

When LogLevel is set to "error" in cupsd.conf, authentication 
failure messages were logged at CUPSD_LOG_DEBUG level and never 
appeared in logs. This prevented fail2ban from detecting failed 
login attempts and blocked brute force protection.

This change raises the log level from CUPSD_LOG_DEBUG to 
CUPSD_LOG_WARN for the "User not in group(s)" message in 
scheduler/auth.c, ensuring it appears in logs regardless of 
the configured LogLevel.