### PR TITLE
Auto-regenerate expired self-signed certificates

### DIFF
--- a/cups/tls-gnutls.c
+++ b/cups/tls-gnutls.c
@@ -1836,7 +1836,7 @@ _httpTLSStart(http_t *http)		// I - Connection to server
         }
       }
 
-      have_creds = !access(crtfile, R_OK) && !access(keyfile, R_OK);
+      have_creds = !access(crtfile, R_OK) && !access(keyfile, R_OK) && cupsGetCredentialsExpiration(crtfile) > time(NULL);
     }
 
     if (!have_creds && tls_auto_create && cn)

--- a/cups/tls-gnutls.c
+++ b/cups/tls-gnutls.c
@@ -1833,10 +1833,23 @@ _httpTLSStart(http_t *http)		// I - Connection to server
           // Use the CA certs...
           cupsCopyString(crtfile, cacrtfile, sizeof(crtfile));
           cupsCopyString(keyfile, cakeyfile, sizeof(keyfile));
+
+          have_creds = true;
         }
       }
+      else
+      {
+        // CUPS-managed self-signed certs: use them only if they have
+        // not expired, otherwise let the auto-create code path below
+        // regenerate them (Issue #1519). cupsGetCredentialsExpiration()
+        // expects a PEM string, not a file path, so load the cert via
+        // cupsCopyCredentials() first.
+        char	*creds = cupsCopyCredentials(tls_keypath, cn);
+					// PEM-encoded certificate
 
-      have_creds = !access(crtfile, R_OK) && !access(keyfile, R_OK) && cupsGetCredentialsExpiration(crtfile) > time(NULL);
+        have_creds = creds && cupsGetCredentialsExpiration(creds) > time(NULL);
+        free(creds);
+      }
     }
 
     if (!have_creds && tls_auto_create && cn)

--- a/cups/tls-openssl.c
+++ b/cups/tls-openssl.c
@@ -1900,7 +1900,7 @@ _httpTLSStart(http_t *http)		// I - Connection to server
         }
       }
 
-      have_creds = !access(crtfile, R_OK) && !access(keyfile, R_OK);
+      have_creds = !access(crtfile, R_OK) && !access(keyfile, R_OK) && cupsGetCredentialsExpiration(crtfile) > time(NULL);
     }
 
     if (!have_creds && tls_auto_create && cn)

--- a/cups/tls-openssl.c
+++ b/cups/tls-openssl.c
@@ -1897,10 +1897,23 @@ _httpTLSStart(http_t *http)		// I - Connection to server
           // Use the CA certs...
           cupsCopyString(crtfile, cacrtfile, sizeof(crtfile));
           cupsCopyString(keyfile, cakeyfile, sizeof(keyfile));
+
+          have_creds = true;
         }
       }
+      else
+      {
+        // CUPS-managed self-signed certs: use them only if they have
+        // not expired, otherwise let the auto-create code path below
+        // regenerate them (Issue #1519). cupsGetCredentialsExpiration()
+        // expects a PEM string, not a file path, so load the cert via
+        // cupsCopyCredentials() first.
+        char	*creds = cupsCopyCredentials(tls_keypath, cn);
+					// PEM-encoded certificate
 
-      have_creds = !access(crtfile, R_OK) && !access(keyfile, R_OK) && cupsGetCredentialsExpiration(crtfile) > time(NULL);
+        have_creds = creds && cupsGetCredentialsExpiration(creds) > time(NULL);
+        free(creds);
+      }
     }
 
     if (!have_creds && tls_auto_create && cn)


### PR DESCRIPTION
## Summary

- `_httpTLSStart` checked whether certificate files exist on disk via `access()` but never verified whether they have expired. When an auto-generated self-signed certificate expired, CUPS continued using it instead of creating a new one, breaking HTTPS access.
- Added a `cupsGetCredentialsExpiration()` check so that expired certificates are treated as missing, triggering the existing auto-create code path.
- Applied to both `tls-openssl.c` and `tls-gnutls.c` backends.

Fixes: #1519

## Test plan

- [ ] Create a self-signed cert, manually set its expiration to the past, and verify CUPS regenerates it on next startup
- [ ] Verify that valid (non-expired) certificates are still used normally
- [ ] Test with both OpenSSL and GnuTLS backends