### PR TITLE
fix out-of-bounds write in cups_collection_string

### DIFF
--- a/cups/dest-options.c
+++ b/cups/dest-options.c
@@ -2161,7 +2161,11 @@ cups_collection_string(
       bufptr ++;
   }
 
-  *bufptr = '\0';
+  if (bufptr < bufend)
+    *bufptr = '\0';
+  else if (bufsize > 0)
+    *bufend = '\0';
+
   return ((size_t)(bufptr - buffer + 1));
 }
 


### PR DESCRIPTION
AddressSanitizer, exercising cupsCopyDestConflicts() against a printer that answers Get-Printer-Attributes with an oversized media-col-default:

    ==51104==ERROR: AddressSanitizer: stack-buffer-overflow
    WRITE of size 1 at 0x00016b159fa7 thread T0
        #0 cups_collection_string dest-options.c:2164
        #1 main repro.c
      [240, 2288) 'buffer' (line 36) <== Memory access at offset 2343 overflows this variable

cups_collection_string() advances bufptr even when there is no room, so it can report the length needed, but the closing *bufptr = '\0' is the one write that never checks bufend. cups_create_defaults() calls it with a 2048-byte stack buffer for every *-default collection attribute, and those attributes come straight off the wire through cupsCopyDestInfo2(). A printer returning a collection that serialises past 2048 bytes therefore drops a nul a content-controlled distance past the buffer. The length check in the caller only runs after the write.

ippAttributeString() guards the same terminator already. This matches it, and keeps the bufsize==0 sub-collection call at line 2005 safe.