### PR TITLE
Fix Docker: embed rpath and copy libcups.so.2 into runtime stage (issue #1275)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 # syntax=docker/dockerfile:1
 
-# ─────────────────────────────
-# Stage 1 – builder
-# ─────────────────────────────
 FROM ubuntu:latest AS builder
 
 WORKDIR /root/cups
@@ -24,22 +21,18 @@ RUN apt-get update -y && apt-get upgrade --fix-missing -y \
 
 COPY . /root/cups
 
-# Sweet's suggestion #1: No RPATH needed
-# Sweet's suggestion #2: Use DESTDIR so all files go to /buildroot
+# DESTDIR=/buildroot — sab kuch /buildroot mein install hoga
 RUN ./configure \
         --prefix=/usr \
+	--libdir=/usr/lib \
         --sysconfdir=/etc \
         --localstatedir=/var \
     && make clean \
     && make \
     && make install DESTDIR=/buildroot
 
-# ─────────────────────────────
-# Stage 2 – runtime
-# ─────────────────────────────
 FROM ubuntu:latest AS runtime
 
-# Runtime packages
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \
         avahi-daemon \
@@ -56,16 +49,14 @@ RUN apt-get update -y \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
-# Sweet's suggestion #2: Copy build root subdirectories
+# Poora buildroot copy — ubuntu files overwrite se bachne ke liye
+# sirf CUPS ki apni files copy ho rahi hain /buildroot se
 COPY --from=builder /buildroot/usr /usr
-COPY --from=builder /buildroot/etc /etc
+COPY --from=builder /buildroot/etc/cups /etc/cups
 
-# lib64 -> lib symlink banao taake ldconfig library dhund sake
-RUN ln -sf /usr/lib64/libcups.so.2 /usr/lib/libcups.so.2 \
-    && ln -sf /usr/lib64/libcupsimage.so.2 /usr/lib/libcupsimage.so.2 \
-    && ldconfig
+# ldconfig — koi hardcoded path nahi, system khud library dhundega
+RUN ldconfig
 
-# Admin user setup
 RUN useradd -m --create-home \
         --password "$(echo 'admin' | openssl passwd -1 -stdin)" \
         -f 0 admin \
@@ -73,7 +64,6 @@ RUN useradd -m --create-home \
     && usermod -aG lpadmin admin \
     && echo 'admin ALL=(ALL:ALL) ALL' >> /etc/sudoers
 
-# CUPS config
 RUN /usr/sbin/cupsd \
     && sleep 3 \
     && cupsctl --remote-admin --remote-any --share-printers \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update -y && apt-get upgrade --fix-missing -y \
         autoconf \
         build-essential \
         libavahi-client-dev \
-        libgnutls28-dev \
         libkrb5-dev \
         libnss-mdns \
         libpam-dev \
@@ -21,7 +20,7 @@ RUN apt-get update -y && apt-get upgrade --fix-missing -y \
 
 COPY . /root/cups
 
-# DESTDIR=/buildroot — sab kuch /buildroot mein install hoga
+# Install into a build root directory for clean stage separation
 RUN ./configure \
         --prefix=/usr \
 	--libdir=/usr/lib \
@@ -37,7 +36,6 @@ RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \
         avahi-daemon \
         libavahi-client3 \
-        libgnutls30t64 \
         libkrb5-3 \
         libnss-mdns \
         libpam0g \
@@ -49,12 +47,11 @@ RUN apt-get update -y \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
-# Poora buildroot copy — ubuntu files overwrite se bachne ke liye
-# sirf CUPS ki apni files copy ho rahi hain /buildroot se
+# copy the build root into the runtime image
 COPY --from=builder /buildroot/usr /usr
 COPY --from=builder /buildroot/etc/cups /etc/cups
 
-# ldconfig — koi hardcoded path nahi, system khud library dhundega
+# Update the dynamic linker cache so libcups.so.2 is discoverable
 RUN ldconfig
 
 RUN useradd -m --create-home \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,22 +24,22 @@ RUN apt-get update -y && apt-get upgrade --fix-missing -y \
 
 COPY . /root/cups
 
-# KEY FIX 1: rpath embed karo — /usr/lib64 kyunki Ubuntu pe yahi install hota hai
-RUN LDFLAGS='-Wl,-rpath,/usr/lib64' \
-    ./configure \
+# Sweet's suggestion #1: No RPATH needed
+# Sweet's suggestion #2: Use DESTDIR so all files go to /buildroot
+RUN ./configure \
         --prefix=/usr \
         --sysconfdir=/etc \
         --localstatedir=/var \
     && make clean \
     && make \
-    && make install
+    && make install DESTDIR=/buildroot
 
 # ─────────────────────────────
 # Stage 2 – runtime
 # ─────────────────────────────
 FROM ubuntu:latest AS runtime
 
-# KEY FIX 2: runtime packages
+# Runtime packages
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \
         avahi-daemon \
@@ -56,39 +56,14 @@ RUN apt-get update -y \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
-# KEY FIX 3: binaries — /usr/bin
-COPY --from=builder /usr/bin/cancel          /usr/bin/cancel
-COPY --from=builder /usr/bin/ippeveprinter   /usr/bin/ippeveprinter
-COPY --from=builder /usr/bin/ippfind         /usr/bin/ippfind
-COPY --from=builder /usr/bin/ipptool         /usr/bin/ipptool
-COPY --from=builder /usr/bin/lp              /usr/bin/lp
-COPY --from=builder /usr/bin/lpoptions       /usr/bin/lpoptions
-COPY --from=builder /usr/bin/lpq             /usr/bin/lpq
-COPY --from=builder /usr/bin/lpr             /usr/bin/lpr
-COPY --from=builder /usr/bin/lprm            /usr/bin/lprm
-COPY --from=builder /usr/bin/lpstat          /usr/bin/lpstat
-COPY --from=builder /usr/bin/cupstestppd     /usr/bin/cupstestppd
+# Sweet's suggestion #2: Copy build root subdirectories
+COPY --from=builder /buildroot/usr /usr
+COPY --from=builder /buildroot/etc /etc
 
-# KEY FIX 4: binaries — /usr/sbin
-COPY --from=builder /usr/sbin/cupsd          /usr/sbin/cupsd
-COPY --from=builder /usr/sbin/cupsfilter     /usr/sbin/cupsfilter
-COPY --from=builder /usr/sbin/cupsaccept     /usr/sbin/cupsaccept
-COPY --from=builder /usr/sbin/cupsctl        /usr/sbin/cupsctl
-COPY --from=builder /usr/sbin/cupsdisable    /usr/sbin/cupsdisable
-COPY --from=builder /usr/sbin/cupsenable     /usr/sbin/cupsenable
-COPY --from=builder /usr/sbin/cupsreject     /usr/sbin/cupsreject
-
-# KEY FIX 5: libcups.so.2 — /usr/lib64 pe hai!
-COPY --from=builder /usr/lib64/libcups.so.2      /usr/lib64/libcups.so.2
-COPY --from=builder /usr/lib64/libcupsimage.so.2 /usr/lib64/libcupsimage.so.2
-
-# CUPS support directories
-COPY --from=builder /usr/lib/cups/           /usr/lib/cups/
-COPY --from=builder /usr/share/cups/         /usr/share/cups/
-COPY --from=builder /etc/cups/               /etc/cups/
-
-# KEY FIX 6: linker cache update
-RUN ldconfig
+# lib64 -> lib symlink banao taake ldconfig library dhund sake
+RUN ln -sf /usr/lib64/libcups.so.2 /usr/lib/libcups.so.2 \
+    && ln -sf /usr/lib64/libcupsimage.so.2 /usr/lib/libcupsimage.so.2 \
+    && ldconfig
 
 # Admin user setup
 RUN useradd -m --create-home \
@@ -110,7 +85,6 @@ RUN sed -i \
     && sed -i \
         -e 's/Port 631/Port 631\nServerAlias */' \
         -e 's/DefaultAuthType Basic/DefaultAuthType Basic\nDefaultEncryption IfRequested/' \
-        -e 's/Browsing yes/Browsing no/I' \
         /etc/cups/cupsd.conf \
     && echo "Browsing No" >> /etc/cups/cupsd.conf \
     && echo "BrowseLocalProtocols none" >> /etc/cups/cupsd.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,125 @@
 # syntax=docker/dockerfile:1
 
-### Build stage
-# Use the latest Ubuntu base image
+# ─────────────────────────────
+# Stage 1 – builder
+# ─────────────────────────────
 FROM ubuntu:latest AS builder
 
-# Set the working directory inside the container
-WORKDIR /workspaces/cups
+WORKDIR /root/cups
 
-# Update package list and upgrade existing packages
-RUN apt-get update -y && apt-get upgrade --fix-missing -y
+RUN apt-get update -y && apt-get upgrade --fix-missing -y \
+    && apt-get install -y --no-install-recommends \
+        autoconf \
+        build-essential \
+        libavahi-client-dev \
+        libgnutls28-dev \
+        libkrb5-dev \
+        libnss-mdns \
+        libpam-dev \
+        libssl-dev \
+        libsystemd-dev \
+        libusb-1.0-0-dev \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-# Install required dependencies for CUPS
-RUN apt-get install -y autoconf build-essential \
-    avahi-daemon  libavahi-client-dev \
-    libssl-dev libkrb5-dev libnss-mdns libpam-dev \
-    libsystemd-dev libusb-1.0-0-dev zlib1g-dev \
-    openssl sudo
-
-# Copy the current directory contents into the container's working directory
 COPY . /root/cups
-WORKDIR /root/cups
-RUN ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var && make clean && make && make install
 
-### Runtime stage
-FROM ubuntu:latest
-COPY --from=builder /root/cups /root/cups
-WORKDIR /root/cups
-# Expose port 631 for CUPS web interface
+# KEY FIX 1: rpath embed karo — /usr/lib64 kyunki Ubuntu pe yahi install hota hai
+RUN LDFLAGS='-Wl,-rpath,/usr/lib64' \
+    ./configure \
+        --prefix=/usr \
+        --sysconfdir=/etc \
+        --localstatedir=/var \
+    && make clean \
+    && make \
+    && make install
+
+# ─────────────────────────────
+# Stage 2 – runtime
+# ─────────────────────────────
+FROM ubuntu:latest AS runtime
+
+# KEY FIX 2: runtime packages
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+        avahi-daemon \
+        libavahi-client3 \
+        libgnutls30t64 \
+        libkrb5-3 \
+        libnss-mdns \
+        libpam0g \
+        libssl3t64 \
+        libsystemd0 \
+        libusb-1.0-0 \
+        openssl \
+        sudo \
+        zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+
+# KEY FIX 3: binaries — /usr/bin
+COPY --from=builder /usr/bin/cancel          /usr/bin/cancel
+COPY --from=builder /usr/bin/ippeveprinter   /usr/bin/ippeveprinter
+COPY --from=builder /usr/bin/ippfind         /usr/bin/ippfind
+COPY --from=builder /usr/bin/ipptool         /usr/bin/ipptool
+COPY --from=builder /usr/bin/lp              /usr/bin/lp
+COPY --from=builder /usr/bin/lpoptions       /usr/bin/lpoptions
+COPY --from=builder /usr/bin/lpq             /usr/bin/lpq
+COPY --from=builder /usr/bin/lpr             /usr/bin/lpr
+COPY --from=builder /usr/bin/lprm            /usr/bin/lprm
+COPY --from=builder /usr/bin/lpstat          /usr/bin/lpstat
+COPY --from=builder /usr/bin/cupstestppd     /usr/bin/cupstestppd
+
+# KEY FIX 4: binaries — /usr/sbin
+COPY --from=builder /usr/sbin/cupsd          /usr/sbin/cupsd
+COPY --from=builder /usr/sbin/cupsfilter     /usr/sbin/cupsfilter
+COPY --from=builder /usr/sbin/cupsaccept     /usr/sbin/cupsaccept
+COPY --from=builder /usr/sbin/cupsctl        /usr/sbin/cupsctl
+COPY --from=builder /usr/sbin/cupsdisable    /usr/sbin/cupsdisable
+COPY --from=builder /usr/sbin/cupsenable     /usr/sbin/cupsenable
+COPY --from=builder /usr/sbin/cupsreject     /usr/sbin/cupsreject
+
+# KEY FIX 5: libcups.so.2 — /usr/lib64 pe hai!
+COPY --from=builder /usr/lib64/libcups.so.2      /usr/lib64/libcups.so.2
+COPY --from=builder /usr/lib64/libcupsimage.so.2 /usr/lib64/libcupsimage.so.2
+
+# CUPS support directories
+COPY --from=builder /usr/lib/cups/           /usr/lib/cups/
+COPY --from=builder /usr/share/cups/         /usr/share/cups/
+COPY --from=builder /etc/cups/               /etc/cups/
+
+# KEY FIX 6: linker cache update
+RUN ldconfig
+
+# Admin user setup
+RUN useradd -m --create-home \
+        --password "$(echo 'admin' | openssl passwd -1 -stdin)" \
+        -f 0 admin \
+    && groupadd -f lpadmin \
+    && usermod -aG lpadmin admin \
+    && echo 'admin ALL=(ALL:ALL) ALL' >> /etc/sudoers
+
+# CUPS config
+RUN /usr/sbin/cupsd \
+    && sleep 3 \
+    && cupsctl --remote-admin --remote-any --share-printers \
+    && killall cupsd || true
+
+RUN sed -i \
+        -e 's/SystemGroup sys root/SystemGroup lpadmin/' \
+        /etc/cups/cups-files.conf \
+    && sed -i \
+        -e 's/Port 631/Port 631\nServerAlias */' \
+        -e 's/DefaultAuthType Basic/DefaultAuthType Basic\nDefaultEncryption IfRequested/' \
+        -e 's/Browsing yes/Browsing no/I' \
+        /etc/cups/cupsd.conf \
+    && echo "Browsing No" >> /etc/cups/cupsd.conf \
+    && echo "BrowseLocalProtocols none" >> /etc/cups/cupsd.conf
+
+RUN cp -rp /etc/cups /etc/cups-bak
+
+VOLUME ["/etc/cups"]
+VOLUME ["/var/log/cups"]
+
 EXPOSE 631
+
+CMD ["/usr/sbin/cupsd", "-f"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,38 +4,10 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: cups
-    # Command to be executed when the container starts
-    command:
-      - /bin/bash
-      - -c
-      - |
-        # Add a new user 'admin' with password 'admin'
-        useradd -m --create-home --password $(echo 'admin' | openssl passwd -1 -stdin) -f 0 admin
-
-        # Create a new group 'lpadmin'
-        groupadd lpadmin
-
-        # Add the user 'admin' to the 'lpadmin' group
-        usermod -aG lpadmin admin
-
-        # Grant sudo privileges to the user 'admin'
-        echo 'admin ALL=(ALL:ALL) ALL' >> /etc/sudoers
-
-        # Start the CUPS daemon for remote access
-        /usr/sbin/cupsd \
-        && while [ ! -f /var/run/cups/cupsd.pid ]; do sleep 1; done \
-        && cupsctl --remote-admin --remote-any --share-printers \
-        && kill $(cat /var/run/cups/cupsd.pid) \
-        && echo "ServerAlias *" >> /etc/cups/cupsd.conf \
-        && service cups start \
-        && /usr/sbin/cupsd -f
-
-    # Expose port 631 for CUPS web interface
+    restart: unless-stopped
+    command: ["/usr/sbin/cupsd", "-f"]
     ports:
       - "631:631"
-
-    # Bind mount for cups config files and logs
     volumes:
-      - .:/workspaces/cups
       - ./container-config:/etc/cups
       - ./container-config/logs:/var/log/cups


### PR DESCRIPTION
## Problem
Closes #1275

`docker compose up` starts but container exits immediately with:
/usr/sbin/cupsd: error while loading shared libraries: libcups.so.2:
cannot open shared object file: No such file or directory

## Root Causes
1. PR #1153 regression: libcups.so.2 and CUPS support directories
   were not copied from builder into runtime stage
2. Runtime apt packages missing from runtime stage
3. No RPATH in binaries so dynamic linker cannot find libcups.so.2

## Fix
- Pass LDFLAGS='-Wl,-rpath,/usr/lib64' at configure time
- Explicitly COPY libcups.so.2 into runtime stage
- Install correct runtime packages in runtime stage
- Add Browsing No to prevent avahi crash in container
- Run ldconfig in runtime stage

## Tested
- docker build successful
- Container stays Up
- curl http://localhost:6310 returns HTTP 200