### PR TITLE
fix off-by-one write copying snmp supply names

### DIFF
--- a/backend/snmp-supplies.c
+++ b/backend/snmp-supplies.c
@@ -907,16 +907,19 @@ backend_walk_cb(cups_snmp_t *packet,	/* I - SNMP packet */
 	  */
 
           {
-	    char	*src, *dst;	/* Pointers into strings */
+	    char	*src, *dst,	/* Pointers into strings */
+			*dstend;	/* End of name buffer */
 
            /*
-	    * Loop safe because both the object_value and supplies char arrays
-	    * are CUPS_SNMP_MAX_STRING elements long.
+	    * object_value.string.bytes is one element larger than the supplies
+	    * name buffer, so stop at the end of the destination to keep the
+	    * terminating nul in bounds.
 	    */
 
             for (src = (char *)packet->object_value.string.bytes,
-	             dst = supplies[i - 1].name;
-		 *src;
+	             dst = supplies[i - 1].name,
+	             dstend = dst + sizeof(supplies[0].name) - 1;
+		 *src && dst < dstend;
 		 src ++)
 	    {
 	      if ((*src & 0x80) || *src < ' ' || *src == 0x7f)


### PR DESCRIPTION
Checking the SNMP backend supply parser. The unknown-charset branch in backend_walk_cb carries a comment that the copy is safe because both buffers are CUPS_SNMP_MAX_STRING long. They are not:

    object_value.string.bytes[CUPS_SNMP_MAX_STRING + 1]   // source, 1025
    supplies[i - 1].name[CUPS_SNMP_MAX_STRING]            // dest, 1024

asn1_get_string can fill the source with 1024 non-nul bytes. A printer that reports an unknown character set and a 1024-byte prtMarkerSuppliesDescription then makes the loop copy 1024 chars and write the terminating nul one past name. Reproduced the exact loop with a canary:

    ORIGINAL: nul written at name[1024] (slots 0..1023) -> out of bounds, color[0] 0x23 -> 0x00
    FIXED   : nul written at name[1023] -> in bounds, color[0] 0x23

The other charset branches pass sizeof(supplies[0].name) and stay inside the buffer. Bounding the loop the same way keeps the nul in range.