### PR TITLE
ippeveps: fix handle leak

### DIFF
--- a/tools/ippeveps.c
+++ b/tools/ippeveps.c
@@ -768,6 +768,9 @@ jpeg_to_ps(const char    *filename,	/* I - Filename */
     puts("grestore showpage");
   }
 
+  if (fd > 0)
+    close(fd);
+
   dsc_trailer(0);
 
   return (0);


### PR DESCRIPTION
In the 'jpeg_to_ps' function close the 'fd' handle by adding a missing 'fclose'.