### PR TITLE
ppdc-source: fix potential null dereference

### DIFF
--- a/ppdc/ppdc-source.cxx
+++ b/ppdc/ppdc-source.cxx
@@ -3483,8 +3483,8 @@ ppdcSource::write_file(const char *f)	// I - File to write
   for (d = (ppdcDriver *)drivers->first(); d; d = (ppdcDriver *)drivers->next())
   {
     // Start the driver...
-    cupsFilePrintf(fp, "\n// %s %s\n", d->manufacturer->value,
-                   d->model_name->value);
+    cupsFilePrintf(fp, "\n// %s %s\n", d->manufacturer ? d->manufacturer->value : "None",
+                   d->model_name ? d->model_name->value : "None");
     cupsFilePuts(fp, "{\n");
 
     // Write the copyright strings...
@@ -3496,7 +3496,7 @@ ppdcSource::write_file(const char *f)	// I - File to write
     // Write other strings and values...
     if (d->manufacturer && d->manufacturer->value)
       quotef(fp, "  Manufacturer \"%s\"\n", d->manufacturer->value);
-    if (d->model_name->value)
+    if (d->model_name && d->model_name->value)
       quotef(fp, "  ModelName \"%s\"\n", d->model_name->value);
     if (d->file_name && d->file_name->value)
       quotef(fp, "  FileName \"%s\"\n", d->file_name->value);


### PR DESCRIPTION
In the PPD import utility, according to the `import_ppd()` function, the values of `driver->manufacturer` and `driver->model_name` might be a null pointer, which could lead to the dereference of `d->manufacturer` and `d->model_name` in the `write_file()` function. Also `d->manufacturer` is usually checked before dereference. It may be not that major, but I haven't able to prove otherwise. My commit perhaps breaks the structure of a writing file, but I relied on the example of a debug print for null values.