### PR TITLE
fix out-of-bounds write stripping section comments in help_load_file

### DIFF
--- a/cgi-bin/help-index.c
+++ b/cgi-bin/help-index.c
@@ -887,10 +887,9 @@ help_load_file(
         * Strip comment stuff from end of line...
 	*/
 
-        for (*ptr-- = '\0'; ptr > line && isspace(*ptr & 255); *ptr-- = '\0');
-
-	if (isspace(*ptr & 255))
-	  *ptr = '\0';
+        *ptr = '\0';
+        while (ptr > section && isspace(ptr[-1] & 255))
+          *--ptr = '\0';
       }
       continue;
     }


### PR DESCRIPTION
Isolated the `<!-- SECTION: -->` parsing from `help_load_file()` under ASan and fed it a comment with no text:

    help-index.c: AddressSanitizer: stack-buffer-overflow
    READ of size 1 ... offset 1183 ... underflows this variable 'section'

Tracked it down from there. `ptr` indexes into `section` after the `cupsCopyString(section, ...)`, but the trailing-strip loop guards the walk with `ptr > line`. `line` and `section` are separate stack buffers, so that test never bounds `ptr` inside `section`.

A section that is empty or all-whitespace up to `-->` (e.g. `<!-- SECTION:-->`) puts `ptr` at `section[0]`. The guard against `line` then lets the loop decrement past the start of `section`, writing `\0` over the adjacent stack, and the following `isspace(*ptr & 255)` reads out of bounds too.

Bound the walk to `section` and drop the stray trailing test. Valid section comments strip the same as before.
