### PR TITLE
Add 8-up printing support

### DIFF
--- a/berkeley/lpr.c
+++ b/berkeley/lpr.c
@@ -438,7 +438,7 @@ usage(void)
   _cupsLangPuts(stdout, _("-o option[=value]       Specify a printer-specific option"));
   _cupsLangPuts(stdout, _("-o job-sheets=standard  Print a banner page with the job"));
   _cupsLangPuts(stdout, _("-o media=size           Specify the media size to use"));
-  _cupsLangPuts(stdout, _("-o number-up=N          Specify that input pages should be printed N-up (1, 2, 4, 6, 9, and 16 are supported)"));
+  _cupsLangPuts(stdout, _("-o number-up=N          Specify that input pages should be printed N-up (1, 2, 4, 6, 8, 9, and 16 are supported)"));
   _cupsLangPuts(stdout, _("-o orientation-requested=N\n"
                           "                        Specify portrait (3) or landscape (4) orientation"));
   _cupsLangPuts(stdout, _("-o print-quality=N      Specify the print quality - draft (3), normal (4), or best (5)"));

--- a/doc/help/man-lp.html
+++ b/doc/help/man-lp.html
@@ -173,8 +173,8 @@ The &quot;name&quot; can be &quot;classified&quot;, &quot;confidential&quot;, &q
     <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>-o media=</strong><em>size</em><br>
 Sets the page size to <em>size</em>. Most printers support at least the size names &quot;a4&quot;, &quot;letter&quot;, and &quot;legal&quot;.
 </p>
-    <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>-o number-up=</strong>{<em>2|4|6|9|16</em>}<br>
-Prints 2, 4, 6, 9, or 16 document (input) pages on each output page.
+    <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>-o number-up=</strong>{<em>2|4|6|8|9|16</em>}<br>
+Prints 2, 4, 6, 8, 9, or 16 document (input) pages on each output page.
 </p>
     <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>-o orientation-requested=4</strong><br>
 Prints the job in landscape (rotated 90 degrees counter-clockwise).

--- a/doc/help/man-lpr.html
+++ b/doc/help/man-lpr.html
@@ -128,8 +128,8 @@ The &quot;name&quot; can be &quot;classified&quot;, &quot;confidential&quot;, &q
     <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>-o media=</strong><em>size</em><br>
 Sets the page size to <em>size</em>. Most printers support at least the size names &quot;a4&quot;, &quot;letter&quot;, and &quot;legal&quot;.
 </p>
-    <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>-o number-up=</strong>{<em>2|4|6|9|16</em>}<br>
-Prints 2, 4, 6, 9, or 16 document (input) pages on each output page.
+    <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>-o number-up=</strong>{<em>2|4|6|8|9|16</em>}<br>
+Prints 2, 4, 6, 8, 9, or 16 document (input) pages on each output page.
 </p>
     <p style="margin-left: 2.5em; text-indent: -2.5em;"><strong>-o orientation-requested=4</strong><br>
 Prints the job in landscape (rotated 90 degrees counter-clockwise).

--- a/doc/help/options.html
+++ b/doc/help/options.html
@@ -456,13 +456,14 @@ can make the output page numbering not match the document page numbers.</p>
 
 <P>The <CODE>-o number-up=value</CODE> option selects N-Up
 printing. N-Up printing places multiple document pages on a
-single printed page. CUPS supports 1, 2, 4, 6, 9, and 16-Up
+single printed page. CUPS supports 1, 2, 4, 6, 8, 9, and 16-Up
 formats; the default format is 1-Up:</P>
 
 <PRE CLASS="command">
 lp -o number-up=1 filename
 lp -o number-up=2 filename
 lp -o number-up=4 filename
+lpr -o number-up=8 filename
 lpr -o number-up=16 filename
 </PRE>
 

