### PR TITLE
fix off-by-one buffer overflow in copy_hex_string

### DIFF
--- a/tools/ipptool.c
+++ b/tools/ipptool.c
@@ -1127,7 +1127,7 @@ copy_hex_string(char          *buffer,	// I - String buffer
   else
   {
     // No, copy as a string...
-    if ((size_t)datalen > bufsize)
+    if ((size_t)datalen >= bufsize)
       datalen = (int)bufsize - 1;
 
     memcpy(buffer, data, (size_t)datalen);


### PR DESCRIPTION
Was checking the octetString paths in `with_value` against an IPP server I control. ASan tripped when the server returned a value whose length was exactly `sizeof(temp)`:

    tools/ipptool.c:1134: heap-buffer-overflow WRITE of size 1
        #0 copy_hex_string  tools/ipptool.c:1134
        #1 with_value       tools/ipptool.c:7686

`copy_hex_string` clamps the copy length with `>` where it wants `>=`. When an all-printable octetString is exactly `bufsize` bytes the clamp is skipped, so `memcpy` fills the whole buffer and `buffer[datalen]` writes the terminating NUL one byte past the end. Both call sites pass a 1024-byte `temp[]`, so a response attribute of 1024 printable bytes is enough. The over-length case (`> bufsize`) already truncates to `bufsize - 1`; the exact-fit case just fell through the gap.