### PR TITLE
fix out-of-bounds write in encode_string

### DIFF
--- a/cups/form.c
+++ b/cups/form.c
@@ -301,12 +301,18 @@ encode_string(const char *s,            // I - String to encode
     if (*s == ' ')
     {
       // Space is encoded as '+'
-      *bufptr++ = '+';
+      if (bufptr < bufend)
+        *bufptr++ = '+';
+      else
+        bufptr ++;
     }
     else if (*s == '\n')
     {
       // Newline is encoded as percent-encoded CR & LF
-      *bufptr++ = '%';
+      if (bufptr < bufend)
+        *bufptr++ = '%';
+      else
+        bufptr ++;
       if (bufptr < bufend)
         *bufptr++ = '0';
       else
@@ -331,7 +337,10 @@ encode_string(const char *s,            // I - String to encode
     else if (!isalnum(*s & 255))
     {
       // Characters other than letters and numbers get percent-encoded
-      *bufptr++ = '%';
+      if (bufptr < bufend)
+        *bufptr++ = '%';
+      else
+        bufptr ++;
       if (bufptr < bufend)
         *bufptr++ = hex[(*s >> 4) & 15];
       else


### PR DESCRIPTION
Auditing the 2.5 form API. encode_string carries the comment "can go past bufend, but we don't write past there", so I checked each write against bufend.

Three of them have no guard: the '+' in the space branch, and the leading '%' in the newline and percent-encode branches. Every other write in the function is wrapped in `if (bufptr < bufend)`.

Fed cupsFormEncode one option whose value is 69999 spaces. It lays out a 65536-byte stack buffer, then encode_string writes one '+' per space with no bound. Marked the bytes past the buffer with a canary and counted the overwrites:

    buggy  encode_string: bytes written past end = 4463
    fixed  encode_string: bytes written past end = 0

The caller does test `bufptr >= bufend` after the call, but the overflow has already happened inside encode_string by then. Guarding those three writes the same way as the others keeps it inside the buffer.