### PR TITLE
scheduler: Fix typo in have_source check preventing default trays

### DIFF
--- a/scheduler/job.c
+++ b/scheduler/job.c
@@ -3787,7 +3787,7 @@ get_options(cupsd_job_t *job,		/* I - Job */
     }
 
     have_size   = ippFindAttribute(job->attrs, "PageRegion", IPP_TAG_ZERO) != NULL || ippFindAttribute(job->attrs, "PageSize", IPP_TAG_ZERO) != NULL;
-    have_source = ippFindAttribute(job->attrs, "InputSlot", IPP_TAG_ZERO) != NULL || ippFindAttribute(job->attrs, "HPPaperSource", IPP_TAG_ZERO) == NULL;
+    have_source = ippFindAttribute(job->attrs, "InputSlot", IPP_TAG_ZERO) != NULL || ippFindAttribute(job->attrs, "HPPaperSource", IPP_TAG_ZERO) !== NULL;
     have_type   = ippFindAttribute(job->attrs, "MediaType", IPP_TAG_ZERO) != NULL;
 
     if (banner_page && (attr = ippFindAttribute(job->attrs, "job-sheets-col", IPP_TAG_BEGIN_COLLECTION)) != NULL)

--- a/scheduler/job.c
+++ b/scheduler/job.c
@@ -3787,7 +3787,7 @@ get_options(cupsd_job_t *job,		/* I - Job */
     }
 
     have_size   = ippFindAttribute(job->attrs, "PageRegion", IPP_TAG_ZERO) != NULL || ippFindAttribute(job->attrs, "PageSize", IPP_TAG_ZERO) != NULL;
-    have_source = ippFindAttribute(job->attrs, "InputSlot", IPP_TAG_ZERO) != NULL || ippFindAttribute(job->attrs, "HPPaperSource", IPP_TAG_ZERO) !== NULL;
+    have_source = ippFindAttribute(job->attrs, "InputSlot", IPP_TAG_ZERO) != NULL || ippFindAttribute(job->attrs, "HPPaperSource", IPP_TAG_ZERO) != NULL;
     have_type   = ippFindAttribute(job->attrs, "MediaType", IPP_TAG_ZERO) != NULL;
 
     if (banner_page && (attr = ippFindAttribute(job->attrs, "job-sheets-col", IPP_TAG_BEGIN_COLLECTION)) != NULL)


### PR DESCRIPTION
In commit 074526b0, the logic for checking whether a job already specified a paper source was refactored into the `have_source` boolean. However, the De Morgan's inversion for the `HPPaperSource` attribute was accidentally written as `== NULL` instead of `!= NULL`.

This caused `have_source` to erroneously evaluate to `true` for almost all print jobs (since normal jobs never include the proprietary `HPPaperSource` attribute). As a result, the scheduler assumed the client had explicitly requested a tray, causing it to skip mapping the queue's `DefaultInputSlot` into the outgoing job options.

This commit corrects the operator so that `have_source` correctly evaluates to `false` when no tray is specified, allowing IPP Everywhere printers to successfully receive their default tray assignments.

Fixes #1636