### PR TITLE
bound Font attribute sscanf in import_ppd

### DIFF
--- a/ppdc/ppdc-import.cxx
+++ b/ppdc/ppdc-import.cxx
@@ -252,7 +252,7 @@ ppdcSource::import_ppd(const char *f)	// I - Filename
       ppdcFontStatus	fstatus;	// Status enumeration
 
 
-      if (sscanf(attr->value, "%s%*[^\"]\"%[^\"]\"%s%s", encoding, version,
+      if (sscanf(attr->value, "%255s%*[^\"]\"%255[^\"]\"%255s%255s", encoding, version,
 		 charset, status) != 4)
       {
 	_cupsLangPrintf(stderr, _("ppdc: Bad font attribute: %s"),


### PR DESCRIPTION
Auditing ppdc's PPD importer. import_ppd parses every *Font attribute with an unbounded sscanf:

    sscanf(attr->value, "%s%*[^\"]\"%[^\"]\"%s%s", encoding, version, charset, status)

encoding, version, charset and status are each char[256], and none of the four conversions is width-limited.

Assumed ppd_read's 256-byte line cap bounded attr->value, but it caps each physical line only. Inside a quoted value the reader keeps appending across newlines, so a multi-line version field grows past 256 bytes. ppdOpenFile on a PPD whose Font version field spans a few lines hands back a 427-byte value with a 404-byte version token, and the %[^"] conversion then writes 404+1 bytes into version[256].

Canary placed straight after version[256], 400-byte version field:

    bare    %[^"]   : bytes written past end = 145
    capped  %255[^"]: bytes written past end = 0

Width-limiting the four fields keeps the writes inside the buffers, matching the %255s / %255[^"] forms already used in ppd.c and cups-driverd.cxx.
