### PR TITLE
mask request bytes before ctype calls in client.c

### DIFF
--- a/scheduler/client.c
+++ b/scheduler/client.c
@@ -761,7 +761,7 @@ cupsdReadClient(cupsd_client_t *con)	/* I - Client to read from */
 	      _cups_strcasecmp(hostname, ServerName) &&
 	      _cups_strcasecmp(hostname, "localhost") &&
 	      !cupsArrayFind(ServerAlias, hostname) &&
-	      !isdigit(hostname[0]) && hostname[0] != '[')
+	      !isdigit(hostname[0] & 255) && hostname[0] != '[')
 	  {
 	   /*
 	    * Nope, we don't do proxies...
@@ -2683,7 +2683,7 @@ check_if_modified(
 
   while (*ptr != '\0')
   {
-    while (isspace(*ptr) || *ptr == ';')
+    while (isspace(*ptr & 255) || *ptr == ';')
       ptr ++;
 
     if (_cups_strncasecmp(ptr, "length=", 7) == 0)
@@ -2691,10 +2691,10 @@ check_if_modified(
       ptr += 7;
       size = strtoll(ptr, NULL, 10);
 
-      while (isdigit(*ptr))
+      while (isdigit(*ptr & 255))
         ptr ++;
     }
-    else if (isalpha(*ptr))
+    else if (isalpha(*ptr & 255))
     {
       date = httpGetDateTime(ptr);
       while (*ptr != '\0' && *ptr != ';')


### PR DESCRIPTION
ASan, modelling a ctype lookup that indexes its 256-entry table by the raw argument:

    ctype_demo.c:12: ERROR: AddressSanitizer: BUS, READ memory access
        #0 main ctype_demo.c:12   // table[c] with c == -128

Spotted while reading the request path. The host parsed from the request URI and the If-Modified-Since header value both reach ctype calls on a bare char. char is signed here, so a request byte of 0x80 or above arrives as a negative int, which isdigit/isspace/isalpha must not be given. The rest of this file already masks with & 255 (see lines 2476 and 3755); these four sites were missed. The two tolower calls a bit further down are already safe, since they run only after an isxdigit check on the same byte.