### PR TITLE
Reject invalid custom page parameter types

### DIFF
--- a/cups/ppd.c
+++ b/cups/ppd.c
@@ -1060,6 +1060,17 @@ _ppdOpen(
 	goto error;
       }
 
+      if (!strcmp(coption->keyword, "PageSize") &&
+          (((!strcmp(name, "Width") || !strcmp(name, "Height") ||
+             !strcmp(name, "WidthOffset") || !strcmp(name, "HeightOffset")) &&
+            cparam->type != PPD_CUSTOM_POINTS) ||
+           (!strcmp(name, "Orientation") && cparam->type != PPD_CUSTOM_INT)))
+      {
+        pg->ppd_status = PPD_BAD_CUSTOM_PARAM;
+
+	goto error;
+      }
+
      /*
       * Now special-case for CustomPageSize...
       */


### PR DESCRIPTION
## Summary

- reject `ParamCustomPageSize` Width, Height, WidthOffset, and HeightOffset declarations unless their type is `points`
- reject `ParamCustomPageSize` Orientation unless its type is `int`
- keep the change confined to the PPD loader, without adding a permanent test fixture

## Root cause

Custom PageSize processing consumes Width, Height, WidthOffset, and HeightOffset through the `custom_points` union member and Orientation through `custom_int`. A malformed PPD can declare one of those parameters with an incompatible pointer-backed type. For Width, the disclosed OSS-Fuzz testcase causes `ppdPageSize()` to overwrite the pointer union member with float bits, and `ppdClose()` later passes those bits to `free()`.

Rejecting incompatible types during parsing prevents the union type confusion and applies the same invariant to the related custom page parameters.

## Verification

- disclosed OSS-Fuzz Width testcase: rejected with `Bad custom parameter`, with no AddressSanitizer fault
- reduced Width testcase: rejected with `Bad custom parameter`, with no AddressSanitizer fault
- local review matrix: malformed Width, Height, WidthOffset, HeightOffset, and Orientation declarations were all rejected
- valid control with four `points` parameters and integer Orientation was accepted
- complete `cups/testppd` focused suite: all checks passed under AddressSanitizer
- `git diff --check`

References: OSV-2026-551 / OSS-Fuzz issue 500762221