### PR TITLE
use constant-time comparison for HMAC in cupsJWTHasValidSignature

### DIFF
--- a/cups/jwt.c
+++ b/cups/jwt.c
@@ -12,6 +12,7 @@
 #include "json-private.h"
 #include <assert.h>
 #ifdef HAVE_OPENSSL
+#  include <openssl/crypto.h>
 #  include <openssl/ecdsa.h>
 #  include <openssl/evp.h>
 #  include <openssl/rsa.h>
@@ -437,8 +438,14 @@ cupsJWTHasValidSignature(
 
 	DEBUG_printf("1cupsJWTHasValidSignature: calc sig(%u) = %02X%02X%02X%02X...%02X%02X%02X%02X", (unsigned)sigsize, signature[0], signature[1], signature[2], signature[3], signature[sigsize - 4], signature[sigsize - 3], signature[sigsize - 2], signature[sigsize - 1]);
 
-	// Compare and return the result...
-	ret = jwt->sigsize == sigsize && !memcmp(jwt->signature, signature, sigsize);
+	// Compare and return the result using a constant-time comparison so the
+	// HMAC value cannot be recovered a byte at a time via a timing side
+	// channel...
+#ifdef HAVE_OPENSSL
+	ret = jwt->sigsize == sigsize && !CRYPTO_memcmp(jwt->signature, signature, sigsize);
+#else // HAVE_GNUTLS
+	ret = jwt->sigsize == sigsize && !gnutls_memcmp(jwt->signature, signature, sigsize);
+#endif // HAVE_OPENSSL
 	break;
 
     case CUPS_JWA_RS256 :


### PR DESCRIPTION
Was reading through the JOSE signature paths in jwt.c. The HMAC branch stood out:

    // cups/jwt.c, cupsJWTHasValidSignature(), HS256/HS384/HS512
    ret = jwt->sigsize == sigsize && !memcmp(jwt->signature, signature, sigsize);

`signature` here is the HMAC recomputed from the shared secret; `jwt->signature` is the value off the wire. memcmp returns at the first differing byte, so the compare time tracks how many leading bytes of the supplied tag are correct. That is a byte-at-a-time timing oracle: an attacker can recover a valid HMAC one byte at a time without ever knowing the key.

cupsJWTHasValidSignature is a public API and gets called on OIDC id_tokens from oauth.c, so both the token and its signature are attacker-controlled. The RS/ES branches verify through RSA_verify / ECDSA_do_verify (public key, no secret) so they are fine as they stand. Only the symmetric branch compares a secret-derived value, so only it needs a constant-time compare.

Swapped memcmp for CRYPTO_memcmp on OpenSSL and gnutls_memcmp on GnuTLS. Result is identical for valid and invalid tokens; testjwt passes on both backends.
