### PR TITLE
stop response skip loop at nul in commandtops

### DIFF
--- a/filter/commandtops.c
+++ b/filter/commandtops.c
@@ -318,7 +318,7 @@ auto_configure(ppd_file_t *ppd,		/* I - PPD file */
 	else
 	  break;
 
-      for (bufptr = buffer; isspace(*bufptr & 255) || iscntrl(*bufptr & 255);
+      for (bufptr = buffer; *bufptr && (isspace(*bufptr & 255) || iscntrl(*bufptr & 255));
 	   bufptr ++);
 
       if (bufptr > buffer)


### PR DESCRIPTION
Chasing an ASan abort while feeding a fake back-channel to the commandtops filter:

    READ of size 1 at 0x6020000000d4 thread T0
        #0 process commandtops.c:321
    0x6020000000d4 is located 0 bytes after ... region

The filter reads an option query response from the printer with cupsBackChannelRead(), trims trailing whitespace/control, then skips leading whitespace/control:

    for (bufptr = buffer; isspace(*bufptr & 255) || iscntrl(*bufptr & 255); bufptr ++);

iscntrl() is true for the nul byte, so the skip loop walks straight past the string terminator. A device that answers with an all-whitespace line ending in CR/LF (a bare "\n" is enough) reaches here after the trailing trim has zeroed the whole buffer, and the loop then runs off the end of the data. The runaway pointer is handed to _cups_strcpy(buffer, bufptr), so the out-of-bounds read turns into a copy from past the buffer.

The trailing-trim loop above already guards with bufptr >= buffer; the forward loop just needs the matching terminator check.