### PR TITLE
cups: Fix use-after-free in cups_enum_dests() for local destinations (issue #1531)

### DIFF
--- a/cups/dest.c
+++ b/cups/dest.c
@@ -3201,8 +3201,8 @@ cups_enum_dests(
     // Get the list of local printers and pass them to the callback function...
     num_dests = _cupsGetDests(http, IPP_OP_CUPS_GET_PRINTERS, NULL, &dests, data.type, data.mask);
 
-    data.num_local   = num_dests;
-    data.local_dests = dests;
+    data.num_local   = 0;
+    data.local_dests = NULL;
 
     if (data.def_name[0])
     {
@@ -3216,6 +3216,8 @@ cups_enum_dests(
 
     for (i = num_dests, dest = dests; i > 0 && (!cancel || !*cancel); i --, dest ++)
     {
+      data.num_local = cupsCopyDest(dest, data.num_local, &data.local_dests);
+
       cups_dest_t	*user_dest;	// Destination from lpoptions
       const char	*device_uri;	// Device URI
 
@@ -3295,6 +3297,7 @@ cups_enum_dests(
     DEBUG_puts("1cups_enum_dests: Unable to create service browser, returning 0.");
 
     cupsFreeDests(data.num_dests, data.dests);
+    cupsFreeDests(data.num_local, data.local_dests);
     cupsArrayDelete(data.devices);
 
     return (false);
@@ -3315,6 +3318,7 @@ cups_enum_dests(
 	cupsDNSSDDelete(dnssd);
 
 	cupsFreeDests(data.num_dests, data.dests);
+        cupsFreeDests(data.num_local, data.local_dests);
 	cupsArrayDelete(data.devices);
 
 	return (false);
@@ -3326,6 +3330,7 @@ cups_enum_dests(
 	cupsDNSSDDelete(dnssd);
 
 	cupsFreeDests(data.num_dests, data.dests);
+        cupsFreeDests(data.num_local, data.local_dests);
 	cupsArrayDelete(data.devices);
 
 	return (false);
@@ -3341,6 +3346,7 @@ cups_enum_dests(
       cupsDNSSDDelete(dnssd);
 
       cupsFreeDests(data.num_dests, data.dests);
+      cupsFreeDests(data.num_local, data.local_dests);
       cupsArrayDelete(data.devices);
 
       return (false);
@@ -3352,6 +3358,7 @@ cups_enum_dests(
       cupsDNSSDDelete(dnssd);
 
       cupsFreeDests(data.num_dests, data.dests);
+      cupsFreeDests(data.num_local, data.local_dests);
       cupsArrayDelete(data.devices);
 
       return (false);
@@ -3419,6 +3426,13 @@ cups_enum_dests(
 
         if ((device->type & mask) != type)
           device->state = _CUPS_DNSSD_INCOMPATIBLE;
+          
+        if (device->state == _CUPS_DNSSD_INCOMPATIBLE)
+        {
+          DEBUG_printf("2cups_enum_dests: Skipping incompatible '%s'.",
+                       device->fullname);
+          continue;
+        }  
 
         if (device->state == _CUPS_DNSSD_PENDING)
         {


### PR DESCRIPTION
This PR replaces #1586 with the same change, recommitted with a signed commit as requested, to resolve the "Commits must have verified signatures" merge requirement. Fixes #1531.