### PR TITLE
fix out-of-bounds read in rastertolabel delta-row compare

### DIFF
--- a/filter/rastertolabel.c
+++ b/filter/rastertolabel.c
@@ -953,8 +953,8 @@ PCLCompress(unsigned char *line,	/* I - Line to compress */
       * The seed buffer is valid, so compare against it...
       */
 
-      while (*line_ptr == *seed &&
-             line_ptr < line_end)
+      while (line_ptr < line_end &&
+             *line_ptr == *seed)
       {
         line_ptr ++;
         seed ++;
@@ -971,8 +971,8 @@ PCLCompress(unsigned char *line,	/* I - Line to compress */
 
       start = line_ptr;
       count = 0;
-      while (*line_ptr != *seed &&
-             line_ptr < line_end &&
+      while (line_ptr < line_end &&
+             *line_ptr != *seed &&
              count < 8)
       {
         line_ptr ++;


### PR DESCRIPTION
Building rastertolabel under ASan and pushing two identical non-blank raster lines to an INTELLITECH_PCL queue:

    ERROR: AddressSanitizer: heap-buffer-overflow
    READ of size 1 at ... thread T0
        #0 PCLCompress rastertolabel.c:956
    0 bytes after 16-byte region allocated by malloc (cupsBytesPerLine)

PCLCompress delta-row compresses each line against the previous one in `LastBuffer`. `Buffer` and `LastBuffer` are both `malloc(cupsBytesPerLine)`. The two compare loops read `*line_ptr`/`*seed` first and test `line_ptr < line_end` second, so a run that reaches the end of the line re-reads one byte past both allocations before the loop exits. It fires whenever consecutive lines share a trailing run, not only on wholly identical lines, so most multi-line pages hit it.

Reordered both conditions to bound-check before the dereference. Valid input compresses to the same bytes.