### PR TITLE
Add PWG media sizes for PRC D0-D6 and PRC ZL

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,8 @@ v2.5b1 - YYYY-MM-DD
   (Issue #1282)
 - Added an "install" sub-command to the `cups-x509` command (Issue #1227)
 - Added a "--user-agent" option to the `ipptool` command.
+- Added new PWG media sizes (PRC D0-D6, ZL) and moved several Japanese media
+  sizes from the Chinese block to the Japanese block.
 - Updated documentation (Issue #984, Issue #1086, Issue #1182)
 - Updated translations (Issue #1146, Issue #1161, Issue #1164, Issue #1535)
 - Updated the configure script to default to installing to /usr/local.

--- a/cups/pwg-media.c
+++ b/cups/pwg-media.c
@@ -201,6 +201,9 @@ static pwg_media_t const cups_pwg_media[] =
   _PWG_MEDIA_MM("jpn_chou40_90x225mm", NULL, "EnvChou40", 90, 225),
   _PWG_MEDIA_MM("jpn_oufuku_148x200mm", NULL, "DoublePostcardRotated", 148, 200),
   _PWG_MEDIA_MM("jpn_kahu_240x322.1mm", NULL, "240x322mm", 240, 322.1),
+  _PWG_MEDIA_MM("om_juuro-ku-kai_198x275mm", NULL, "198x275mm", 198, 275),
+  _PWG_MEDIA_MM("om_pa-kai_267x389mm", NULL, "267x389mm", 267, 389),
+  _PWG_MEDIA_MM("om_dai-pa-kai_275x395mm", NULL, "275x395mm", 275, 395),
 
   /* Chinese Standard Sheet Media Sizes */
   _PWG_MEDIA_MM("prc_32k_97x151mm", NULL, "PRC32K", 97, 151),
@@ -214,9 +217,14 @@ static pwg_media_t const cups_pwg_media[] =
   /* prc_10 is iso_c3_324x458mm. */
   _PWG_MEDIA_MM("prc_16k_146x215mm", NULL, "PRC16K", 146, 215),
   _PWG_MEDIA_MM("prc_7_160x230mm", NULL, "EnvPRC7", 160, 230),
-  _PWG_MEDIA_MM("om_juuro-ku-kai_198x275mm", NULL, "198x275mm", 198, 275),
-  _PWG_MEDIA_MM("om_pa-kai_267x389mm", NULL, "267x389mm", 267, 389),
-  _PWG_MEDIA_MM("om_dai-pa-kai_275x395mm", NULL, "275x395mm", 275, 395),
+  _PWG_MEDIA_MM("prc_d0_764x1064mm", NULL, "PRCD0", 764, 1064),
+  _PWG_MEDIA_MM("prc_d1_532x760mm", NULL, "PRCD1", 532, 760),
+  _PWG_MEDIA_MM("prc_d2_380x528mm", NULL, "PRCD2", 380, 528),
+  _PWG_MEDIA_MM("prc_d3_264x376mm", NULL, "PRCD3", 264, 376),
+  _PWG_MEDIA_MM("prc_d4_188x260mm", NULL, "PRCD4", 188, 260),
+  _PWG_MEDIA_MM("prc_d5_130x184mm", NULL, "PRCD5", 130, 184),
+  _PWG_MEDIA_MM("prc_d6_92x126mm", NULL, "PRCD6", 92, 126),
+  _PWG_MEDIA_MM("prc_zl_120x230mm", NULL, "PRCZL", 120, 230),
 
   /* Chinese Standard Sheet Media Inch Sizes */
   _PWG_MEDIA_IN("roc_16k_7.75x10.75in", NULL, "roc16k", 7.75, 10.75),


### PR DESCRIPTION
This pull request adds PWG media sizes for PRC D0-D6 and PRC ZL and moves the Japanese media sizes from the Chinese block to the Japanese block.

References:

- GB/T 148-2026 standard text: https://openstd.samr.gov.cn/bzgk/std/newGbInfo?hcno=EB3ABA24014A3C55ED4BF88B0BB8DD22 (Chinese, pay-walled)
- GB/T 1416-2021 standard text: http://c.gb688.cn/bzgk/gb/showGb?type=online&hcno=DE308FCC68F31C0B7C6F169AA5BFA593 (Chinese, free PDF download)
- PWG errata: https://www.pwg.org/dynamo/issues.php?L140+P-1+S-2+I0+E0+Z81+Q
- `libpaper` pull request: https://github.com/rrthomas/libpaper/pull/64