### PR TITLE
Fix rastertohp heap-buffer-overread on planar KCMY/CMY input

### DIFF
--- a/filter/rastertohp.c
+++ b/filter/rastertohp.c
@@ -424,10 +424,11 @@ OutputLine(cups_page_header2_t *header)	/* I - Page header */
   }
 
  /*
-  * Write bitmap data as needed...
+  * Write bitmap data as needed. For planar (KCMY/CMY) input each color
+  * plane is cupsBytesPerLine / NumPlanes bytes wide.
   */
 
-  bytes = (header->cupsWidth + 7) / 8;
+  bytes = header->cupsBytesPerLine / NumPlanes;
 
   for (plane = 0; plane < NumPlanes; plane ++)
     CompressData(Planes[plane], bytes, plane < (NumPlanes - 1) ? 'V' : 'W', header->cupsCompression);


### PR DESCRIPTION
Rastertohp (the HP PCL driver filter) reads past the end of its per-line plane buffer when processing a planar
KCMY/CMY CUPS Raster page, leaking heap data into the emitted PCL stream. This can be reproduced with the attached PoC. (attached as a text file)
[kcmy1-planar-width64-height2.ras.txt](https://github.com/user-attachments/files/31178148/kcmy1-planar-width64-height2.ras.txt)
 
OutputLine() sized each color plane with the full single-channel row length,
(cupsWidth + 7) / 8 == cupsBytesPerLine, instead of the per-plane physical
row size, cupsBytesPerLine / NumPlanes. For planar KCMY/CMY input,
cupsBytesPerLine already packs all planes into one line, each plane being
only cupsBytesPerLine / NumPlanes bytes wide. At width 64 the last of the 4
planes reads [6, 14) of a 12-byte allocation — 2 bytes beyond the
cupsBytesPerLine + NumPlanes buffer.
 
In order to fix this, use bytes = cupsBytesPerLine / NumPlanes, the actual
per-plane row size. This matches the values used by the other rasterto*
filters, so output never extends beyond the supplied raster payload.

Fixes #1658