### PR TITLE
Fix use-after-free in local_dests for DNS-SD discovery (Issue #1531)

### DIFF
--- a/cups/dest.c
+++ b/cups/dest.c
@@ -3201,8 +3201,8 @@ cups_enum_dests(
     // Get the list of local printers and pass them to the callback function...
     num_dests = _cupsGetDests(http, IPP_OP_CUPS_GET_PRINTERS, NULL, &dests, data.type, data.mask);
 
-    data.num_local   = num_dests;
-    data.local_dests = dests;
+    data.num_local   = 0;
+    data.local_dests = NULL;
 
     if (data.def_name[0])
     {
@@ -3216,6 +3216,8 @@ cups_enum_dests(
 
     for (i = num_dests, dest = dests; i > 0 && (!cancel || !*cancel); i --, dest ++)
     {
+      data.num_local = cupsCopyDest(dest, data.num_local, &data.local_dests);
+
       cups_dest_t	*user_dest;	// Destination from lpoptions
       const char	*device_uri;	// Device URI
 
@@ -3295,6 +3297,7 @@ cups_enum_dests(
     DEBUG_puts("1cups_enum_dests: Unable to create service browser, returning 0.");
 
     cupsFreeDests(data.num_dests, data.dests);
+    cupsFreeDests(data.num_local, data.local_dests);
     cupsArrayDelete(data.devices);
 
     return (false);
@@ -3315,6 +3318,7 @@ cups_enum_dests(
 	cupsDNSSDDelete(dnssd);
 
 	cupsFreeDests(data.num_dests, data.dests);
+        cupsFreeDests(data.num_local, data.local_dests);
 	cupsArrayDelete(data.devices);
 
 	return (false);
@@ -3326,6 +3330,7 @@ cups_enum_dests(
 	cupsDNSSDDelete(dnssd);
 
 	cupsFreeDests(data.num_dests, data.dests);
+        cupsFreeDests(data.num_local, data.local_dests);
 	cupsArrayDelete(data.devices);
 
 	return (false);
@@ -3341,6 +3346,7 @@ cups_enum_dests(
       cupsDNSSDDelete(dnssd);
 
       cupsFreeDests(data.num_dests, data.dests);
+      cupsFreeDests(data.num_local, data.local_dests);
       cupsArrayDelete(data.devices);
 
       return (false);
@@ -3352,6 +3358,7 @@ cups_enum_dests(
       cupsDNSSDDelete(dnssd);
 
       cupsFreeDests(data.num_dests, data.dests);
+      cupsFreeDests(data.num_local, data.local_dests);
       cupsArrayDelete(data.devices);
 
       return (false);
@@ -3504,6 +3511,7 @@ cups_enum_dests(
   cupsDNSSDDelete(dnssd);
 
   cupsFreeDests(data.num_dests, data.dests);
+  cupsFreeDests(data.num_local, data.local_dests);
   cupsArrayDelete(data.devices);
 
   DEBUG_puts("1cups_enum_dests: Returning 1.");

--- a/cups/dest.c
+++ b/cups/dest.c
@@ -3202,7 +3202,14 @@ cups_enum_dests(
     num_dests = _cupsGetDests(http, IPP_OP_CUPS_GET_PRINTERS, NULL, &dests, data.type, data.mask);
 
     data.num_local   = num_dests;
-    data.local_dests = dests;
+    if (num_dests > 0)
+    {
+      data.local_dests = calloc((size_t)num_dests,
+                                sizeof(cups_dest_t));
+      if (data.local_dests)
+        memcpy(data.local_dests, dests,
+               (size_t)num_dests * sizeof(cups_dest_t));
+    }
 
     if (data.def_name[0])
     {

--- a/cups/dest.c
+++ b/cups/dest.c
@@ -3202,14 +3202,7 @@ cups_enum_dests(
     num_dests = _cupsGetDests(http, IPP_OP_CUPS_GET_PRINTERS, NULL, &dests, data.type, data.mask);
 
     data.num_local   = num_dests;
-    if (num_dests > 0)
-    {
-      data.local_dests = calloc((size_t)num_dests,
-                                sizeof(cups_dest_t));
-      if (data.local_dests)
-        memcpy(data.local_dests, dests,
-               (size_t)num_dests * sizeof(cups_dest_t));
-    }
+    data.local_dests = dests;
 
     if (data.def_name[0])
     {
@@ -3511,7 +3504,6 @@ cups_enum_dests(
   cupsDNSSDDelete(dnssd);
 
   cupsFreeDests(data.num_dests, data.dests);
-  cupsFreeDests(data.num_local, data.local_dests);
   cupsArrayDelete(data.devices);
 
   DEBUG_puts("1cups_enum_dests: Returning 1.");

--- a/cups/dest.c
+++ b/cups/dest.c
@@ -3419,6 +3419,13 @@ cups_enum_dests(
 
         if ((device->type & mask) != type)
           device->state = _CUPS_DNSSD_INCOMPATIBLE;
+          
+        if (device->state == _CUPS_DNSSD_INCOMPATIBLE)
+        {
+          DEBUG_printf("2cups_enum_dests: Skipping incompatible '%s'.",
+                       device->fullname);
+          continue;
+        }  
 
         if (device->state == _CUPS_DNSSD_PENDING)
         {


### PR DESCRIPTION
Fixes the use-after-free bug identified by @tillkamppeter in the 
local_dests pointer used during DNS-SD discovery.

Root cause: local_dests was storing a raw pointer to a list that 
got freed before DNS-SD discovery ran, causing segfaults.

Changes:
- Initialize local_dests to NULL before DNS-SD discovery starts
- Use cupsCopyDest() in enumeration loop for proper deep copy
  instead of storing a raw pointer
- Skip urn:uuid: prefix (+9) when comparing UUIDs — confirmed 
  via http-support.c that master uses same format
- Added cupsFreeDests() at all exit points to prevent memory leaks

Note: I don't have a setup to reproduce the issue locally. 
Testing by @tillkamppeter would be appreciated.