### PR TITLE
Sanitize device IDs to prevent newline injection in usb backend

### DIFF
--- a/backend/usb-libusb.c
+++ b/backend/usb-libusb.c
@@ -1084,6 +1084,7 @@ get_device_id(usb_printer_t *printer,	/* I - Printer */
 {
   int		err;			/* libusb error */
   size_t	length;			/* Length of device ID */
+  char		*ptr;			/* Pointer into device ID */
 
 
   if ((err = libusb_control_transfer(printer->handle, LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_ENDPOINT_IN | LIBUSB_RECIPIENT_INTERFACE, 0, printer->conf, (printer->iface << 8) | printer->altset, (unsigned char *)buffer, bufsize, 5000)) < 0)
@@ -1135,6 +1136,22 @@ get_device_id(usb_printer_t *printer,	/* I - Printer */
 
   memmove(buffer, buffer + 2, length);
   buffer[length] = '\0';
+
+  /*
+  * Clean up the device ID - collapse whitespace to single spaces and reject
+  * any string containing other control characters (matches the sanitization
+  * already applied in backend/ieee1284.c:backendGetDeviceID()). The device ID
+  * is later written to stderr where embedded newlines would otherwise be
+  * interpreted by cupsd as separate STATE:/ATTR:/PPD: directive lines.
+  */
+  for (ptr = buffer; *ptr; ptr ++)
+    if (_cups_isspace(*ptr))
+      *ptr = ' ';
+    else if ((*ptr & 255) < ' ' || *ptr == 127)
+    {
+      *buffer = '\0';
+      return (-1);
+    }
 
   return (0);
 }


### PR DESCRIPTION
The `get_device_id()` function in `backend/usb-libusb.c` previously copied the IEEE-1284 device ID directly from the USB device without filtering control characters. Since this device ID is subsequently written to stderr via a `DEBUG2` log, a malicious USB device could embed newlines in its device ID to inject arbitrary configuration directives (like `PPD:`, `ATTR:`, or `STATE:`) directly into the `cupsd` status stream.

This commit applies the same sanitization logic already used in `backend/ieee1284.c` to the usb backend. It collapses whitespace into single spaces and rejects any string containing other control characters, effectively mitigating the log injection vulnerability.