### PR TITLE
fix BitBuffer overflow in rastertohp OutputLine deinterleave

### DIFF
--- a/filter/rastertohp.c
+++ b/filter/rastertohp.c
@@ -538,7 +538,7 @@ OutputLine(cups_page_header2_t *header)	/* I - Page header */
 
       for (count = header->cupsBytesPerLine / NumPlanes,
                plane_ptr = Planes[plane], bit_ptr = BitBuffer;
-	   count > 0;
+	   count > 0 && bit_ptr < (BitBuffer + bytes);
 	   count -= 2, plane_ptr += 2, bit_ptr ++)
       {
         bit = plane_ptr[0];


### PR DESCRIPTION
ASan, feeding a crafted `application/vnd.cups-raster` page to a queue that uses an HP PCL PPD:

    ERROR: AddressSanitizer: heap-buffer-overflow WRITE of size 1
      #0 OutputLine rastertohp.c:558
      #1 main rastertohp.c:727
    0x... is located 0 bytes after 800-byte region
      #1 StartPage rastertohp.c:338

I was tracing the deep-colour (`cupsBitsPerColor > 1`) branch of `OutputLine`. `StartPage` sizes `BitBuffer` as `ColorBits * (cupsWidth + 7) / 8`, but the deinterleave loop runs `count = cupsBytesPerLine / NumPlanes` times and writes `bit_ptr[0]` and `bit_ptr[bytes]`. `NumPlanes` is 1 for any colourspace that is not CMY or KCMY, so an RGB or CMYK header (its `cupsNumColors` already folded into `cupsBytesPerLine`) makes `count` several times larger than the two `bytes`-wide sub-planes the buffer holds, and `bit_ptr[bytes]` runs past the allocation. The page above is 800px, 8-bit, RGB.

Same loop, second way in: `count` is unsigned and the loop only stops on `count > 0` with `count -= 2`, so an odd `cupsBytesPerLine / NumPlanes` (e.g. a 12px 2-bit black line where `cupsBytesPerLine` is 3) underflows to ~2^31 and it keeps writing off the heap.

Both reduce to the loop overrunning the two sub-planes, so I bounded `bit_ptr` to `BitBuffer + bytes`. Valid input where `count` is exactly `2 * bytes` reaches the bound just as `count` hits 0, so nothing changes there; I diffed a 2-bit page before and after and the output is byte-identical.
