### PR TITLE
Avoid int overflow after year 2038

### DIFF
--- a/cups/ppd-util.c
+++ b/cups/ppd-util.c
@@ -302,7 +302,7 @@ cupsGetPPD3(http_t     *http,		/* I  - HTTP connection or @code CUPS_HTTP_DEFAUL
       }
       else
       {
-        DEBUG_printf("2cupsGetPPD3: Returning ok, filename=\"%s\", modtime=%ld.", buffer, (long)ppdinfo.st_mtime);
+        DEBUG_printf("2cupsGetPPD3: Returning ok, filename=\"%s\", modtime=%lld.", buffer, (long long)ppdinfo.st_mtime);
         *modtime = ppdinfo.st_mtime;
 	return (HTTP_STATUS_OK);
       }

--- a/cups/tls-openssl.c
+++ b/cups/tls-openssl.c
@@ -1024,7 +1024,7 @@ cupsGetCredentialsTrust(
 
     time(&curtime);
 
-    DEBUG_printf("1cupsGetCredentialsTrust: curtime=%ld, notBefore=%ld, notAfter=%ld", (long)curtime, (long)openssl_get_date(cert, 0), (long)openssl_get_date(cert, 1));
+    DEBUG_printf("1cupsGetCredentialsTrust: curtime=%lld, notBefore=%lld, notAfter=%lld", (long long)curtime, (long long)openssl_get_date(cert, 0), (long long)openssl_get_date(cert, 1));
 
     if ((curtime + 86400) < openssl_get_date(cert, 0) || curtime > openssl_get_date(cert, 1))
     {

--- a/cups/util.c
+++ b/cups/util.c
@@ -576,13 +576,13 @@ cupsGetJobs2(http_t     *http,		/* I - Connection to server or @code CUPS_HTTP_D
 	  size = attr->values[0].integer;
         else if (!strcmp(attr->name, "time-at-completed") &&
 	         attr->value_tag == IPP_TAG_INTEGER)
-	  completed_time = attr->values[0].integer;
+	  completed_time = (unsigned)attr->values[0].integer;
         else if (!strcmp(attr->name, "time-at-creation") &&
 	         attr->value_tag == IPP_TAG_INTEGER)
-	  creation_time = attr->values[0].integer;
+	  creation_time = (unsigned)attr->values[0].integer;
         else if (!strcmp(attr->name, "time-at-processing") &&
 	         attr->value_tag == IPP_TAG_INTEGER)
-	  processing_time = attr->values[0].integer;
+	  processing_time = (unsigned)attr->values[0].integer;
         else if (!strcmp(attr->name, "job-printer-uri") &&
 	         attr->value_tag == IPP_TAG_URI)
 	{

--- a/scheduler/classes.c
+++ b/scheduler/classes.c
@@ -475,7 +475,7 @@ cupsdLoadAllClasses(void)
       */
 
       if (value)
-        p->state_time = atoi(value);
+        p->state_time = atoll(value);
     }
     else if (!_cups_strcasecmp(line, "Accepting"))
     {
@@ -756,7 +756,7 @@ cupsdSaveAllClasses(void)
     else
       cupsFilePuts(fp, "State Idle\n");
 
-    cupsFilePrintf(fp, "StateTime %d\n", (int)pclass->state_time);
+    cupsFilePrintf(fp, "StateTime %lld\n", (long long)pclass->state_time);
 
     if (pclass->accepting)
       cupsFilePuts(fp, "Accepting Yes\n");

--- a/scheduler/job.c
+++ b/scheduler/job.c
@@ -226,7 +226,7 @@ cupsdCheckJobs(void)
 
   curtime = time(NULL);
 
-  cupsdLogMessage(CUPSD_LOG_DEBUG2, "cupsdCheckJobs: %d active jobs, sleeping=%d, ac-power=%d, reload=%d, curtime=%ld", cupsArrayCount(ActiveJobs), Sleeping, ACPower, NeedReload, (long)curtime);
+  cupsdLogMessage(CUPSD_LOG_DEBUG2, "cupsdCheckJobs: %d active jobs, sleeping=%d, ac-power=%d, reload=%d, curtime=%lld", cupsArrayCount(ActiveJobs), Sleeping, ACPower, NeedReload, (long long)curtime);
 
   for (job = (cupsd_job_t *)cupsArrayFirst(ActiveJobs);
        job;
@@ -234,10 +234,10 @@ cupsdCheckJobs(void)
   {
     cupsdLogMessage(CUPSD_LOG_DEBUG2,
                     "cupsdCheckJobs: Job %d - dest=\"%s\", printer=%p, "
-                    "state=%d, cancel_time=%ld, hold_until=%ld, kill_time=%ld, "
+                    "state=%d, cancel_time=%lld, hold_until=%lld, kill_time=%lld, "
                     "pending_cost=%d, pending_timeout=%ld", job->id, job->dest,
-                    (void *)job->printer, job->state_value, (long)job->cancel_time,
-                    (long)job->hold_until, (long)job->kill_time,
+                    (void *)job->printer, job->state_value, (long long)job->cancel_time,
+                    (long long)job->hold_until, (long long)job->kill_time,
                     job->pending_cost, (long)job->pending_timeout);
 
    /*
@@ -433,13 +433,13 @@ cupsdCleanJobs(void)
   curtime          = time(NULL);
   JobHistoryUpdate = 0;
 
-  cupsdLogMessage(CUPSD_LOG_DEBUG2, "cupsdCleanJobs: curtime=%d", (int)curtime);
+  cupsdLogMessage(CUPSD_LOG_DEBUG2, "cupsdCleanJobs: curtime=%lld", (long long)curtime);
 
   for (job = (cupsd_job_t *)cupsArrayFirst(Jobs);
        job;
        job = (cupsd_job_t *)cupsArrayNext(Jobs))
   {
-    cupsdLogMessage(CUPSD_LOG_DEBUG2, "cupsdCleanJobs: Job %d, state=%d, printer=%p, history_time=%d, file_time=%d, num_files=%d", job->id, (int)job->state_value, (void *)job->printer, (int)job->history_time, (int)job->file_time, (int)job->num_files);
+    cupsdLogMessage(CUPSD_LOG_DEBUG2, "cupsdCleanJobs: Job %d, state=%d, printer=%p, history_time=%lld, file_time=%lld, num_files=%d", job->id, (int)job->state_value, (void *)job->printer, (long long)job->history_time, (long long)job->file_time, (int)job->num_files);
 
     if ((job->history_time && job->history_time < JobHistoryUpdate) || !JobHistoryUpdate)
       JobHistoryUpdate = job->history_time;
@@ -1718,14 +1718,14 @@ cupsdLoadJob(cupsd_job_t *job)		/* I - Job */
     goto error;
   }
 
-  job->creation_time = attr->values[0].integer;
+  job->creation_time = (unsigned)attr->values[0].integer;
   job->state_value  = (ipp_jstate_t)job->state->values[0].integer;
   job->file_time    = 0;
   job->history_time = 0;
 
   if (job->state_value >= IPP_JSTATE_CANCELED && (attr = ippFindAttribute(job->attrs, "time-at-completed", IPP_TAG_INTEGER)) != NULL)
   {
-    job->completed_time = attr->values[0].integer;
+    job->completed_time = (unsigned)attr->values[0].integer;
 
     if (JobHistory < INT_MAX)
       job->history_time = job->completed_time + JobHistory;
@@ -1743,7 +1743,7 @@ cupsdLoadJob(cupsd_job_t *job)		/* I - Job */
     else
       job->file_time = INT_MAX;
 
-    cupsdLogJob(job, CUPSD_LOG_DEBUG2, "cupsdLoadJob: job->file_time=%ld, time-at-completed=%ld, JobFiles=%d", (long)job->file_time, (long)attr->values[0].integer, JobFiles);
+    cupsdLogJob(job, CUPSD_LOG_DEBUG2, "cupsdLoadJob: job->file_time=%lld, time-at-completed=%lld, JobFiles=%d", (long long)job->file_time, (long long)(unsigned)attr->values[0].integer, JobFiles);
 
     if (job->file_time < JobHistoryUpdate || !JobHistoryUpdate)
       JobHistoryUpdate = job->file_time;
@@ -2236,12 +2236,12 @@ cupsdSaveAllJobs(void)
 
     cupsFilePrintf(fp, "<Job %d>\n", job->id);
     cupsFilePrintf(fp, "State %d\n", job->state_value);
-    cupsFilePrintf(fp, "Created %ld\n", (long)job->creation_time);
+    cupsFilePrintf(fp, "Created %lld\n", (long long)job->creation_time);
     if (job->completed_time)
-      cupsFilePrintf(fp, "Completed %ld\n", (long)job->completed_time);
+      cupsFilePrintf(fp, "Completed %lld\n", (long long)job->completed_time);
     cupsFilePrintf(fp, "Priority %d\n", job->priority);
     if (job->hold_until)
-      cupsFilePrintf(fp, "HoldUntil %ld\n", (long)job->hold_until);
+      cupsFilePrintf(fp, "HoldUntil %lld\n", (long long)job->hold_until);
     cupsFilePrintf(fp, "Username %s\n", job->username);
     if (job->name)
       cupsFilePutConf(fp, "Name", job->name);
@@ -2489,8 +2489,8 @@ cupsdSetJobHoldUntil(cupsd_job_t *job,	/* I - Job */
       job->hold_until += 24 * 60 * 60;
   }
 
-  cupsdLogMessage(CUPSD_LOG_DEBUG2, "cupsdSetJobHoldUntil: hold_until=%d",
-                  (int)job->hold_until);
+  cupsdLogMessage(CUPSD_LOG_DEBUG2, "cupsdSetJobHoldUntil: hold_until=%lld",
+                  (long long)job->hold_until);
 }
 
 
@@ -2877,7 +2877,7 @@ cupsdUpdateJobs(void)
       * Update history/file expiration times...
       */
 
-      job->completed_time = attr->values[0].integer;
+      job->completed_time = (unsigned)attr->values[0].integer;
 
       if (JobHistory < INT_MAX)
 	job->history_time = job->completed_time + JobHistory;
@@ -2898,7 +2898,7 @@ cupsdUpdateJobs(void)
       else
 	job->file_time = INT_MAX;
 
-      cupsdLogJob(job, CUPSD_LOG_DEBUG2, "cupsdUpdateJobs: job->file_time=%ld, time-at-completed=%ld, JobFiles=%d", (long)job->file_time, (long)attr->values[0].integer, JobFiles);
+      cupsdLogJob(job, CUPSD_LOG_DEBUG2, "cupsdUpdateJobs: job->file_time=%lld, time-at-completed=%ld, JobFiles=%d", (long long)job->file_time, (long)attr->values[0].integer, JobFiles);
 
       if (job->file_time < JobHistoryUpdate || !JobHistoryUpdate)
 	JobHistoryUpdate = job->file_time;
@@ -4471,15 +4471,15 @@ load_job_cache(const char *filename)	/* I - job.cache filename */
     }
     else if (!_cups_strcasecmp(line, "Created"))
     {
-      job->creation_time = strtol(value, NULL, 10);
+      job->creation_time = strtoll(value, NULL, 10);
     }
     else if (!_cups_strcasecmp(line, "Completed"))
     {
-      job->completed_time = strtol(value, NULL, 10);
+      job->completed_time = strtoll(value, NULL, 10);
     }
     else if (!_cups_strcasecmp(line, "HoldUntil"))
     {
-      job->hold_until = strtol(value, NULL, 10);
+      job->hold_until = strtoll(value, NULL, 10);
     }
     else if (!_cups_strcasecmp(line, "Priority"))
     {

--- a/scheduler/printers.c
+++ b/scheduler/printers.c
@@ -1367,7 +1367,7 @@ cupsdLoadAllPrinters(void)
 	  cupsdSetPrinterAttrs(p);
 
         if (!strcmp(value, "marker-change-time"))
-	  p->marker_time = (time_t)strtol(valueptr, NULL, 10);
+	  p->marker_time = (time_t)strtoll(valueptr, NULL, 10);
 	else
           cupsdSetPrinterAttr(p, value, valueptr);
       }
@@ -1586,8 +1586,8 @@ cupsdSaveAllPrinters(void)
     else
       cupsFilePuts(fp, "State Idle\n");
 
-    cupsFilePrintf(fp, "StateTime %d\n", (int)printer->state_time);
-    cupsFilePrintf(fp, "ConfigTime %d\n", (int)printer->config_time);
+    cupsFilePrintf(fp, "StateTime %lld\n", (long long)printer->state_time);
+    cupsFilePrintf(fp, "ConfigTime %lld\n", (long long)printer->config_time);
 
     for (j = 0; j < printer->num_reasons; j ++)
       if (strcmp(printer->reasons[j], "connecting-to-device") &&
@@ -1733,8 +1733,8 @@ cupsdSaveAllPrinters(void)
     }
 
     if (printer->marker_time)
-      cupsFilePrintf(fp, "Attribute marker-change-time %ld\n",
-                     (long)printer->marker_time);
+      cupsFilePrintf(fp, "Attribute marker-change-time %lld\n",
+                     (long long)printer->marker_time);
 
     if (printer == DefaultPrinter)
       cupsFilePuts(fp, "</DefaultPrinter>\n");

--- a/scheduler/subscriptions.c
+++ b/scheduler/subscriptions.c
@@ -1019,7 +1019,7 @@ cupsdLoadAllSubscriptions(void)
       */
 
       if (value && isdigit(*value & 255))
-	sub->expire = atoi(value);
+	sub->expire = atoll(value);
       else
       {
 	cupsdLogMessage(CUPSD_LOG_ERROR,
@@ -1179,7 +1179,7 @@ cupsdSaveAllSubscriptions(void)
 
     cupsFilePrintf(fp, "LeaseDuration %d\n", sub->lease);
     cupsFilePrintf(fp, "Interval %d\n", sub->interval);
-    cupsFilePrintf(fp, "ExpirationTime %ld\n", (long)sub->expire);
+    cupsFilePrintf(fp, "ExpirationTime %lld\n", (long long)sub->expire);
     cupsFilePrintf(fp, "NextEventId %d\n", sub->next_event_id);
 
     cupsFilePuts(fp, "</Subscription>\n");

--- a/systemv/lpstat.c
+++ b/systemv/lpstat.c
@@ -1437,7 +1437,7 @@ show_jobs(const char *dests,		/* I - Destinations */
 		 attr->value_tag == IPP_TAG_INTEGER)
 	  size = attr->values[0].integer;
         else if (!strcmp(attr->name, time_at) && attr->value_tag == IPP_TAG_INTEGER)
-	  jobtime = attr->values[0].integer;
+	  jobtime = (unsigned)attr->values[0].integer;
         else if (!strcmp(attr->name, "job-printer-state-message") &&
 	         attr->value_tag == IPP_TAG_TEXT)
 	  message = attr->values[0].string.text;


### PR DESCRIPTION
See https://en.wikipedia.org/wiki/Year_2038_problem

We consistently use `long long` (64 bit) types for input and output of `time_t` except where we get 32-bit int - there we cast it as `unsigned int` to allow it to work until year 2106 and assume that nobody needs dates before 1970. It might also cover for `ippAddInteger(..., "time-at-creation", time(NULL));` that I left as is.

This patch was done while reviewing potential year-2038 issues in openSUSE.

note: this is probably incomplete, e.g. there are several checks for `INT_MAX`.

note2: I only tested that it compiles with the cherry-pick on v2.4.19 in https://github.com/bmwiedemann/cups/tree/time2419