### PR TITLE
fix stack underflow in ippAddStringfv/ippSetStringfv truncation

### DIFF
--- a/cups/ipp.c
+++ b/cups/ipp.c
@@ -1092,7 +1092,8 @@ ippAddStringfv(ipp_t      *ipp,		// I - IPP message
           bufptr --;
       }
 
-      bufptr --;
+      if (bufptr > buffer)
+        bufptr --;
     }
 
     *bufptr = '\0';
@@ -3434,7 +3435,8 @@ ippSetStringfv(ipp_t           *ipp,	// I  - IPP message
           bufptr --;
       }
 
-      bufptr --;
+      if (bufptr > buffer)
+        bufptr --;
     }
 
     *bufptr = '\0';

--- a/cups/testipp.c
+++ b/cups/testipp.c
@@ -893,6 +893,34 @@ main(int  argc,				// I - Number of command-line arguments
       testEnd(true);
     }
 
+    // Oversized values consisting only of UTF-8 continuation bytes must be
+    // truncated to a boundary without stepping below the format buffer...
+    testBegin("ippAddStringf(oversized continuation bytes)");
+    {
+      char	overlong[2 * IPP_MAX_NAME];
+      const char *str;			// Resulting value
+
+      memset(overlong, 0x80, sizeof(overlong) - 1);
+      overlong[sizeof(overlong) - 1] = '\0';
+
+      attr = ippAddStringf(request, IPP_TAG_OPERATION, IPP_TAG_NAME, "overlong-attr", /*lang*/NULL, "%s", overlong);
+
+      if (!attr)
+      {
+        testEndMessage(false, "Unable to create name attribute");
+        status = 1;
+      }
+      else if ((str = ippGetString(attr, 0, NULL)) == NULL || strlen(str) >= IPP_MAX_NAME)
+      {
+        testEndMessage(false, "value not truncated (%d bytes)", str ? (int)strlen(str) : -1);
+        status = 1;
+      }
+      else
+      {
+        testEnd(true);
+      }
+    }
+
     ippDelete(request);
 
 #ifdef DEBUG


### PR DESCRIPTION
Turned up while fuzzing the string constructors with malformed UTF-8.

AddressSanitizer, testipp calling `ippAddStringf()` with a value that is all `0x80` continuation bytes and a length-limited tag:

    ==ERROR: AddressSanitizer: stack-buffer-underflow, WRITE of size 1
        #0 ippAddStringfv ipp.c:1098
        #1 ippAddStringf  ipp.c:960
        #2 main           testipp.c:906
    'buffer' (line 1008) <== Memory access at offset 31 underflows this variable
    SUMMARY: stack-buffer-underflow ipp.c:1098 in ippAddStringfv

When an over-long value is trimmed to the tag maximum at a UTF-8 boundary, the inner loop that skips continuation bytes is bounded by `bufptr > buffer`, but the outer `bufptr --` that follows it is not. A value whose first `max_bytes` bytes are all continuation bytes (no lead byte) walks `bufptr` down to `buffer`, the outer decrement then drops it to `buffer - 1`, the `while (bufptr > bufmax)` exits, and `*bufptr = '\0'` stores one byte below the array. As a side effect the value is also left untrimmed.

`ippSetStringfv` carries the same block, so both get the guard. It only mirrors what the inner loop already does. Added a testipp case that fails before the change (value not trimmed) and passes after.
