### PR TITLE
Prevent deleting a printer that is in use

### DIFF
--- a/scheduler/ipp.c
+++ b/scheduler/ipp.c
@@ -2638,6 +2638,9 @@ add_printer(cupsd_client_t  *con,	/* I - Client connection */
 
       con->bg_pending = 1;
       con->bg_printer = printer;
+      cupsRWLockWrite(&printer->lock);
+      printer->use ++;
+      cupsRWUnlock(&printer->lock);
 
       cupsThreadCreate((cups_thread_func_t)create_local_bg_thread, con);
       return;
@@ -5471,6 +5474,11 @@ create_local_bg_thread(
 
   con->bg_pending = 0;
 
+  cupsRWLockWrite(&printer->lock);
+  if (printer->use > 0)
+    printer->use  --;
+  cupsRWUnlock(&printer->lock);
+
   return (NULL);
 }
 
@@ -5683,6 +5691,9 @@ create_local_printer(
 
   con->bg_pending = 1;
   con->bg_printer = printer;
+  cupsRWLockWrite(&printer->lock);
+  printer->use  ++;
+  cupsRWUnlock(&printer->lock);
 
   cupsThreadCreate((cups_thread_func_t)create_local_bg_thread, con);
 

--- a/scheduler/printers.c
+++ b/scheduler/printers.c
@@ -44,6 +44,7 @@ static void	delete_printer_filters(cupsd_printer_t *p);
 static void	dirty_printer(cupsd_printer_t *p);
 static void	load_ppd(cupsd_printer_t *p);
 static ipp_t	*new_media_col(pwg_size_t *size);
+static bool	printer_in_use_by_client(cupsd_printer_t *p);
 static void	write_xml_string(cups_file_t *fp, const char *s);
 
 
@@ -835,7 +836,7 @@ cupsdDeleteTemporaryPrinters(int force) /* I - Force deletion instead of auto? *
 
   for (p = (cupsd_printer_t *)cupsArrayFirst(Printers); p; p = (cupsd_printer_t *)cupsArrayNext(Printers))
   {
-    if (p->temporary &&
+    if (p->temporary && !printer_in_use_by_client(p) &&
 	(force || (p->state_time < unused_time && p->state != IPP_PSTATE_PROCESSING)))
       cupsdDeletePrinter(p, 0);
   }
@@ -5615,6 +5616,26 @@ new_media_col(pwg_size_t *size)		/* I - media-size/margin values */
   ippAddInteger(media_col, IPP_TAG_PRINTER, IPP_TAG_INTEGER, "media-top-margin", size->top);
 
   return (media_col);
+}
+
+
+/*
+ * 'printer_in_use_by_client()' - Determine whether a printer is currently in use by a background thread.
+ */
+
+static bool				/* O - true if in use, false otherwise */
+printer_in_use_by_client(
+    cupsd_printer_t *p)			/* I - Printer */
+{
+  cupsd_client_t *con;			/* Current client */
+
+  for (con = (cupsd_client_t *)cupsArrayFirst(Clients); con; con = (cupsd_client_t *)cupsArrayNext(Clients))
+  {
+    if (con->bg_pending && con->bg_printer == p)
+      return (true);
+  }
+
+  return (false);
 }
 
 

--- a/scheduler/printers.c
+++ b/scheduler/printers.c
@@ -44,7 +44,6 @@ static void	delete_printer_filters(cupsd_printer_t *p);
 static void	dirty_printer(cupsd_printer_t *p);
 static void	load_ppd(cupsd_printer_t *p);
 static ipp_t	*new_media_col(pwg_size_t *size);
-static bool	printer_in_use_by_client(cupsd_printer_t *p);
 static void	write_xml_string(cups_file_t *fp, const char *s);
 
 
@@ -836,7 +835,7 @@ cupsdDeleteTemporaryPrinters(int force) /* I - Force deletion instead of auto? *
 
   for (p = (cupsd_printer_t *)cupsArrayFirst(Printers); p; p = (cupsd_printer_t *)cupsArrayNext(Printers))
   {
-    if (p->temporary && !printer_in_use_by_client(p) &&
+    if (p->temporary && p->use == 0 &&
 	(force || (p->state_time < unused_time && p->state != IPP_PSTATE_PROCESSING)))
       cupsdDeletePrinter(p, 0);
   }
@@ -5616,26 +5615,6 @@ new_media_col(pwg_size_t *size)		/* I - media-size/margin values */
   ippAddInteger(media_col, IPP_TAG_PRINTER, IPP_TAG_INTEGER, "media-top-margin", size->top);
 
   return (media_col);
-}
-
-
-/*
- * 'printer_in_use_by_client()' - Determine whether a printer is currently in use by a background thread.
- */
-
-static bool				/* O - true if in use, false otherwise */
-printer_in_use_by_client(
-    cupsd_printer_t *p)			/* I - Printer */
-{
-  cupsd_client_t *con;			/* Current client */
-
-  for (con = (cupsd_client_t *)cupsArrayFirst(Clients); con; con = (cupsd_client_t *)cupsArrayNext(Clients))
-  {
-    if (con->bg_pending && con->bg_printer == p)
-      return (true);
-  }
-
-  return (false);
 }
 
 

--- a/scheduler/printers.h
+++ b/scheduler/printers.h
@@ -48,6 +48,7 @@ struct cupsd_printer_s
   cupsd_policy_t *op_policy_ptr;	/* Pointer to operation policy */
   int		shared;			/* Shared? */
   int		temporary;		/* Temporary queue? */
+  int		use;			/* Use count */
   int		accepting;		/* Accepting jobs? */
   int		holding_new_jobs;	/* Holding new jobs for printing? */
   int		in_implicit_class;	/* In an implicit class? */


### PR DESCRIPTION
If the thread create_local_bg_thread is currently using a printer but the printer takes longer than 300 seconds to respond, the printer will get deleted by cupsdDeleteTemporaryPrinters.  If the printer then responds, the background thread will be referencing an invalid pointer.

Add a helper method to check to see if any background thread is using a printer before deleting it.