### PR TITLE
Only ignore specific options when specified in media=

### DIFF
--- a/cups/ppd-mark.c
+++ b/cups/ppd-mark.c
@@ -76,9 +76,9 @@ cupsMarkOptions(
   * print-color-mode, print-quality, and PageSize...
   */
 
-  int		media_pagesize = 0,	/* Did media= set PageSize? */
-		media_source = 0,	/* Did media= set InputSlot? */
-		media_type = 0;		/* Did media= set MediaType? */
+  int		set_pagesize = 0,	/* Did media= set PageSize? */
+		set_source = 0,	/* Did media= set InputSlot? */
+		set_type = 0;		/* Did media= set MediaType? */
 
   media         = cupsGetOption("media", num_options, options);
   page_size     = cupsGetOption("PageSize", num_options, options);
@@ -134,24 +134,24 @@ cupsMarkOptions(
       if (!_cups_strncasecmp(s, "Custom.", 7) && ppdPageSize(ppd, s))
       {
 	ppd_mark_option(ppd, "PageSize", s);
-	media_pagesize = 1;
+	set_pagesize = 1;
       }
       else if ((ppd_keyword = _ppdCacheGetPageSize(cache, NULL, s, NULL)) != NULL)
       {
 	ppd_mark_option(ppd, "PageSize", ppd_keyword);
-	media_pagesize = 1;
+	set_pagesize = 1;
       }
 
       if (cache && cache->source_option && (ppd_keyword = _ppdCacheGetInputSlot(cache, NULL, s)) != NULL)
       {
 	ppd_mark_option(ppd, cache->source_option, ppd_keyword);
-	media_source = 1;
+	set_source = 1;
       }
 
       if ((ppd_keyword = _ppdCacheGetMediaType(cache, NULL, s)) != NULL)
       {
 	ppd_mark_option(ppd, "MediaType", ppd_keyword);
-	media_type = 1;
+	set_type = 1;
       }
     }
   }
@@ -343,9 +343,9 @@ cupsMarkOptions(
     }
     else if (!_cups_strcasecmp(optptr->name, "mirror"))
       ppd_mark_option(ppd, "MirrorPrint", optptr->value);
-    else if ((!media_pagesize || (_cups_strcasecmp(optptr->name, "PageSize") && _cups_strcasecmp(optptr->name, "PageRegion"))) &&
-             (!media_source || _cups_strcasecmp(optptr->name, (cache && cache->source_option) ? cache->source_option : "InputSlot")) &&
-             (!media_type || _cups_strcasecmp(optptr->name, "MediaType")))
+    else if ((!set_pagesize || (_cups_strcasecmp(optptr->name, "PageSize") && _cups_strcasecmp(optptr->name, "PageRegion"))) &&
+             (!set_source || _cups_strcasecmp(optptr->name, (cache && cache->source_option) ? cache->source_option : "InputSlot")) &&
+             (!set_type || _cups_strcasecmp(optptr->name, "MediaType")))
       ppd_mark_option(ppd, optptr->name, optptr->value);
   }
 

--- a/cups/ppd-mark.c
+++ b/cups/ppd-mark.c
@@ -76,6 +76,10 @@ cupsMarkOptions(
   * print-color-mode, print-quality, and PageSize...
   */
 
+  int		media_pagesize = 0,	/* Did media= set PageSize? */
+		media_source = 0,	/* Did media= set InputSlot? */
+		media_type = 0;		/* Did media= set MediaType? */
+
   media         = cupsGetOption("media", num_options, options);
   page_size     = cupsGetOption("PageSize", num_options, options);
   output_bin    = cupsGetOption("output-bin", num_options, options);
@@ -128,15 +132,27 @@ cupsMarkOptions(
       */
 
       if (!_cups_strncasecmp(s, "Custom.", 7) && ppdPageSize(ppd, s))
+      {
 	ppd_mark_option(ppd, "PageSize", s);
+	media_pagesize = 1;
+      }
       else if ((ppd_keyword = _ppdCacheGetPageSize(cache, NULL, s, NULL)) != NULL)
+      {
 	ppd_mark_option(ppd, "PageSize", ppd_keyword);
+	media_pagesize = 1;
+      }
 
       if (cache && cache->source_option && (ppd_keyword = _ppdCacheGetInputSlot(cache, NULL, s)) != NULL)
+      {
 	ppd_mark_option(ppd, cache->source_option, ppd_keyword);
+	media_source = 1;
+      }
 
       if ((ppd_keyword = _ppdCacheGetMediaType(cache, NULL, s)) != NULL)
+      {
 	ppd_mark_option(ppd, "MediaType", ppd_keyword);
+	media_type = 1;
+      }
     }
   }
 
@@ -327,7 +343,9 @@ cupsMarkOptions(
     }
     else if (!_cups_strcasecmp(optptr->name, "mirror"))
       ppd_mark_option(ppd, "MirrorPrint", optptr->value);
