### PR TITLE
Fix PageSize/media to PPD mapping for non-Adobe names. Fixes #1375

### DIFF
--- a/cups/ppd-mark.c
+++ b/cups/ppd-mark.c
@@ -51,6 +51,7 @@ cupsMarkOptions(
 		s[255];			/* Temporary string */
   const char	*val,			/* Pointer into value */
 		*media,			/* media option */
+		*page_size,		/* PageSize option */
 		*output_bin,		/* output-bin option */
 		*ppd_keyword,		/* PPD keyword */
 		*print_color_mode,	/* print-color-mode option */
@@ -76,6 +77,7 @@ cupsMarkOptions(
   */
 
   media         = cupsGetOption("media", num_options, options);
+  page_size     = cupsGetOption("PageSize", num_options, options);
   output_bin    = cupsGetOption("output-bin", num_options, options);
   print_quality = cupsGetOption("print-quality", num_options, options);
   sides         = cupsGetOption("sides", num_options, options);
@@ -84,7 +86,7 @@ cupsMarkOptions(
                                         options)) == NULL)
     print_color_mode = cupsGetOption("output-mode", num_options, options);
 
-  if ((media || output_bin || print_color_mode || print_quality || sides) &&
+  if ((media || page_size || output_bin || print_color_mode || print_quality || sides) &&
       !ppd->cache)
   {
    /*


### PR DESCRIPTION
If the client software sends only PageSize using Adobe name (common when printer is shared), but the PPD file uses non-Adobe name, default page size was used, which is incorrect.

The previous attempt in commit 226f509 to fix this issue have missed loading PPD cache if no media is supplied.