### PR TITLE
fix out-of-bounds read in cupsSignCredentialsRequest

### DIFF
--- a/cups/tls-openssl.c
+++ b/cups/tls-openssl.c
@@ -1240,7 +1240,7 @@ cupsSignCredentialsRequest(
 
           for (purpose = 0, j = 4; j < datalen; j += data[j + 1] + 2)
           {
-            if (data[j] != 0x06 || data[j + 1] != 8 || memcmp(data + j + 2, "+\006\001\005\005\007\003", 7))
+            if ((j + 2) > datalen || (j + 2 + data[j + 1]) > datalen || data[j] != 0x06 || data[j + 1] != 8 || memcmp(data + j + 2, "+\006\001\005\005\007\003", 7))
             {
 	      _cupsSetError(IPP_STATUS_ERROR_INTERNAL, _("Bad keyUsage extension in X.509 certificate request."), 1);
 	      goto done;
@@ -1331,8 +1331,12 @@ cupsSignCredentialsRequest(
           }
 
           // Parse the SAN values (there should be an easier/standard OpenSSL API to do this!)
-          for (j = 4, datalen -= 2; j < datalen; j += data[j + 1] + 2)
+          for (j = 4; j < datalen; j += data[j + 1] + 2)
           {
+            // Stop if the element header or value runs past the extension data...
+            if ((j + 2) > datalen || (j + 2 + data[j + 1]) > datalen)
+              break;
+
             if (data[j] == 0x82 && data[j + 1])
             {
               // GENERAL_STRING for DNS


### PR DESCRIPTION
ASan, cups-x509 signing a hand-crafted CSR:

    ==ERROR: AddressSanitizer: heap-buffer-overflow, READ of size 200
        #1 cupsSignCredentialsRequest tls-openssl.c:1339
        #2 do_ca cups-x509.c:483
    0 bytes after an 8-byte region allocated at tls-openssl.c:1218 (i2d)

The subjectAltName parser walks the DER TLV elements with `j += data[j + 1] + 2`
and only checks `j < datalen`. data[j + 1] is an attacker byte, so an element
whose declared length overruns the extension makes the memcpy read past the i2d
buffer. OpenSSL keeps the SAN value as an opaque octet string, so a CSR can carry
a SEQUENCE whose [2] element claims 200 bytes but supplies 2.

Same defect in the extKeyUsage loop above: for a truncated final element the
memcmp and data[j + 9] read off the end (ASan: READ of size 7 at :1243).

Both loops now bound the element header and value against datalen before reading.
A valid CSR still signs unchanged; the crafted ones are rejected cleanly. Reached
from any signing/CA path, e.g. `cups-x509 ca -R`.
