### PR TITLE
Fix PrinterSpooler D-Bus signal spoofing

### DIFF
--- a/desktop/cups.conf
+++ b/desktop/cups.conf
@@ -1,13 +1,16 @@
 <!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
-  <!-- Only root can send this message -->
-  <policy user="root">
-    <allow send_interface="com.redhat.PrinterSpooler"/>
+  <!-- Reject spoofed PrinterSpooler broadcasts from unprivileged clients. -->
+  <policy context="default">
+    <deny send_type="signal"
+          send_interface="com.redhat.PrinterSpooler"/>
+    <allow receive_interface="com.redhat.PrinterSpooler"/>
   </policy>
 
-  <!-- Allow any connection to receive the message -->
-  <policy context="default">
-    <allow receive_interface="com.redhat.PrinterSpooler"/>
+  <!-- cupsd normally runs as root. -->
+  <policy user="root">
+    <allow send_type="signal"
+           send_interface="com.redhat.PrinterSpooler"/>
   </policy>
 </busconfig>


### PR DESCRIPTION
The existing policy grants root permission to send messages on the
com.redhat.PrinterSpooler interface, but does not deny unprivileged
clients. Since the system bus permits broadcast signals by default, an
ordinary user can emit a spoofed PrinterSpooler signal despite the
comment claiming that only root can send it.

Deny signals on this interface in the default policy and allow them
again for root. This preserves reception for all connections and limits
the change to signal messages, avoiding an unintended restriction on
other message types.