### PR TITLE
check X509_NAME_get_text_by_NID return in credential name checks

### DIFF
--- a/cups/tls-openssl.c
+++ b/cups/tls-openssl.c
@@ -98,7 +98,8 @@ cupsAreCredentialsValidForName(
 
     DEBUG_printf("1cupsAreCredentialsValidForName: certs=%p(num=%d), cert=%p", (void *)certs, sk_X509_num(certs), (void *)cert);
 
-    X509_NAME_get_text_by_NID(X509_get_subject_name(cert), NID_commonName, subjectName, sizeof(subjectName));
+    if (X509_NAME_get_text_by_NID(X509_get_subject_name(cert), NID_commonName, subjectName, sizeof(subjectName)) < 0)
+      cupsCopyString(subjectName, "unknown", sizeof(subjectName));
     DEBUG_printf("1cupsAreCredentialsValidForName: subjectName=\"%s\"", subjectName);
 
     if (!_cups_strcasecmp(common_name, subjectName))
@@ -109,7 +110,8 @@ cupsAreCredentialsValidForName(
 
 #ifdef DEBUG
     char issuerName[256];
-    X509_NAME_get_text_by_NID(X509_get_issuer_name(cert), NID_commonName, issuerName, sizeof(issuerName));
+    if (X509_NAME_get_text_by_NID(X509_get_issuer_name(cert), NID_commonName, issuerName, sizeof(issuerName)) < 0)
+      cupsCopyString(issuerName, "unknown", sizeof(issuerName));
     DEBUG_printf("1cupsAreCredentialsValidForName: issuerName=\"%s\"", issuerName);
 #endif // DEBUG
 
@@ -799,8 +801,10 @@ cupsGetCredentialsInfo(
 
     cert = sk_X509_value(certs, 0);
 
-    X509_NAME_get_text_by_NID(X509_get_subject_name(cert), NID_commonName, name, sizeof(name));
-    X509_NAME_get_text_by_NID(X509_get_issuer_name(cert), NID_commonName, issuer, sizeof(issuer));
+    if (X509_NAME_get_text_by_NID(X509_get_subject_name(cert), NID_commonName, name, sizeof(name)) < 0)
+      cupsCopyString(name, "unknown", sizeof(name));
+    if (X509_NAME_get_text_by_NID(X509_get_issuer_name(cert), NID_commonName, issuer, sizeof(issuer)) < 0)
+      cupsCopyString(issuer, "unknown", sizeof(issuer));
     expiration = openssl_get_date(cert, 1);
 
     switch (X509_get_signature_nid(cert))
@@ -1506,8 +1510,10 @@ httpCopyPeerCredentials(http_t *http)	// I - Connection to server
 
 #ifdef DEBUG
 	char subjectName[256], issuerName[256];
-	X509_NAME_get_text_by_NID(X509_get_subject_name(cert), NID_commonName, subjectName, sizeof(subjectName));
-	X509_NAME_get_text_by_NID(X509_get_issuer_name(cert), NID_commonName, issuerName, sizeof(issuerName));
+	if (X509_NAME_get_text_by_NID(X509_get_subject_name(cert), NID_commonName, subjectName, sizeof(subjectName)) < 0)
+	  cupsCopyString(subjectName, "unknown", sizeof(subjectName));
+	if (X509_NAME_get_text_by_NID(X509_get_issuer_name(cert), NID_commonName, issuerName, sizeof(issuerName)) < 0)
+	  cupsCopyString(issuerName, "unknown", sizeof(issuerName));
 	DEBUG_printf("1httpCopyPeerCredentials: subjectName=\"%s\", issuerName=\"%s\"", subjectName, issuerName);
 
 	STACK_OF(GENERAL_NAME) *names;	// subjectAltName values


### PR DESCRIPTION
X509_NAME_get_text_by_NID() returns -1 and leaves its output buffer untouched when the requested NID is absent. A certificate with no commonName (SAN-only, normal for modern certs) takes that path, and the openssl backend uses the buffer regardless:

    char subjectName[256];
    X509_NAME_get_text_by_NID(..., NID_commonName, subjectName, sizeof(subjectName));  // -1, subjectName untouched
    ...
    _cups_strcasecmp(common_name, subjectName)   // reads uninitialised stack

Found while reading the trust path. cupsGetCredentialsTrust() (the https client certificate check reached from http.c) hands an untrusted server certificate to both cupsAreCredentialsValidForName() and cupsGetCredentialsInfo(), so for a CN-less certificate the name comparison and the "%s (issued by %s)" description both run on uninitialised name[256]/issuer[256]. The snprintf %s then scans past the 256-byte buffer into adjacent stack, so it is an out-of-bounds read and a stack disclosure, and the name check comes out depending on stack residue. With a self-signed no-CN certificate I could get cupsAreCredentialsValidForName() to return true for an unrelated hostname.

The gnutls backend already falls back to "unknown" for the missing-CN case. This checks the return value and does the same at each X509_NAME_get_text_by_NID call in the file.
