### PR TITLE
Fix: Satisfy all with multiple Require directives (issue #1304)

### DIFF
--- a/scheduler/auth.c
+++ b/scheduler/auth.c
@@ -2001,7 +2001,7 @@ cupsdIsAuthorized(cupsd_client_t *con,	/* I - Connection */
 #endif /* HAVE_AUTHORIZATION_H */
 
       
-      int name_result = 0; // 0=not matched, 1=matched
+      bool name_result = false;
 
       
       for (name = (char *)cupsArrayFirst(best->names);
@@ -2009,23 +2009,23 @@ cupsdIsAuthorized(cupsd_client_t *con,	/* I - Connection */
            name = (char *)cupsArrayNext(best->names))
       {
         if (!_cups_strcasecmp(name, "@SYSTEM"))
-          continue; // baad mein check hoga
+          continue; // check @SYSTEM later
 
         if (!_cups_strcasecmp(name, "@OWNER") && owner &&
             ((pw && !strcmp(pw->pw_name, ownername)) ||
              (!pw && type == CUPSD_AUTH_NONE && !_cups_strcasecmp(username, ownername))))
         {
-          name_result = 1;
+          name_result = true;
         }
         else if (name[0] == '@')
         {
           if (cupsdCheckGroup(username, pw, name + 1))
-            name_result = 1;
+            name_result = true;
         }
         else if (pw && !strcmp(pw->pw_name, name))
-          name_result = 1;
+          name_result = true;
         else if (!pw && type == CUPSD_AUTH_NONE && !_cups_strcasecmp(username, name))
-          name_result = 1;
+          name_result = true;
       }
 
       // @SYSTEM check
@@ -2039,7 +2039,7 @@ cupsdIsAuthorized(cupsd_client_t *con,	/* I - Connection */
           {
             if (cupsdCheckGroup(username, pw, SystemGroups[i]) && check_admin_access(con))
             {
-              name_result = 1;
+              name_result = true;
               break;
             }
           }
@@ -2054,9 +2054,8 @@ cupsdIsAuthorized(cupsd_client_t *con,	/* I - Connection */
         else
           return (HTTP_STATUS_FORBIDDEN);
       }
-      else
+      else if (name_result)
       {
-        if (name_result)
           return (HTTP_STATUS_OK);
       }
     }

--- a/scheduler/auth.c
+++ b/scheduler/auth.c
@@ -2000,40 +2000,64 @@ cupsdIsAuthorized(cupsd_client_t *con,	/* I - Connection */
       }
 #endif /* HAVE_AUTHORIZATION_H */
 
+      
+      int name_result = 0; // 0=not matched, 1=matched
+
+      
       for (name = (char *)cupsArrayFirst(best->names);
-	   name;
-	   name = (char *)cupsArrayNext(best->names))
+           name;
+           name = (char *)cupsArrayNext(best->names))
       {
-	if (!_cups_strcasecmp(name, "@OWNER") && owner &&
-	    ((pw && !strcmp(pw->pw_name, ownername)) ||
-	     (!pw && type == CUPSD_AUTH_NONE && !_cups_strcasecmp(username, ownername))))
-	  return (HTTP_STATUS_OK);
-	else if (!_cups_strcasecmp(name, "@SYSTEM"))
-	{
-	  /* Do @SYSTEM later, when every other entry fails */
-	  continue;
-	}
-	else if (name[0] == '@')
-	{
-	  if (cupsdCheckGroup(username, pw, name + 1))
-	    return (HTTP_STATUS_OK);
-	}
-	else if (pw && !strcmp(pw->pw_name, name))
-	  return (HTTP_STATUS_OK);
-	else if (!pw && type == CUPSD_AUTH_NONE && !_cups_strcasecmp(username, name))
-	  return (HTTP_STATUS_OK);
+        if (!_cups_strcasecmp(name, "@SYSTEM"))
+          continue; // baad mein check hoga
+
+        if (!_cups_strcasecmp(name, "@OWNER") && owner &&
+            ((pw && !strcmp(pw->pw_name, ownername)) ||
+             (!pw && type == CUPSD_AUTH_NONE && !_cups_strcasecmp(username, ownername))))
+        {
+          name_result = 1;
+        }
+        else if (name[0] == '@')
+        {
+          if (cupsdCheckGroup(username, pw, name + 1))
+            name_result = 1;
+        }
+        else if (pw && !strcmp(pw->pw_name, name))
+          name_result = 1;
+        else if (!pw && type == CUPSD_AUTH_NONE && !_cups_strcasecmp(username, name))
+          name_result = 1;
       }
 
+      // @SYSTEM check
       for (name = (char *)cupsArrayFirst(best->names);
-	   name;
-	   name = (char *)cupsArrayNext(best->names))
+           name;
+           name = (char *)cupsArrayNext(best->names))
       {
-	if (!_cups_strcasecmp(name, "@SYSTEM"))
-	{
-	  for (i = 0; i < NumSystemGroups; i ++)
-	    if (cupsdCheckGroup(username, pw, SystemGroups[i]) && check_admin_access(con))
-	      return (HTTP_STATUS_OK);
-	}
+        if (!_cups_strcasecmp(name, "@SYSTEM"))
+        {
+          for (i = 0; i < NumSystemGroups; i ++)
+          {
+            if (cupsdCheckGroup(username, pw, SystemGroups[i]) && check_admin_access(con))
+            {
+              name_result = 1;
+              break;
+            }
+          }
+        }
+      }
+
+      
+      if (best->satisfy == CUPSD_AUTH_SATISFY_ALL)
+      {
+        if (name_result)
+          return (HTTP_STATUS_OK);
+        else
+          return (HTTP_STATUS_FORBIDDEN);
+      }
+      else
+      {
+        if (name_result)
+          return (HTTP_STATUS_OK);
       }
     }
     else

--- a/scheduler/conf.c
+++ b/scheduler/conf.c
@@ -2453,9 +2453,17 @@ parse_aaa(cupsd_location_t *loc,	/* I - Location */
 
     if (!_cups_strcasecmp(value, "valid-user") ||
         !_cups_strcasecmp(value, "user"))
-      loc->level = CUPSD_AUTH_USER;
+    {
+      // Only set level if not already set to USER
+      if (loc->level == CUPSD_AUTH_ANON)
+        loc->level = CUPSD_AUTH_USER;
+    }
     else if (!_cups_strcasecmp(value, "group"))
-      loc->level = CUPSD_AUTH_GROUP;
+    {
+      // Only upgrade to GROUP if no USER level set yet
+      if (loc->level == CUPSD_AUTH_ANON)
+        loc->level = CUPSD_AUTH_GROUP;
+    }
     else
     {
       cupsdLogMessage(CUPSD_LOG_WARN, "Unknown Require type %s on line %d of %s.",


### PR DESCRIPTION
Problem
When using Satisfy all with multiple Require directives,
CUPS was granting access if ANY one condition passed instead
of requiring ALL conditions to pass.

Two bugs were found:

conf.c: Second Require directive was overwriting the
level set by first Require
auth.c: OR logic was used instead of AND logic when
Satisfy all was set
Fix
conf.c: Prevent level overwrite on multiple Require directives
auth.c: Implement proper AND logic for Satisfy all
Testing
Tested with user joe in @System group:

joe in @System only → 401 Unauthorized ✅
joe in @System + printadmin → 200 OK ✅
Fixes #1304