### PR TITLE
fix heap overflow in ppdEmitString custom value buffer sizing

### DIFF
--- a/cups/ppd-emit.c
+++ b/cups/ppd-emit.c
@@ -667,7 +667,7 @@ ppdEmitString(ppd_file_t    *ppd,	/* I - PPD file record */
 	    case PPD_CUSTOM_POINTS :
 	    case PPD_CUSTOM_REAL :
 	    case PPD_CUSTOM_INT :
-	        bufsize += 10;
+	        bufsize += 54;		/* %.12f of a float + newline */
 	        break;
 
 	    case PPD_CUSTOM_PASSCODE :
@@ -691,7 +691,7 @@ ppdEmitString(ppd_file_t    *ppd,	/* I - PPD file record */
         DEBUG_puts("2ppdEmitString: Custom size set!");
 
         bufsize += 37;			/* %%BeginFeature: *CustomPageSize True\n */
-        bufsize += 50;			/* Five 9-digit numbers + newline */
+        bufsize += 270;			/* Five %.12f numbers + newline */
       }
       else if (!_cups_strcasecmp(choices[i]->choice, "Custom") &&
                (coption = ppdFindCustomOption(ppd,
@@ -716,7 +716,7 @@ ppdEmitString(ppd_file_t    *ppd,	/* I - PPD file record */
 	    case PPD_CUSTOM_POINTS :
 	    case PPD_CUSTOM_REAL :
 	    case PPD_CUSTOM_INT :
-	        bufsize += 10;
+	        bufsize += 54;		/* %.12f of a float + newline */
 	        break;
 
 	    case PPD_CUSTOM_PASSCODE :

--- a/cups/testppd.c
+++ b/cups/testppd.c
@@ -300,6 +300,7 @@ main(int  argc,				/* I - Number of command-line arguments */
   int		status;			/* Status of tests (0 = success, 1 = fail) */
   int		conflicts;		/* Number of conflicts */
   char		*s;			/* String */
+  size_t	slen;			/* Length of string */
   char		buffer[8192];		/* String buffer */
   const char	*text,			/* Localized text */
 		*val;			/* Option value */
@@ -447,6 +448,28 @@ main(int  argc,				/* I - Number of command-line arguments */
 
       if (s)
 	puts(s);
+    }
+
+    if (s)
+      free(s);
+
+    fputs("ppdEmitString (out-of-range custom size): ", stdout);
+    ppdMarkOption(ppd, "StringOption", "None");
+    ppdMarkOption(ppd, "PageSize",
+                  "Custom.340282346638528859811704183484516925440"
+		  "x340282346638528859811704183484516925440");
+
+    if ((s = ppdEmitString(ppd, PPD_ORDER_ANY, 0.0)) != NULL &&
+        (slen = strlen(s)) >= 22 &&
+	!strcmp(s + slen - 22, "} stopped cleartomark\n"))
+      puts("PASS");
+    else
+    {
+      status ++;
+      puts("FAIL (truncated)");
+
+      if (s)
+        puts(s);
     }
 
     if (s)


### PR DESCRIPTION
ASan, printing with `-o PageSize=Custom.340282346638528859811704183484516925440x340282346638528859811704183484516925440`:

    ==93781==ERROR: AddressSanitizer: heap-buffer-overflow
    WRITE of size 1 at 0x611000002cc9 thread T0
        #0 cupsCopyString string.c:105
        #1 ppdEmitString ppd-emit.c:1077
    0x611000002cc9 is located 0 bytes after 201-byte region [0x611000002c00,0x611000002cc9)

Came out of reading the sizing loop next to the emit loop. Sizing reserves 10 bytes per custom number and 50 for the five CustomPageSize numbers. Emission goes through `_cupsStrFormatd`, which formats `%.12f`, so a float takes up to 39 integer digits, 53 characters with sign and fraction. Nothing clamps the value first: `ppdPageSize` reads Custom.WIDTHxLENGTH straight out of the job option without checking custom_min/custom_max, and `ppd_mark_option` stores custom real/points/int parameters the same way.

Past the reservation bufptr runs beyond bufend, and the writes after the numbers carry no bound: the newline after each number, the memcpy of the choice code at :1070, and the `(size_t)(bufend - bufptr + 1)` length at :1077 that underflows to SIZE_MAX. A custom option with three real parameters is worse:

    WRITE of size 32 at 0x612000001dc3
        #0 memcpy
        #1 ppdEmitString ppd-emit.c:1070
    0x612000001dc3 is located 0 bytes after 259-byte region

The JCL branch undercounts the same way, but its emit loop is bounded, so there it only truncates. All three reservations now use the real `%.12f` width. No behaviour change for in-range values; the new testppd case fails on master and passes here.
