### PR TITLE
Fix PrinterSpooler D-Bus signal spoofing

### DIFF
--- a/desktop/cups.conf
+++ b/desktop/cups.conf
@@ -1,13 +1,16 @@
 <!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
-  <!-- Only root can send this message -->
-  <policy user="root">
-    <allow send_interface="com.redhat.PrinterSpooler"/>
+  <!-- Reject spoofed PrinterSpooler broadcasts from unprivileged clients. -->
+  <policy context="default">
+    <deny send_type="signal"
+          send_interface="com.redhat.PrinterSpooler"/>
+    <allow receive_interface="com.redhat.PrinterSpooler"/>
   </policy>
 
-  <!-- Allow any connection to receive the message -->
-  <policy context="default">
-    <allow receive_interface="com.redhat.PrinterSpooler"/>
+  <!-- cupsd normally runs as root. -->
+  <policy user="root">
+    <allow send_type="signal"
+           send_interface="com.redhat.PrinterSpooler"/>
   </policy>
 </busconfig>


### PR DESCRIPTION
I was able to reproduce this locally with a regular, non-root user.
Even though cups.conf says that only root can send the message, the
following command succeeds and is visible to listeners:

`dbus-send --system --type=signal 
  /com/redhat/PrinterSpooler 
  com.redhat.PrinterSpooler.PrinterAdded 
  string:fake`

It looks like the current rule only allows root, but does not explicitly
deny anyone else. Since the system bus allows broadcast signals by
default, regular users can spoof these notifications too.