-    else if (!media || (_cups_strcasecmp(optptr->name, (cache && cache->source_option) ? cache->source_option : "InputSlot") && _cups_strcasecmp(optptr->name, "MediaType") && _cups_strcasecmp(optptr->name, "PageRegion") && _cups_strcasecmp(optptr->name, "PageSize")))
+    else if ((!media_pagesize || (_cups_strcasecmp(optptr->name, "PageSize") && _cups_strcasecmp(optptr->name, "PageRegion"))) &&
+             (!media_source || _cups_strcasecmp(optptr->name, (cache && cache->source_option) ? cache->source_option : "InputSlot")) &&
+             (!media_type || _cups_strcasecmp(optptr->name, "MediaType")))
       ppd_mark_option(ppd, optptr->name, optptr->value);
   }
 

--- a/cups/testppd.c
+++ b/cups/testppd.c
@@ -309,6 +309,7 @@ main(int  argc,				/* I - Number of command-line arguments */
 		maxsize,		/* Maximum size */
 		*size;			/* Current size */
   ppd_attr_t	*attr;			/* Current attribute */
+  ppd_choice_t 	*choice;		/* Current choice */
   _ppd_cache_t	*pc;			/* PPD cache */
 
 
@@ -625,6 +626,88 @@ main(int  argc,				/* I - Number of command-line arguments */
     if (!size || strcmp(size->name, "A4"))
     {
       printf("FAIL (%s)\n", size ? size->name : "unknown");
+      status ++;
+    }
+    else
+      puts("PASS");
+
+    ppdMarkDefaults(ppd);
+    fputs("cupsMarkOptions(media=A4, InputSlot=Envelope): ", stdout);
+    num_options = cupsAddOption("media", "A4", 0, &options);
+    num_options = cupsAddOption("InputSlot", "Envelope", num_options, &options);
+    cupsMarkOptions(ppd, num_options, options);
+    cupsFreeOptions(num_options, options);
+
+    choice = ppdFindMarkedChoice(ppd, "InputSlot");
+    if (!choice || strcmp(choice->choice, "Envelope"))
+    {
+      printf("FAIL (%s)\n", choice ? choice->choice : "unknown");
+      status ++;
+    }
+    else
+      puts("PASS");
+
+    ppdMarkDefaults(ppd);
+    fputs("cupsMarkOptions(media=envelope, InputSlot=Tray): ", stdout);
+    num_options = cupsAddOption("media", "envelope", 0, &options);
+    num_options = cupsAddOption("InputSlot", "Tray", num_options, &options);
+    cupsMarkOptions(ppd, num_options, options);
+    cupsFreeOptions(num_options, options);
+
+    choice = ppdFindMarkedChoice(ppd, "InputSlot");
+    if (!choice || strcmp(choice->choice, "Envelope"))
+    {
+      printf("FAIL (%s)\n", choice ? choice->choice : "unknown");
+      status ++;
+    }
+    else
+      puts("PASS");
+
+    ppdMarkDefaults(ppd);
+    fputs("cupsMarkOptions(media=A4, PageSize=Letter): ", stdout);
+    num_options = cupsAddOption("media", "A4", 0, &options);
+    num_options = cupsAddOption("PageSize", "Letter", num_options, &options);
+    cupsMarkOptions(ppd, num_options, options);
+    cupsFreeOptions(num_options, options);
+
+    size = ppdPageSize(ppd, NULL);
+    if (!size || strcmp(size->name, "A4"))
+    {
+      printf("FAIL (%s)\n", size ? size->name : "unknown");
+      status ++;
+    }
+    else
+      puts("PASS");
+
+    ppdMarkDefaults(ppd);
+    fputs("cupsMarkOptions(media=A4, PageSize=bogus): ", stdout);
+    num_options = cupsAddOption("media", "A4", 0, &options);
+    num_options = cupsAddOption("PageSize", "bogus", num_options, &options);
+    cupsMarkOptions(ppd, num_options, options);
+    cupsFreeOptions(num_options, options);
+
+    size = ppdPageSize(ppd, NULL);
+    if (!size || strcmp(size->name, "A4"))
+    {
+      printf("FAIL (%s)\n", size ? size->name : "unknown");
+      status ++;
+    }
+    else
+      puts("PASS");
+
+    ppdMarkDefaults(ppd);
+    fputs("cupsMarkOptions(media=A4,envelope, PageSize=Letter, InputSlot=Tray): ", stdout);
+    num_options = cupsAddOption("media", "A4,envelope", 0, &options);
+    num_options = cupsAddOption("PageSize", "Letter", num_options, &options);
+    num_options = cupsAddOption("InputSlot", "Tray", num_options, &options);
+    cupsMarkOptions(ppd, num_options, options);
+    cupsFreeOptions(num_options, options);
+
+    size   = ppdPageSize(ppd, NULL);
+    choice = ppdFindMarkedChoice(ppd, "InputSlot");
+    if (!size || strcmp(size->name, "A4") || !choice || strcmp(choice->choice, "Envelope"))
+    {
+      printf("FAIL (%s / %s)\n", size ? size->name : "unknown", choice ? choice->choice : "unknown");
       status ++;
     }
     else


### PR DESCRIPTION
If media specifies only the PageSize, we still want to allow an InputSlot PPD option to be used.

Similarly for PageRegion and MediaType.

Previously, if media= was specified, all PPD options for PageSize, PageRegion, InputSlot, and MediaType were ignored even if they were not specified in the media= IPP attriubte.