--- a/filter/pstops.c
+++ b/filter/pstops.c
@@ -1973,10 +1973,10 @@ do_setup(pstops_doc_t *doc,		/* I - Document information */
   * Write the page and label prologs...
   */
 
-  if (doc->number_up == 2 || doc->number_up == 6)
+  if (doc->number_up == 2 || doc->number_up == 6 || doc->number_up == 8)
   {
    /*
-    * For 2- and 6-up output, rotate the labels to match the orientation
+    * For 2-, 6-, and 8-up output, rotate the labels to match the orientation
     * of the pages...
     */
 
@@ -2079,6 +2079,7 @@ end_nup(pstops_doc_t *doc,		/* I - Document information */
 
     case 2 :
     case 6 :
+    case 8 :
 	if (is_last_page(number) && doc->use_ESPshowpage)
 	{
 	  if (Orientation & 1)
@@ -2431,6 +2432,7 @@ set_pstops_options(
       case 2 :
       case 4 :
       case 6 :
+      case 8 :
       case 9 :
       case 16 :
           doc->number_up = intval;
@@ -3004,6 +3006,99 @@ start_nup(pstops_doc_t *doc,		/* I - Document information */
           doc_printf(doc, "%.1f %.1f translate %.3f %.3f scale\n",
                      tx + w * x, ty + l * y, w / bboxw, l / bboxl);
 
+        }
+        break;
+
+    case 8 :
+        if (Orientation & 1)
+	{
+	  if (doc->number_up_layout & PSTOPS_LAYOUT_VERTICAL)
+	  {
+	    x = pos / 4;
+	    y = pos & 3;
+
+            if (doc->number_up_layout & PSTOPS_LAYOUT_NEGATEX)
+	      x = 1 - x;
+
+            if (doc->number_up_layout & PSTOPS_LAYOUT_NEGATEY)
+	      y = 3 - y;
+	  }
+	  else
+	  {
+	    x = pos & 1;
+	    y = pos / 2;
+
+            if (doc->number_up_layout & PSTOPS_LAYOUT_NEGATEX)
+	      x = 1 - x;
+
+            if (doc->number_up_layout & PSTOPS_LAYOUT_NEGATEY)
+	      y = 3 - y;
+	  }
+
+          w = pagel * 0.5;
+          l = w * bboxl / bboxw;
+
+          if (l > (pagew * 0.25))
+          {
+            l = pagew * 0.25;
+            w = l * bboxw / bboxl;
+          }
+
+          tx = 0.5 * (pagel - 2 * w);
+          ty = 0.5 * (pagew - 4 * l);
+
+          if (doc->normal_landscape)
+            doc_printf(doc, "0 %.1f translate -90 rotate\n", pagel);
+	  else
+	    doc_printf(doc, "%.1f 0 translate 90 rotate\n", pagew);
+
+          doc_printf(doc, "%.1f %.1f translate %.3f %.3f scale\n",
+                     tx + x * w, ty + y * l, l / bboxl, w / bboxw);
+        }
+	else
+	{
+	  if (doc->number_up_layout & PSTOPS_LAYOUT_VERTICAL)
+	  {
+	    x = pos / 2;
+	    y = pos & 1;
+
+            if (doc->number_up_layout & PSTOPS_LAYOUT_NEGATEX)
+	      x = 3 - x;
+
+            if (doc->number_up_layout & PSTOPS_LAYOUT_NEGATEY)
+	      y = 1 - y;
+	  }
+	  else
+	  {
+	    x = pos & 3;
+	    y = pos / 4;
+
+            if (doc->number_up_layout & PSTOPS_LAYOUT_NEGATEX)
+	      x = 3 - x;
+
+            if (doc->number_up_layout & PSTOPS_LAYOUT_NEGATEY)
+	      y = 1 - y;
+	  }
+
+          l = pagew * 0.5;
+          w = l * bboxw / bboxl;
+
+          if (w > (pagel * 0.25))
+          {
+            w = pagel * 0.25;
+            l = w * bboxl / bboxw;
+          }
+
+	  tx = 0.5 * (pagel - 4 * w);
+	  ty = 0.5 * (pagew - 2 * l);
+
+          if (doc->normal_landscape)
+	    doc_printf(doc, "%.1f 0 translate 90 rotate\n", pagew);
+	  else
+            doc_printf(doc, "0 %.1f translate -90 rotate\n", pagel);
+
+          doc_printf(doc, "%.1f %.1f translate %.3f %.3f scale\n",
+                     tx + w * x, ty + l * y, w / bboxw, l / bboxl);
         }
         break;
 

--- a/man/lp.1
+++ b/man/lp.1
@@ -168,8 +168,8 @@ The "name" can be "classified", "confidential", "secret", "standard", "topsecret
 \fB\-o media=\fIsize\fR
 Sets the page size to \fIsize\fR. Most printers support at least the size names "a4", "letter", and "legal".
 .TP 5
-\fB\-o number\-up=\fR{\fI2|4|6|9|16\fR}
-Prints 2, 4, 6, 9, or 16 document (input) pages on each output page.
+\fB\-o number\-up=\fR{\fI2|4|6|8|9|16\fR}
+Prints 2, 4, 6, 8, 9, or 16 document (input) pages on each output page.
 .TP 5
 \fB\-o orientation\-requested=4\fR
 Prints the job in landscape (rotated 90 degrees counter-clockwise).

--- a/man/lpr.1
+++ b/man/lpr.1
@@ -123,8 +123,8 @@ The "name" can be "classified", "confidential", "secret", "standard", "topsecret
 \fB\-o media=\fIsize\fR
 Sets the page size to \fIsize\fR. Most printers support at least the size names "a4", "letter", and "legal".
 .TP 5
-\fB\-o number\-up=\fR{\fI2|4|6|9|16\fR}
-Prints 2, 4, 6, 9, or 16 document (input) pages on each output page.
+\fB\-o number\-up=\fR{\fI2|4|6|8|9|16\fR}
+Prints 2, 4, 6, 8, 9, or 16 document (input) pages on each output page.
 .TP 5
 \fB\-o orientation\-requested=4\fR
 Prints the job in landscape (rotated 90 degrees counter-clockwise).

--- a/scheduler/ipp.c
+++ b/scheduler/ipp.c
@@ -1349,6 +1349,7 @@ add_job(cupsd_client_t  *con,		/* I - Client connection */
         attr->values[0].integer != 2 &&
         attr->values[0].integer != 4 &&
         attr->values[0].integer != 6 &&
+        attr->values[0].integer != 8 &&
         attr->values[0].integer != 9 &&
         attr->values[0].integer != 16)
     {

--- a/scheduler/printers.c
+++ b/scheduler/printers.c
@@ -180,6 +180,7 @@ cupsdCreateCommonData(void)
     2,
     4,
     6,
+    8,
     9,
     16
   };

--- a/systemv/lp.c
+++ b/systemv/lp.c
@@ -766,7 +766,7 @@ usage(void)
   _cupsLangPuts(stdout, _("-o option[=value]       Specify a printer-specific option"));
   _cupsLangPuts(stdout, _("-o job-sheets=standard  Print a banner page with the job"));
   _cupsLangPuts(stdout, _("-o media=size           Specify the media size to use"));
-  _cupsLangPuts(stdout, _("-o number-up=N          Specify that input pages should be printed N-up (1, 2, 4, 6, 9, and 16 are supported)"));
+  _cupsLangPuts(stdout, _("-o number-up=N          Specify that input pages should be printed N-up (1, 2, 4, 6, 8, 9, and 16 are supported)"));
   _cupsLangPuts(stdout, _("-o orientation-requested=N\n"
                           "                        Specify portrait (3) or landscape (4) orientation"));
   _cupsLangPuts(stdout, _("-o print-quality=N      Specify the print quality - draft (3), normal (4), or best (5)"));

--- a/test/4.2-cups-printer-ops.test
+++ b/test/4.2-cups-printer-ops.test
@@ -326,4 +326,5 @@
 
 	# What attributes do we expect?
 	EXPECT media-col-default
+	EXPECT number-up-supported WITH-VALUE 8
 }

--- a/test/5.6-lpr.sh
+++ b/test/5.6-lpr.sh
@@ -36,8 +36,8 @@ echo ""
 
 echo "LPR Options Test"
 echo ""
-echo "    lpr -P Test1 -o number-up=4 -o job-sheets=standard,none testfile.pdf"
-$runcups $VALGRIND ../berkeley/lpr -P Test1 -o number-up=4 -o job-sheets=standard,none ../examples/testfile.pdf 2>&1
+echo "    lpr -P Test1 -o number-up=8 -o job-sheets=standard,none testfile.pdf"
+$runcups $VALGRIND ../berkeley/lpr -P Test1 -o number-up=8 -o job-sheets=standard,none ../examples/testfile.pdf 2>&1
 if test $? != 0; then
 	echo "    FAILED"
 	exit 1


### PR DESCRIPTION
## Summary

Add support for 8 logical pages per sheet (`number-up=8`).

- Accept and advertise `8` alongside the existing 1, 2, 4, 6, 9, and 16 values.
- Add 4x2 portrait and 2x4 landscape imposition in `pstops`, including every `number-up-layout` ordering and label handling.
- Update command-line help and user documentation.

## Testing

- `make -j4 all`
- `make -C scheduler test`
- A local 16-case PostScript-to-PDF smoke test covering eight layouts in portrait and landscape; it verified one output sheet, pages 1--8, and order.
- `git diff --check`

The change was developed with assistance from an LLM; I reviewed the implementation and performed the tests above.
