### PR TITLE
fix out-of-bounds read in mime_check_rules char test

### DIFF
--- a/scheduler/type.c
+++ b/scheduler/type.c
@@ -888,7 +888,7 @@ mime_check_rules(
 
       case MIME_MAGIC_CHAR :
           // Load the buffer if necessary...
-          if (fb->offset < 0 || rules->offset < fb->offset)
+          if (fb->offset < 0 || rules->offset < fb->offset || (rules->offset + 1) > (fb->offset + fb->length))
 	  {
 	    // Reload file buffer...
             if (cupsFileSeek(fb->fp, rules->offset) < 0)


### PR DESCRIPTION
Caught this with AddressSanitizer while fuzzing type detection on short files:

    ==ERROR: AddressSanitizer: SEGV on unknown address (READ)
        #0 mime_check_rules type.c:913
        #1 mime_check_rules type.c:1030
        #2 mimeFileType type.c:599

Traced it back to the `char()` magic test. Every other fixed-offset op (`string`, `istring`, `short`, `int`, `contains`) reloads the file buffer when `(rules->offset + N) > (fb->offset + fb->length)`. The `MIME_MAGIC_CHAR` case only checks `rules->offset < fb->offset`, so a rule whose offset sits past the buffered region never triggers a reload and `fb->buffer[rules->offset - fb->offset]` reads past the data.

mimeFileType only buffers the first 8192 bytes, so a `char()` rule at a large offset against a short file walks straight off the stack buffer. Minimal repro: type a 1-byte file against `char(100000,65)` and it segfaults at type.c:913. With the offset term added the read stays in range and the test just returns no-match.

Lined the condition up with the sibling cases.