### PR TITLE
bound destination writes in win32_utf8cpy

### DIFF
--- a/cups/dnssd.c
+++ b/cups/dnssd.c
@@ -2606,10 +2606,11 @@ win32_utf8cpy(char        *dst,		// I - Destination string
 	      size_t      dstsize)	// I - Size of destination string
 {
   int	ch;				// Current character
+  char	*dstend = dst + dstsize - 5;	// End of destination string
 
 
   // Loop until we run out of characters or buffer space...
-  while (*src && dstsize > 4)
+  while (*src && dst <= dstend)
   {
     // Get the current character...
     ch = *src++;


### PR DESCRIPTION
Auditing the DNS-SD backends. `win32_utf8cpy` takes a `dstsize` but never touches it, so `while (*src && dstsize > 4)` is a one-time check that the buffer started out bigger than 4 bytes, not a running bound. The loop then stops only at the source nul.

Lifted the function out and gave it a 599-character name against a 256-byte buffer:

    ==52960==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x611000000140
    WRITE of size 1 at 0x611000000140 thread T0
        #0 0x0001008f4e10 in win32_utf8cpy dnssd.c:2625
    0x611000000140 is located 0 bytes after 256-byte region [0x611000000040,0x611000000140)

All six callers pass `char[256]` stack buffers holding strings that came off the wire. `win32_browse_cb` copies the PTR target of a browse reply into `fullname[256]`; `win32_resolve_cb` copies the instance name, the hostname, and every TXT key and value. A responder answering an `_ipp._tcp.local` browse with a long name walks straight past the buffer.

`win32_wstrcpy` directly below keeps its own counter, and `cupsDNSSDSeparateFullName` guards each store with `ptr < end`, so the shape was already there. Bounded each encoding branch against `dstend` the same way. In-range output is byte-identical and the full 255 bytes are still used.
